### PR TITLE
QPID-7541: [Broker-J] Close consumers when a Queue is deleted

### DIFF
--- a/broker-core/src/main/java/org/apache/qpid/server/consumer/AbstractConsumerTarget.java
+++ b/broker-core/src/main/java/org/apache/qpid/server/consumer/AbstractConsumerTarget.java
@@ -40,6 +40,7 @@ import org.apache.qpid.server.message.MessageInstance;
 import org.apache.qpid.server.message.MessageInstanceConsumer;
 import org.apache.qpid.server.message.MessageSource;
 import org.apache.qpid.server.model.Consumer;
+import org.apache.qpid.server.model.Queue;
 import org.apache.qpid.server.protocol.converter.MessageConversionException;
 import org.apache.qpid.server.queue.SuspendedConsumerLoggingTicker;
 import org.apache.qpid.server.store.TransactionLogResource;
@@ -367,4 +368,11 @@ public abstract class AbstractConsumerTarget<T extends AbstractConsumerTarget<T>
     {
         _scheduled.set(false);
     }
+
+    @Override
+    public void queueDeleted(final Queue queue, final MessageInstanceConsumer sub)
+    {
+        consumerRemoved(sub);
+    }
+
 }

--- a/broker-core/src/main/java/org/apache/qpid/server/consumer/ConsumerTarget.java
+++ b/broker-core/src/main/java/org/apache/qpid/server/consumer/ConsumerTarget.java
@@ -25,6 +25,7 @@ import com.google.common.util.concurrent.ListenableFuture;
 import org.apache.qpid.server.message.MessageInstance;
 import org.apache.qpid.server.message.MessageInstanceConsumer;
 import org.apache.qpid.server.message.ServerMessage;
+import org.apache.qpid.server.model.Queue;
 import org.apache.qpid.server.session.AMQPSession;
 
 public interface ConsumerTarget<T extends ConsumerTarget<T>>
@@ -75,4 +76,6 @@ public interface ConsumerTarget<T extends ConsumerTarget<T>>
     boolean isSuspended();
 
     boolean close();
+
+    void queueDeleted(Queue queue, MessageInstanceConsumer sub);
 }

--- a/broker-core/src/main/java/org/apache/qpid/server/message/MessageDestination.java
+++ b/broker-core/src/main/java/org/apache/qpid/server/message/MessageDestination.java
@@ -24,7 +24,9 @@ import java.security.AccessControlException;
 import java.util.Map;
 
 import org.apache.qpid.server.exchange.DestinationReferrer;
+import org.apache.qpid.server.model.DoOnConfigThread;
 import org.apache.qpid.server.model.NamedAddressSpace;
+import org.apache.qpid.server.model.Param;
 import org.apache.qpid.server.model.PublishingLink;
 import org.apache.qpid.server.security.SecurityToken;
 import org.apache.qpid.server.store.StorableMessageMetaData;
@@ -53,8 +55,11 @@ public interface MessageDestination extends MessageNode
 
     boolean isDurable();
 
-    void linkAdded(MessageSender sender, PublishingLink link);
-    void linkRemoved(MessageSender sender, PublishingLink link);
+    @DoOnConfigThread
+    void linkAdded(@Param(name = "sender") MessageSender sender, @Param(name = "link") PublishingLink link);
+
+    @DoOnConfigThread
+    void linkRemoved(@Param(name = "sender") MessageSender sender, @Param(name = "link") PublishingLink link);
 
     MessageDestination getAlternateBindingDestination();
 

--- a/broker-core/src/main/java/org/apache/qpid/server/model/TransactionMonitor.java
+++ b/broker-core/src/main/java/org/apache/qpid/server/model/TransactionMonitor.java
@@ -1,0 +1,32 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package org.apache.qpid.server.model;
+
+import org.apache.qpid.server.txn.LocalTransaction;
+
+public interface TransactionMonitor
+{
+    void registerTransaction(LocalTransaction tx);
+
+    void unregisterTransaction(LocalTransaction tx);
+
+    void dischargeTransaction(LocalTransaction tx, boolean failure);
+}

