### PR TITLE
QPID-7615 Number of selectors can be equal to connection thread pool size

### DIFF
--- a/broker-core/src/main/java/org/apache/qpid/server/virtualhost/AbstractVirtualHost.java
+++ b/broker-core/src/main/java/org/apache/qpid/server/virtualhost/AbstractVirtualHost.java
@@ -543,9 +543,9 @@ public abstract class AbstractVirtualHost<X extends AbstractVirtualHost<X>> exte
         {
             throw new IllegalConfigurationException(String.format("Number of Selectors %d on VirtualHost %s must be greater than zero.", virtualHost.getNumberOfSelectors(), getName()));
         }
-        if (virtualHost.getConnectionThreadPoolSize() <= virtualHost.getNumberOfSelectors())
+        if (virtualHost.getConnectionThreadPoolSize() < virtualHost.getNumberOfSelectors())
         {
-            throw new IllegalConfigurationException(String.format("Number of Selectors %d on VirtualHost %s must be less than the connection pool size %d.", virtualHost.getNumberOfSelectors(), getName(), virtualHost.getConnectionThreadPoolSize()));
+            throw new IllegalConfigurationException(String.format("Number of Selectors %d on VirtualHost %s must be less than or equal to the connection pool size %d.", virtualHost.getNumberOfSelectors(), getName(), virtualHost.getConnectionThreadPoolSize()));
         }
     }
 

--- a/broker-core/src/test/java/org/apache/qpid/server/model/VirtualHostTest.java
+++ b/broker-core/src/test/java/org/apache/qpid/server/model/VirtualHostTest.java
@@ -509,31 +509,13 @@ public class VirtualHostTest extends UnitTestBase
     }
 
     @Test
