### PR TITLE
QPID-7973: Table Name Prefix is set to NULL if no prefix is provided

### DIFF
--- a/broker-plugins/jdbc-store/src/main/java/org/apache/qpid/server/store/jdbc/AbstractJDBCConfigurationStore.java
+++ b/broker-plugins/jdbc-store/src/main/java/org/apache/qpid/server/store/jdbc/AbstractJDBCConfigurationStore.java
@@ -70,7 +70,9 @@ public abstract class AbstractJDBCConfigurationStore implements MessageStoreProv
 
     protected void setTableNamePrefix(final String tableNamePrefix)
     {
-        _tableNamePrefix = tableNamePrefix;
+        if (tableNamePrefix != null) {
+            _tableNamePrefix = tableNamePrefix;
+        }
     }
 
     @Override


### PR DESCRIPTION
QPID-7973: Table Name Prefix is set to NULL if no prefix is provided