--- a/broker-core/src/main/java/org/apache/qpid/server/queue/QueueConsumerImpl.java
+++ b/broker-core/src/main/java/org/apache/qpid/server/queue/QueueConsumerImpl.java
@@ -285,7 +285,7 @@ class QueueConsumerImpl<T extends ConsumerTarget>
     @Override
     public void queueDeleted()
     {
-        _target.consumerRemoved(this);
+        _target.queueDeleted(getQueue(), this);
     }
 
     @Override

--- a/broker-core/src/main/java/org/apache/qpid/server/transport/AbstractAMQPConnection.java
+++ b/broker-core/src/main/java/org/apache/qpid/server/transport/AbstractAMQPConnection.java
@@ -949,7 +949,8 @@ public abstract class AbstractAMQPConnection<C extends AbstractAMQPConnection<C,
         _localTransactionOpens.incrementAndGet();
         return new LocalTransaction(getAddressSpace().getMessageStore(),
                                     () -> getLastReadTime(),
-                                    _transactionObserver);
+                                    _transactionObserver,
+                                    getProtocol() != Protocol.AMQP_1_0);
     }
 
     @Override

--- a/broker-core/src/test/java/org/apache/qpid/server/consumer/TestConsumerTarget.java
+++ b/broker-core/src/test/java/org/apache/qpid/server/consumer/TestConsumerTarget.java
@@ -66,6 +66,12 @@ public class TestConsumerTarget implements ConsumerTarget<TestConsumerTarget>
         return true;
     }
 
+    @Override
+    public void queueDeleted(final Queue queue, final MessageInstanceConsumer sub)
+    {
+        consumerRemoved(sub);
+    }
+
     public String getName()
     {
         return tag;

--- a/broker-plugins/amqp-1-0-protocol/src/main/java/org/apache/qpid/server/protocol/v1_0/StandardReceivingLinkEndpoint.java
+++ b/broker-plugins/amqp-1-0-protocol/src/main/java/org/apache/qpid/server/protocol/v1_0/StandardReceivingLinkEndpoint.java
@@ -115,7 +115,10 @@ public class StandardReceivingLinkEndpoint extends AbstractReceivingLinkEndpoint
         @Override
         public void destinationRemoved(final MessageDestination destination)
         {
-            // TODO - we should probably schedule a link closure here! (QPID-7541)
+            getSession().getConnection()
+                        .doOnIOThreadAsync(() -> close(new Error(AmqpError.RESOURCE_DELETED,
+                                                                 String.format("Destination '%s' has been removed.",
+                                                                               destination.getName()))));
         }
 
         @Override

--- a/broker-plugins/management-amqp/src/main/java/org/apache/qpid/server/management/amqp/ProxyMessageSource.java
+++ b/broker-plugins/management-amqp/src/main/java/org/apache/qpid/server/management/amqp/ProxyMessageSource.java
@@ -53,6 +53,7 @@ import org.apache.qpid.server.message.ServerMessage;
 import org.apache.qpid.server.model.ConfiguredObject;
 import org.apache.qpid.server.model.NamedAddressSpace;
 import org.apache.qpid.server.model.PublishingLink;
+import org.apache.qpid.server.model.Queue;
 import org.apache.qpid.server.security.SecurityToken;
 import org.apache.qpid.server.session.AMQPSession;
 import org.apache.qpid.server.store.MessageDurability;
@@ -353,7 +354,11 @@ public class ProxyMessageSource implements MessageSource, MessageDestination
             return _underlying.close();
         }
 