-    public void testCreateValidation()
+    public void testSelectorNumberMustBePositiveOnCreate()
     {
+        createVirtualHost(getTestName(), Collections.singletonMap(QueueManagingVirtualHost.NUMBER_OF_SELECTORS, "1"));
         try
         {
-            createVirtualHost(getTestName(), Collections.singletonMap(QueueManagingVirtualHost.NUMBER_OF_SELECTORS,
-                                                                      "-1"));
-            fail("Exception not thrown for negative number of selectors");
-        }
-        catch (IllegalConfigurationException e)
-        {
-            // pass
-        }
-        try
-        {
-            createVirtualHost(getTestName(), Collections.singletonMap(QueueManagingVirtualHost.CONNECTION_THREAD_POOL_SIZE, "-1"));
-            fail("Exception not thrown for negative connection thread pool size");
-        }
-        catch (IllegalConfigurationException e)
-        {
-            // pass
-        }
-        try
-        {
-            createVirtualHost(getTestName(), Collections.<String, Object>singletonMap(QueueManagingVirtualHost.NUMBER_OF_SELECTORS, QueueManagingVirtualHost.DEFAULT_VIRTUALHOST_CONNECTION_THREAD_POOL_SIZE));
-            fail("Exception not thrown for number of selectors equal to connection thread pool size");
+            createVirtualHost(getTestName(), Collections.singletonMap(QueueManagingVirtualHost.NUMBER_OF_SELECTORS, "0"));
+            fail("Exception not thrown for non-positive number of selectors");
         }
         catch (IllegalConfigurationException e)
         {
@@ -542,32 +524,84 @@ public class VirtualHostTest extends UnitTestBase
     }
 
     @Test
-    public void testChangeValidation()
+    public void testConnectionThreadPoolSizeMustBePositiveOnCreate()
     {
-        QueueManagingVirtualHost<?> virtualHost = createVirtualHost(getTestName());
+        final Map<String, Object> vhAttributes = new HashMap<>();
+        vhAttributes.put(QueueManagingVirtualHost.CONNECTION_THREAD_POOL_SIZE, 1);
+        vhAttributes.put(QueueManagingVirtualHost.NUMBER_OF_SELECTORS, 1);
+        createVirtualHost(getTestName(), vhAttributes);
         try
         {
-            virtualHost.setAttributes(Collections.<String, Object>singletonMap(QueueManagingVirtualHost.NUMBER_OF_SELECTORS, "-1"));
-            fail("Exception not thrown for negative number of selectors");
+            createVirtualHost(getTestName(), Collections.singletonMap(QueueManagingVirtualHost.CONNECTION_THREAD_POOL_SIZE, "0"));
+            fail("Exception not thrown for non-positive connection thread pool size");
         }
         catch (IllegalConfigurationException e)
         {
             // pass
         }
+    }
+
+    @Test
+    public void testSelectorNumberMustBeLessOrEqualToThePoolSizeOnCreate()
+    {
+        createVirtualHost(getTestName(), Collections.singletonMap(QueueManagingVirtualHost.NUMBER_OF_SELECTORS, QueueManagingVirtualHost.DEFAULT_VIRTUALHOST_CONNECTION_THREAD_POOL_SIZE - 1));
+        createVirtualHost(getTestName(), Collections.singletonMap(QueueManagingVirtualHost.NUMBER_OF_SELECTORS, QueueManagingVirtualHost.DEFAULT_VIRTUALHOST_CONNECTION_THREAD_POOL_SIZE));
         try
         {
-            virtualHost.setAttributes(Collections.singletonMap(QueueManagingVirtualHost.CONNECTION_THREAD_POOL_SIZE,
-                                                               "-1"));
-            fail("Exception not thrown for negative connection thread pool size");
+            createVirtualHost(getTestName(), Collections.singletonMap(QueueManagingVirtualHost.NUMBER_OF_SELECTORS, QueueManagingVirtualHost.DEFAULT_VIRTUALHOST_CONNECTION_THREAD_POOL_SIZE + 1));
+            fail("Exception not thrown for number of selectors greater than connection thread pool size");
         }
         catch (IllegalConfigurationException e)
         {
             // pass
         }
+    }
+
+    @Test
+    public void testSelectorNumberMustBePositiveOnChange()
+    {
+        final QueueManagingVirtualHost<?> virtualHost = createVirtualHost(getTestName());
+        virtualHost.setAttributes(Collections.singletonMap(QueueManagingVirtualHost.NUMBER_OF_SELECTORS, "1"));
         try
         {
-            virtualHost.setAttributes(Collections.singletonMap(QueueManagingVirtualHost.NUMBER_OF_SELECTORS, QueueManagingVirtualHost.DEFAULT_VIRTUALHOST_CONNECTION_THREAD_POOL_SIZE));
-            fail("Exception not thrown for number of selectors equal to connection thread pool size");
+            virtualHost.setAttributes(Collections.singletonMap(QueueManagingVirtualHost.NUMBER_OF_SELECTORS, "0"));
+            fail("Exception not thrown for non-positive number of selectors");
+        }
+        catch (IllegalConfigurationException e)
+        {
+            // pass
+        }
+    }
+
+    @Test
+    public void testConnectionThreadPoolSizeMustBePositiveOnChange()
+    {
+        final QueueManagingVirtualHost<?> virtualHost = createVirtualHost(getTestName());
+        final Map<String, Object> vhAttributes = new HashMap<>();
+        vhAttributes.put(QueueManagingVirtualHost.CONNECTION_THREAD_POOL_SIZE, 1);
+        vhAttributes.put(QueueManagingVirtualHost.NUMBER_OF_SELECTORS, 1);
+        virtualHost.setAttributes(vhAttributes);
+        try
+        {
+            virtualHost.setAttributes(Collections.singletonMap(QueueManagingVirtualHost.CONNECTION_THREAD_POOL_SIZE, "0"));
+            fail("Exception not thrown for non-positive connection thread pool size");
+        }
+        catch (IllegalConfigurationException e)
+        {
+            // pass
+        }
+    }
+
+    @Test
+    public void testSelectorNumberMustBeLessOrEqualToThePoolSizeOnChange()
+    {
+        final QueueManagingVirtualHost<?> virtualHost = createVirtualHost(getTestName());
+        virtualHost.setAttributes(Collections.singletonMap(QueueManagingVirtualHost.NUMBER_OF_SELECTORS, QueueManagingVirtualHost.DEFAULT_VIRTUALHOST_CONNECTION_THREAD_POOL_SIZE - 1));
+        virtualHost.setAttributes(Collections.singletonMap(QueueManagingVirtualHost.NUMBER_OF_SELECTORS, QueueManagingVirtualHost.DEFAULT_VIRTUALHOST_CONNECTION_THREAD_POOL_SIZE));
+        try
+        {
+            virtualHost.setAttributes(Collections.singletonMap(QueueManagingVirtualHost.NUMBER_OF_SELECTORS, QueueManagingVirtualHost.DEFAULT_VIRTUALHOST_CONNECTION_THREAD_POOL_SIZE + 1));
+            fail("Exception not thrown for number of selectors greater than connection thread pool size");
         }
         catch (IllegalConfigurationException e)
         {


### PR DESCRIPTION
Divided test **testCreateValidation** to
* testSelectorNumberMustBePositiveOnCreate
* testConnectionThreadPoolSizeMustBePositiveOnCreate
* testSelectorNumberMustBeLessOrEqualToThePoolSizeOnCreate

and test **testChangeValidation** to
* testSelectorNumberMustBePositiveOnChange
* testConnectionThreadPoolSizeMustBePositiveOnChange
* testSelectorNumberMustBeLessOrEqualToThePoolSizeOnChange
