### PR TITLE
QPID-7372, hasn't been fixed fully, there is still code dependency on logback

### DIFF
--- a/broker/src/main/java/org/apache/qpid/server/Broker.java
+++ b/broker/src/main/java/org/apache/qpid/server/Broker.java
@@ -212,15 +212,16 @@ public class Broker
             @Override
             public void run()
             {
-
-                ch.qos.logback.classic.Logger rootLogger =
+                if (LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME) instanceof ch.qos.logback.classic.Logger){
+                    ch.qos.logback.classic.Logger rootLogger =
                         (ch.qos.logback.classic.Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
 
-                StartupAppender startupAppender = (StartupAppender) rootLogger.getAppender(StartupAppender.class.getName());
-                if (startupAppender != null)
-                {
-                    rootLogger.detachAppender(startupAppender);
-                    startupAppender.stop();
+                    StartupAppender startupAppender = (StartupAppender) rootLogger.getAppender(StartupAppender.class.getName());
+                    if (startupAppender != null)
+                    {
+                        rootLogger.detachAppender(startupAppender);
+                        startupAppender.stop();
+                    }
                 }
 
             }

--- a/broker/src/main/java/org/apache/qpid/server/Broker.java
+++ b/broker/src/main/java/org/apache/qpid/server/Broker.java
@@ -144,16 +144,16 @@ public class Broker
             @Override
             public Object run() throws Exception
             {
+                StartupAppender startupAppender = null;
                 if (LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME) instanceof ch.qos.logback.classic.Logger){
-                    ch.qos.logback.classic.Logger logger =
-                        (ch.qos.logback.classic.Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
+                    ch.qos.logback.classic.Logger logger = (ch.qos.logback.classic.Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
                     if (!logger.iteratorForAppenders().hasNext())
                     {
                         logger.setLevel(Level.ALL);
                         logger.setAdditive(true);
                     }
 
-                    StartupAppender startupAppender = new StartupAppender();
+                    startupAppender = new StartupAppender();
                     startupAppender.setContext(logger.getLoggerContext());
                     startupAppender.start();
                     logger.addAppender(startupAppender);
@@ -166,13 +166,17 @@ public class Broker
                 catch (RuntimeException e)
                 {
                     LOGGER.error("Exception during startup", e);
-                    startupAppender.logToConsole();
+                    if (startupAppender != null){
+                        startupAppender.logToConsole();
+                    }
                     closeSystemConfigAndCleanUp();
                 }
                 finally
                 {
-                    logger.detachAppender(startupAppender);
-                    startupAppender.stop();
+                    if (startupAppender != null){
+                        logger.detachAppender(startupAppender);
+                        startupAppender.stop();
+                    }
                 }
                 return null;
             }

--- a/broker/src/main/java/org/apache/qpid/server/Broker.java
+++ b/broker/src/main/java/org/apache/qpid/server/Broker.java
@@ -145,8 +145,9 @@ public class Broker
             public Object run() throws Exception
             {
                 StartupAppender startupAppender = null;
+                ch.qos.logback.classic.Logger logger = null;
                 if (LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME) instanceof ch.qos.logback.classic.Logger){
-                    ch.qos.logback.classic.Logger logger = (ch.qos.logback.classic.Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
+                    logger = (ch.qos.logback.classic.Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
                     if (!logger.iteratorForAppenders().hasNext())
                     {
                         logger.setLevel(Level.ALL);
@@ -173,8 +174,10 @@ public class Broker
                 }
                 finally
                 {
-                    if (startupAppender != null){
-                        logger.detachAppender(startupAppender);
+                    if (startupAppender != null) {
+                        if (logger != null ) {
+                            logger.detachAppender(startupAppender);
+                        }
                         startupAppender.stop();
                     }
                 }

--- a/broker/src/main/java/org/apache/qpid/server/Broker.java
+++ b/broker/src/main/java/org/apache/qpid/server/Broker.java
@@ -144,18 +144,20 @@ public class Broker
             @Override
             public Object run() throws Exception
             {
-                ch.qos.logback.classic.Logger logger =
+                if (LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME) instanceof ch.qos.logback.classic.Logger){
+                    ch.qos.logback.classic.Logger logger =
                         (ch.qos.logback.classic.Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
-                if (!logger.iteratorForAppenders().hasNext())
-                {
-                    logger.setLevel(Level.ALL);
-                    logger.setAdditive(true);
-                }
+                    if (!logger.iteratorForAppenders().hasNext())
+                    {
+                        logger.setLevel(Level.ALL);
+                        logger.setAdditive(true);
+                    }
 
-                StartupAppender startupAppender = new StartupAppender();
-                startupAppender.setContext(logger.getLoggerContext());
-                startupAppender.start();
-                logger.addAppender(startupAppender);
+                    StartupAppender startupAppender = new StartupAppender();
+                    startupAppender.setContext(logger.getLoggerContext());
+                    startupAppender.start();
+                    logger.addAppender(startupAppender);
+                }
 
                 try
                 {


### PR DESCRIPTION
Here we have hardcoded dependency on logback which makes broker fail to start when using https://github.com/daknin/qpid-maven-plugin/, because maven uses org.slf4j.impl.SimpleLogger.

Exception:
Caused by: java.lang.ClassCastException: org.slf4j.impl.SimpleLogger cannot be cast to ch.qos.logback.classic.Logger
	at org.apache.qpid.server.Broker$1.run(Broker.java:147)
	at java.security.AccessController.doPrivileged(Native Method)
	at javax.security.auth.Subject.doAs(Subject.java:422)
	at org.apache.qpid.server.Broker.startup(Broker.java:142)
	at com.github.daknin.qpid.plugin.QpidBroker.start(QpidBroker.java:43)