-
+        @Override
+        public void queueDeleted(final Queue queue, final MessageInstanceConsumer sub)
+        {
+            _underlying.queueDeleted(queue, _consumer);
+        }
     }
     private static class UnwrappingWrappingConsumer<T extends ConsumerTarget<T>> implements MessageInstanceConsumer<T>
     {

--- a/systests/protocol-tests-amqp-1-0/src/main/java/org/apache/qpid/tests/protocol/v1_0/Interaction.java
+++ b/systests/protocol-tests-amqp-1-0/src/main/java/org/apache/qpid/tests/protocol/v1_0/Interaction.java
@@ -953,7 +953,7 @@ public class Interaction extends AbstractInteraction<Interaction>
         return this;
     }
 
-    public Interaction txnDischarge(final InteractionTransactionalState txnState, boolean failed) throws Exception
+    public Interaction discharge(final InteractionTransactionalState txnState, final boolean failed) throws Exception
     {
         final Discharge discharge = new Discharge();
         discharge.setTxnId(txnState.getCurrentTransactionId());
@@ -962,6 +962,12 @@ public class Interaction extends AbstractInteraction<Interaction>
         Transfer transfer = createTransactionTransfer(txnState.getHandle());
         transferPayload(transfer, discharge);
         sendPerformativeAndChainFuture(transfer, _sessionChannel);
+        return this;
+    }
+
+    public Interaction txnDischarge(final InteractionTransactionalState txnState, boolean failed) throws Exception
+    {
+        discharge(txnState, failed);
 
         Disposition declareTransactionDisposition = null;
         Flow coordinatorFlow = null;

--- a/systests/protocol-tests-amqp-1-0/src/test/java/org/apache/qpid/tests/protocol/v1_0/extensions/qpid/queue/QueueDeletionTest.java
+++ b/systests/protocol-tests-amqp-1-0/src/test/java/org/apache/qpid/tests/protocol/v1_0/extensions/qpid/queue/QueueDeletionTest.java
@@ -1,0 +1,282 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package org.apache.qpid.tests.protocol.v1_0.extensions.qpid.queue;
+
+import static org.apache.qpid.tests.utils.BrokerAdmin.KIND_BROKER_J;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
+
+import java.net.InetSocketAddress;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import org.apache.qpid.server.protocol.v1_0.type.UnsignedInteger;
+import org.apache.qpid.server.protocol.v1_0.type.messaging.Accepted;
+import org.apache.qpid.server.protocol.v1_0.type.messaging.Rejected;
+import org.apache.qpid.server.protocol.v1_0.type.transaction.TransactionError;
+import org.apache.qpid.server.protocol.v1_0.type.transaction.TransactionalState;
+import org.apache.qpid.server.protocol.v1_0.type.transport.AmqpError;
+import org.apache.qpid.server.protocol.v1_0.type.transport.Attach;
+import org.apache.qpid.server.protocol.v1_0.type.transport.Begin;
+import org.apache.qpid.server.protocol.v1_0.type.transport.Detach;
+import org.apache.qpid.server.protocol.v1_0.type.transport.Disposition;
+import org.apache.qpid.server.protocol.v1_0.type.transport.Error;
+import org.apache.qpid.server.protocol.v1_0.type.transport.Flow;
+import org.apache.qpid.server.protocol.v1_0.type.transport.Open;
+import org.apache.qpid.server.protocol.v1_0.type.transport.ReceiverSettleMode;
+import org.apache.qpid.server.protocol.v1_0.type.transport.Role;
+import org.apache.qpid.tests.protocol.Response;
+import org.apache.qpid.tests.protocol.v1_0.FrameTransport;
+import org.apache.qpid.tests.protocol.v1_0.Interaction;
+import org.apache.qpid.tests.protocol.v1_0.InteractionTransactionalState;
+import org.apache.qpid.tests.utils.BrokerAdmin;
+import org.apache.qpid.tests.utils.BrokerAdminUsingTestBase;
+import org.apache.qpid.tests.utils.BrokerSpecific;
+
+@BrokerSpecific(kind = KIND_BROKER_J)
+public class QueueDeletionTest extends BrokerAdminUsingTestBase
+{
+    private static final String TEST_MESSAGE_CONTENT = "test";
+
+    private InetSocketAddress _brokerAddress;
+
+    @Before
+    public void setUp()
+    {
+        _brokerAddress = getBrokerAdmin().getBrokerAddress(BrokerAdmin.PortType.ANONYMOUS_AMQP);
+        getBrokerAdmin().createQueue(BrokerAdmin.TEST_QUEUE_NAME);
+    }
+
+    @Test
+    public void senderDetachedOnQueueDelete() throws Exception
+    {
+        try (FrameTransport transport = new FrameTransport(_brokerAddress).connect())
+        {
+            Interaction interaction = transport.newInteraction();
+            final Attach responseAttach = interaction.negotiateProtocol().consumeResponse()
+                                                     .open().consumeResponse(Open.class)
+                                                     .begin().consumeResponse(Begin.class)
+                                                     .attachRole(Role.SENDER)
+                                                     .attachTargetAddress(BrokerAdmin.TEST_QUEUE_NAME)
+                                                     .attach().consumeResponse()
+                                                     .getLatestResponse(Attach.class);
+            assertThat(responseAttach.getRole(), is(Role.RECEIVER));
+
+            Flow flow = interaction.consumeResponse(Flow.class).getLatestResponse(Flow.class);
+            assertThat(flow.getLinkCredit().intValue(), is(greaterThan(1)));
+
+            getBrokerAdmin().deleteQueue(BrokerAdmin.TEST_QUEUE_NAME);
+
+            final Detach receivedDetach = interaction.consumeResponse().getLatestResponse(Detach.class);
+            assertThat(receivedDetach.getError(), is(notNullValue()));
+            assertThat(receivedDetach.getError().getCondition(), is(AmqpError.RESOURCE_DELETED));
+        }
+    }
+
+    @Test
+    public void receiverDetachedOnQueueDelete() throws Exception
+    {
+        try (FrameTransport transport = new FrameTransport(_brokerAddress).connect())
+        {
+            Interaction interaction = transport.newInteraction();
+            final Attach responseAttach = interaction.negotiateProtocol()
+                                                     .consumeResponse()
+                                                     .open()
+                                                     .consumeResponse(Open.class)
+                                                     .begin()
+                                                     .consumeResponse(Begin.class)
+                                                     .attachRole(Role.RECEIVER)
+                                                     .attachSourceAddress(BrokerAdmin.TEST_QUEUE_NAME)
+                                                     .attach()
+                                                     .consumeResponse(Attach.class)
+                                                     .getLatestResponse(Attach.class);
+
+            assertThat(responseAttach.getRole(), is(Role.SENDER));
+
+            getBrokerAdmin().deleteQueue(BrokerAdmin.TEST_QUEUE_NAME);
+
+            final Detach receivedDetach = interaction.consumeResponse().getLatestResponse(Detach.class);
+            assertThat(receivedDetach.getError(), is(notNullValue()));
+            assertThat(receivedDetach.getError().getCondition(), is(AmqpError.RESOURCE_DELETED));
+        }
+    }
+
+    @Test
+    public void transactedSenderDetachedOnQueueDeletionWhenTransactionInProgress() throws Exception
+    {
+        try (FrameTransport transport = new FrameTransport(_brokerAddress).connect())
+        {
+            final UnsignedInteger linkHandle = UnsignedInteger.ONE;
+
+            final Interaction interaction = transport.newInteraction();
+            final InteractionTransactionalState txnState = interaction.createTransactionalState(UnsignedInteger.ZERO);
+
+            Attach attach = interaction.negotiateProtocol()
+                                       .consumeResponse()
+                                       .open()
+                                       .consumeResponse(Open.class)
+                                       .begin()
+                                       .consumeResponse(Begin.class)
+
+                                       .txnAttachCoordinatorLink(txnState)
+                                       .txnDeclare(txnState)
+
+                                       .attachRole(Role.SENDER)
+                                       .attachTargetAddress(BrokerAdmin.TEST_QUEUE_NAME)
+                                       .attachHandle(linkHandle)
+                                       .attach().consumeResponse(Attach.class).getLatestResponse(Attach.class);
+
+            Disposition responseDisposition = interaction.consumeResponse(Flow.class)
+
+                                                         .transferHandle(linkHandle)
+                                                         .transferPayloadData(TEST_MESSAGE_CONTENT)
+                                                         .transferTransactionalState(txnState.getCurrentTransactionId())
+                                                         .transfer()
+                                                         .consumeResponse(Disposition.class)
+                                                         .getLatestResponse(Disposition.class);
+
+            assertThat(responseDisposition.getRole(), is(Role.RECEIVER));
+            assertThat(responseDisposition.getSettled(), is(Boolean.TRUE));
+            assertThat(responseDisposition.getState(), is(instanceOf(TransactionalState.class)));
+            assertThat(((TransactionalState) responseDisposition.getState()).getOutcome(),
+                       is(instanceOf(Accepted.class)));
+
+            getBrokerAdmin().deleteQueue(BrokerAdmin.TEST_QUEUE_NAME);
+
+            final Detach receivedDetach = interaction.consumeResponse().getLatestResponse(Detach.class);
+            assertThat(receivedDetach.getError(), is(notNullValue()));
+            assertThat(receivedDetach.getError().getCondition(), is(AmqpError.RESOURCE_DELETED));
+            assertThat(receivedDetach.getHandle(), is(equalTo(attach.getHandle())));
+
+            interaction.discharge(txnState, false);
+
+            assertTransactionRollbackOnly(interaction, txnState);
+        }
+    }
+
+    @Test
+    public void transactedReceiverDetachedOnQueueDeletionWhenTransactionInProgress() throws Exception
+    {
+        getBrokerAdmin().putMessageOnQueue(BrokerAdmin.TEST_QUEUE_NAME,
+                                           TEST_MESSAGE_CONTENT + 1,
+                                           TEST_MESSAGE_CONTENT + 2);
+        try (FrameTransport transport = new FrameTransport(_brokerAddress).connect())
+        {
+            final Interaction interaction = transport.newInteraction();
+            final InteractionTransactionalState txnState = interaction.createTransactionalState(UnsignedInteger.ZERO);
+            Attach attach = interaction.negotiateProtocol()
+                                       .consumeResponse()
+                                       .open()
+                                       .consumeResponse(Open.class)
+                                       .begin()
+                                       .consumeResponse(Begin.class)
+
+                                       .txnAttachCoordinatorLink(txnState)
+                                       .txnDeclare(txnState)
+
+                                       .attachRole(Role.RECEIVER)
+                                       .attachHandle(UnsignedInteger.ONE)
+                                       .attachSourceAddress(BrokerAdmin.TEST_QUEUE_NAME)
+                                       .attachRcvSettleMode(ReceiverSettleMode.FIRST)
+                                       .attach()
+                                       .consumeResponse(Attach.class).getLatestResponse(Attach.class);
+
+            interaction.flowIncomingWindow(UnsignedInteger.ONE)
+                       .flowNextIncomingId(UnsignedInteger.ZERO)
+                       .flowOutgoingWindow(UnsignedInteger.ZERO)
+                       .flowNextOutgoingId(UnsignedInteger.ZERO)
+                       .flowLinkCredit(UnsignedInteger.ONE)
+                       .flowHandleFromLinkHandle()
+                       .flow()
+
+                       .receiveDelivery()
+                       .decodeLatestDelivery();
+
+            Object data = interaction.getDecodedLatestDelivery();
+            assertThat(data, is(equalTo(TEST_MESSAGE_CONTENT + 1)));
+
+            interaction.dispositionSettled(true)
+                       .dispositionRole(Role.RECEIVER)
+                       .dispositionTransactionalState(txnState.getCurrentTransactionId(), new Accepted())
+                       .disposition();
+
+            interaction.flowIncomingWindow(UnsignedInteger.valueOf(2))
+                       .flowNextIncomingId(UnsignedInteger.ONE)
+                       .flowOutgoingWindow(UnsignedInteger.ZERO)
+                       .flowNextOutgoingId(UnsignedInteger.ZERO)
+                       .flowLinkCredit(UnsignedInteger.ONE)
+                       .flowHandleFromLinkHandle()
+                       .flow()
+                       .receiveDelivery()
+                       .decodeLatestDelivery();
+
+            data = interaction.getDecodedLatestDelivery();
+            assertThat(data, is(equalTo(TEST_MESSAGE_CONTENT + 2)));
+
+            getBrokerAdmin().deleteQueue(BrokerAdmin.TEST_QUEUE_NAME);
+
+            final Detach receivedDetach = interaction.consumeResponse().getLatestResponse(Detach.class);
+            assertThat(receivedDetach.getError(), is(notNullValue()));
+            assertThat(receivedDetach.getError().getCondition(), is(AmqpError.RESOURCE_DELETED));
+            assertThat(receivedDetach.getHandle(), is(equalTo(attach.getHandle())));
+
+            interaction.discharge(txnState, false);
+
+            assertTransactionRollbackOnly(interaction, txnState);
+        }
+    }
+
+    private void assertTransactionRollbackOnly(final Interaction interaction,
+                                               final InteractionTransactionalState txnState) throws Exception
+    {
+        Disposition declareTransactionDisposition = null;
+        Flow coordinatorFlow = null;
+        do
+        {
+            interaction.consumeResponse(Disposition.class, Flow.class);
+            Response<?> response = interaction.getLatestResponse();
+            if (response.getBody() instanceof Disposition)
+            {
+                declareTransactionDisposition = (Disposition) response.getBody();
+            }
+            if (response.getBody() instanceof Flow)
+            {
+                final Flow flowResponse = (Flow) response.getBody();
+                if (flowResponse.getHandle().equals(txnState.getHandle()))
+                {
+                    coordinatorFlow = flowResponse;
+                }
+            }
+        } while (declareTransactionDisposition == null || coordinatorFlow == null);
+
+        assertThat(declareTransactionDisposition.getSettled(), is(equalTo(true)));
+        assertThat(declareTransactionDisposition.getState(), is(instanceOf(Rejected.class)));
+
+        final Error error = ((Rejected) declareTransactionDisposition.getState()).getError();
+        assertThat(error, is(notNullValue()));
+        assertThat(error.getCondition(), is(equalTo(TransactionError.TRANSACTION_ROLLBACK)));
+    }
+}

--- a/systests/qpid-systests-jms-core/src/main/java/org/apache/qpid/systests/Utils.java
+++ b/systests/qpid-systests-jms-core/src/main/java/org/apache/qpid/systests/Utils.java
@@ -73,17 +73,22 @@ public class Utils
     {
         List<Message> messages = new ArrayList<>(count);
         MessageProducer producer = session.createProducer(destination);
-
-        for (int i = 0; i < (count); i++)
+        try
         {
-            Message next = createNextMessage(session, i);
-            producer.send(next);
-            messages.add(next);
+            for (int i = 0; i < (count); i++)
+            {
+                Message next = createNextMessage(session, i);
+                producer.send(next);
+                messages.add(next);
+            }
+            if (session.getTransacted())
+            {
+                session.commit();
+            }
         }
-
-        if (session.getTransacted())
+        finally
         {
-            session.commit();
+            producer.close();
         }
 
         return messages;


### PR DESCRIPTION
The proposed changes allow to close queue sending and receiving links and mark all in-progress queue transactions as read-only. If in-progress transaction is in process of committing/rollingback when queue is deleted, the deletion functionality is waiting for the transaction discharge to complete in order to avoid loosing any messages in case of pushing deleted queue messages into alternate destination.