### PR TITLE
QPID-8369: [Broker-J] Limit number of connections per user

### DIFF
--- a/broker-core/src/main/java/org/apache/qpid/server/security/QpidPrincipal.java
+++ b/broker-core/src/main/java/org/apache/qpid/server/security/QpidPrincipal.java
@@ -55,8 +55,8 @@ public interface QpidPrincipal extends Principal, Serializable
                                 "Can't find single %s in the authenticated subject. There were %d "
                                 + "%s principals out of a total number of principals of: %s",
                                 principalClazz.getSimpleName(),
-                                principalClazz.getSimpleName(),
                                 numberOfAuthenticatedPrincipals,
+                                principalClazz.getSimpleName(),
                                 authSubject.getPrincipals()));
             }
             return principals.iterator().next();

--- a/broker-core/src/main/java/org/apache/qpid/server/security/auth/manager/SpnegoAuthenticator.java
+++ b/broker-core/src/main/java/org/apache/qpid/server/security/auth/manager/SpnegoAuthenticator.java
@@ -215,11 +215,15 @@ public class SpnegoAuthenticator
             {
                 TokenCarryingPrincipal principal = new TokenCarryingPrincipal()
                 {
+
+                    private Map<String, String> _tokens = Collections.singletonMap(RESPONSE_AUTH_HEADER_NAME,
+                                                                                   NEGOTIATE_PREFIX + Base64.getEncoder()
+                                                                                                            .encodeToString(outToken));
+
                     @Override
                     public Map<String, String> getTokens()
                     {
-                        return Collections.singletonMap(RESPONSE_AUTH_HEADER_NAME,
-                                                        NEGOTIATE_PREFIX + Base64.getEncoder().encodeToString(outToken));
+                        return _tokens;
                     }
 
                     @Override
@@ -233,6 +237,42 @@ public class SpnegoAuthenticator
                     {
                         return principalName;
                     }
+
+                    @Override
+                    public boolean equals(final Object o)
+                    {
+                        if (this == o)
+                        {
+                            return true;
+                        }
+                        if (!(o instanceof TokenCarryingPrincipal))
+                        {
+                            return false;
+                        }
+
+                        final TokenCarryingPrincipal that = (TokenCarryingPrincipal) o;
+
+                        if (!getName().equals(that.getName()))
+                        {
+                            return false;
+                        }
+
+                        if (!getTokens().equals(that.getTokens()))
+                        {
+                            return false;
+                        }
+                        return getOrigin() != null ? getOrigin().equals(that.getOrigin()) : that.getOrigin() == null;
+                    }
+
+                    @Override
+                    public int hashCode()
+                    {
+                        int result = getName().hashCode();
+                        result = 31 * result + (getOrigin() != null ? getOrigin().hashCode() : 0);
+                        result = 31 * result + getTokens().hashCode();
+                        return result;
+                    }
+
                 };
                 return new AuthenticationResult(principal);
             }

--- a/broker-core/src/main/java/org/apache/qpid/server/transport/AMQPConnection.java
+++ b/broker-core/src/main/java/org/apache/qpid/server/transport/AMQPConnection.java
@@ -39,6 +39,7 @@ import org.apache.qpid.server.txn.LocalTransaction;
 import org.apache.qpid.server.txn.ServerTransaction;
 import org.apache.qpid.server.util.Action;
 import org.apache.qpid.server.util.Deletable;
+import org.apache.qpid.server.virtualhost.ConnectionPrincipalStatistics;
 
 public interface AMQPConnection<C extends AMQPConnection<C>>
         extends Connection<C>, Deletable<C>, EventLoggerProvider
@@ -146,5 +147,11 @@ public interface AMQPConnection<C extends AMQPConnection<C>>
 
     @Override
     AmqpPort<?> getPort();
+
+    void registered(ConnectionPrincipalStatistics connectionPrincipalStatistics);
+
+    int getAuthenticatedPrincipalConnectionCount();
+
+    int getAuthenticatedPrincipalConnectionFrequency();
 
 }

--- a/broker-core/src/main/java/org/apache/qpid/server/transport/AbstractAMQPConnection.java
+++ b/broker-core/src/main/java/org/apache/qpid/server/transport/AbstractAMQPConnection.java
@@ -83,6 +83,7 @@ import org.apache.qpid.server.util.Action;
 import org.apache.qpid.server.util.ConnectionScopedRuntimeException;
 import org.apache.qpid.server.util.FixedKeyMapCreator;
 import org.apache.qpid.server.util.ServerScopedRuntimeException;
+import org.apache.qpid.server.virtualhost.ConnectionPrincipalStatistics;
 import org.apache.qpid.server.virtualhost.QueueManagingVirtualHost;
 
 public abstract class AbstractAMQPConnection<C extends AbstractAMQPConnection<C,T>, T>
@@ -148,6 +149,7 @@ public abstract class AbstractAMQPConnection<C extends AbstractAMQPConnection<C,
     private long _maxUncommittedInMemorySize;
 
     private final Map<ServerTransaction, Set<Ticker>> _transactionTickers = new ConcurrentHashMap<>();
+    private volatile ConnectionPrincipalStatistics _connectionPrincipalStatistics;
 
     public AbstractAMQPConnection(Broker<?> broker,
                                   ServerNetworkConnection network,
@@ -1156,5 +1158,31 @@ public abstract class AbstractAMQPConnection<C extends AbstractAMQPConnection<C,
     public void incrementTransactionBeginCounter()
     {
         _localTransactionBegins.incrementAndGet();
+    }
+
+    @Override
+    public void registered(final ConnectionPrincipalStatistics connectionPrincipalStatistics)
+    {
+        _connectionPrincipalStatistics = connectionPrincipalStatistics;
+    }
+
+    @Override
+    public int getAuthenticatedPrincipalConnectionCount()
+    {
+        if (_connectionPrincipalStatistics == null)
+        {
+            return 0;
+        }
+        return _connectionPrincipalStatistics.getConnectionCount();
+    }
+
+    @Override
+    public int getAuthenticatedPrincipalConnectionFrequency()
+    {
+        if (_connectionPrincipalStatistics == null)
+        {
+            return 0;
+        }
+        return _connectionPrincipalStatistics.getConnectionFrequency();
     }
 }

--- a/broker-core/src/main/java/org/apache/qpid/server/virtualhost/AbstractVirtualHost.java
+++ b/broker-core/src/main/java/org/apache/qpid/server/virtualhost/AbstractVirtualHost.java
@@ -38,6 +38,7 @@ import java.nio.charset.StandardCharsets;
 import java.security.AccessControlContext;
 import java.security.Principal;
 import java.security.PrivilegedAction;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -147,6 +148,7 @@ import org.apache.qpid.server.txn.LocalTransaction;
 import org.apache.qpid.server.txn.ServerTransaction;
 import org.apache.qpid.server.util.HousekeepingExecutor;
 import org.apache.qpid.server.util.Strings;
+import org.apache.qpid.server.virtualhost.connection.ConnectionPrincipalStatisticsRegistryImpl;
 
 public abstract class AbstractVirtualHost<X extends AbstractVirtualHost<X>> extends AbstractConfiguredObject<X>
         implements QueueManagingVirtualHost<X>
@@ -282,6 +284,8 @@ public abstract class AbstractVirtualHost<X extends AbstractVirtualHost<X>> exte
     private PreferenceStore _preferenceStore;
     private long _flowToDiskCheckPeriod;
     private volatile boolean _isDiscardGlobalSharedSubscriptionLinksOnDetach;
+    private volatile ConnectionPrincipalStatisticsRegistry _connectionPrincipalStatisticsRegistry;
+    private volatile HouseKeepingTask _statisticsCheckTask;
 
     public AbstractVirtualHost(final Map<String, Object> attributes, VirtualHostNode<?> virtualHostNode)
     {
@@ -2447,6 +2451,7 @@ public abstract class AbstractVirtualHost<X extends AbstractVirtualHost<X>> exte
             @Override
             public void run()
             {
+                resetConnectionPrincipalStatisticsRegistry();
                 shutdownHouseKeeping();
                 closeNetworkConnectionScheduler();
                 if (_linkRegistry != null)
@@ -2602,6 +2607,9 @@ public abstract class AbstractVirtualHost<X extends AbstractVirtualHost<X>> exte
                 {
                     if (connectionEstablishmentPolicy.mayEstablishNewConnection(_connections, connection))
                     {
+                        final ConnectionPrincipalStatistics cps =
+                                _connectionPrincipalStatisticsRegistry.connectionOpened(connection);
+                        connection.registered(cps);
                         _connections.add(connection);
                         _totalConnectionCount.incrementAndGet();
 
@@ -2664,6 +2672,7 @@ public abstract class AbstractVirtualHost<X extends AbstractVirtualHost<X>> exte
             {
                 connection.popScheduler();
                 _connections.remove(connection);
+                _connectionPrincipalStatisticsRegistry.connectionClosed(connection);
 
                 return Futures.immediateFuture(null);
             }
@@ -2707,6 +2716,7 @@ public abstract class AbstractVirtualHost<X extends AbstractVirtualHost<X>> exte
 
         updateAccessControl();
         initialiseStatisticsReporting();
+        initialiseConnectionPrincipalStatisticsRegistry();
 
         MessageStore messageStore = getMessageStore();
         messageStore.openMessageStore(this);
@@ -2753,6 +2763,42 @@ public abstract class AbstractVirtualHost<X extends AbstractVirtualHost<X>> exte
             postCreateDefaultExchangeTasks();
             return Futures.immediateFuture(null);
         }
+    }
+
+    private void initialiseConnectionPrincipalStatisticsRegistry()
+    {
+        final long connectionFrequencyPeriodMillis = getContextValue(Long.class, CONNECTION_FREQUENCY_PERIOD);
+        final Duration connectionFrequencyPeriod = Duration.ofMillis(connectionFrequencyPeriodMillis);
+        final ConnectionPrincipalStatisticsRegistryImpl connectionStatisticsRegistry =
+                new ConnectionPrincipalStatisticsRegistryImpl(() -> connectionFrequencyPeriod);
+        HouseKeepingTask task = null;
+        long taskRunPeriod = connectionFrequencyPeriodMillis / 2;
+        if (taskRunPeriod > 0)
+        {
+            final AccessControlContext context =
+                    getSystemTaskControllerContext("ConnectionPrincipalStatisticsCheck", _principal);
+            task = new ConnectionPrincipalStatisticsCheckingTask(this, context, connectionStatisticsRegistry);
+            scheduleHouseKeepingTask(taskRunPeriod, task);
+        }
+        _statisticsCheckTask = task;
+        _connectionPrincipalStatisticsRegistry = connectionStatisticsRegistry;
+    }
+
+    private void resetConnectionPrincipalStatisticsRegistry()
+    {
+        final HouseKeepingTask previousStatisticsCheckTask = _statisticsCheckTask;
+        if (previousStatisticsCheckTask != null)
+        {
+            previousStatisticsCheckTask.cancel();
+        }
+        _statisticsCheckTask = null;
+        final ConnectionPrincipalStatisticsRegistry connectionPrincipalStatisticsRegistry =
+                _connectionPrincipalStatisticsRegistry;
+        if (connectionPrincipalStatisticsRegistry != null)
+        {
+            connectionPrincipalStatisticsRegistry.reset();
+        }
+        _connectionPrincipalStatisticsRegistry = null;
     }
 
     private void postCreateDefaultExchangeTasks()

--- a/broker-core/src/main/java/org/apache/qpid/server/virtualhost/ConnectionPrincipalStatistics.java
+++ b/broker-core/src/main/java/org/apache/qpid/server/virtualhost/ConnectionPrincipalStatistics.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.qpid.server.virtualhost;
+
+public interface ConnectionPrincipalStatistics
+{
+    int getConnectionCount();
+
+    int getConnectionFrequency();
+}

--- a/broker-core/src/main/java/org/apache/qpid/server/virtualhost/ConnectionPrincipalStatisticsCheckingTask.java
+++ b/broker-core/src/main/java/org/apache/qpid/server/virtualhost/ConnectionPrincipalStatisticsCheckingTask.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.qpid.server.virtualhost;
+
+import java.security.AccessControlContext;
+
+public class ConnectionPrincipalStatisticsCheckingTask extends HouseKeepingTask
+{
+    private static final String TASK_NAME = "ConnectionPrincipalStatisticsCheck";
+    private final ConnectionPrincipalStatisticsRegistry _connectionPrincipalStatisticsRegistry;
+
+    public ConnectionPrincipalStatisticsCheckingTask(final QueueManagingVirtualHost virtualHost,
+                                                     final AccessControlContext controlContext,
+                                                     final ConnectionPrincipalStatisticsRegistry connectionPrincipalStatisticsRegistry)
+    {
+        super(TASK_NAME, virtualHost, controlContext);
+        _connectionPrincipalStatisticsRegistry = connectionPrincipalStatisticsRegistry;
+    }
+
+    @Override
+    public void execute()
+    {
+        _connectionPrincipalStatisticsRegistry.reevaluateConnectionStatistics();
+    }
+}

--- a/broker-core/src/main/java/org/apache/qpid/server/virtualhost/ConnectionPrincipalStatisticsRegistry.java
+++ b/broker-core/src/main/java/org/apache/qpid/server/virtualhost/ConnectionPrincipalStatisticsRegistry.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.qpid.server.virtualhost;
+
+import org.apache.qpid.server.transport.AMQPConnection;
+
+public interface ConnectionPrincipalStatisticsRegistry
+{
+    ConnectionPrincipalStatistics connectionOpened(AMQPConnection<?> connection);
+
+    ConnectionPrincipalStatistics connectionClosed(AMQPConnection<?> connection);
+
+    void reevaluateConnectionStatistics();
+
+    void reset();
+}

--- a/broker-core/src/main/java/org/apache/qpid/server/virtualhost/ConnectionStatisticsRegistrySettings.java
+++ b/broker-core/src/main/java/org/apache/qpid/server/virtualhost/ConnectionStatisticsRegistrySettings.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.qpid.server.virtualhost;
+
+import java.time.Duration;
+
+public interface ConnectionStatisticsRegistrySettings
+{
+    Duration getConnectionFrequencyPeriod();
+}

--- a/broker-core/src/main/java/org/apache/qpid/server/virtualhost/QueueManagingVirtualHost.java
+++ b/broker-core/src/main/java/org/apache/qpid/server/virtualhost/QueueManagingVirtualHost.java
@@ -104,6 +104,11 @@ public interface QueueManagingVirtualHost<X extends QueueManagingVirtualHost<X>>
                                          + " link detaches. This is to avoid leaking links with the Qpid JMS client.")
     boolean DEFAULT_DISCARD_GLOBAL_SHARED_SUBSCRIPTION_LINKS_ON_DETACH = true;
 
+    String CONNECTION_FREQUENCY_PERIOD = "qpid.virtualhost.connectionFrequencyPeriodInMillis";
+    @ManagedContextDefault(name = CONNECTION_FREQUENCY_PERIOD, description = "Interval (in milliseconds) to evaluate connection frequency")
+    @SuppressWarnings("unused")
+    long DEFAULT_CONNECTION_FREQUENCY_PERIOD = 60 * 1000;
+
     @ManagedAttribute( defaultValue = "${" + VIRTUALHOST_STATISTICS_REPORING_PERIOD + "}", description = "Period (in seconds) of the statistic report.")
     int getStatisticsReportingPeriod();
 

--- a/broker-core/src/main/java/org/apache/qpid/server/virtualhost/connection/ConnectionPrincipalStatisticsImpl.java
+++ b/broker-core/src/main/java/org/apache/qpid/server/virtualhost/connection/ConnectionPrincipalStatisticsImpl.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.qpid.server.virtualhost.connection;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.qpid.server.virtualhost.ConnectionPrincipalStatistics;
+
+class ConnectionPrincipalStatisticsImpl implements ConnectionPrincipalStatistics
+{
+    private final int _connectionCount;
+    private final List<Long> _latestConnectionCreatedTimes;
+
+    ConnectionPrincipalStatisticsImpl(final int connectionCount, final List<Long> latestConnectionCreatedTimes)
+    {
+        _connectionCount = connectionCount;
+        _latestConnectionCreatedTimes = Collections.unmodifiableList(latestConnectionCreatedTimes);
+    }
+
+    @Override
+    public int getConnectionCount()
+    {
+        return _connectionCount;
+    }
+
+    @Override
+    public int getConnectionFrequency()
+    {
+        return _latestConnectionCreatedTimes.size();
+    }
+
+    List<Long> getLatestConnectionCreatedTimes()
+    {
+        return _latestConnectionCreatedTimes;
+    }
+
+    @Override
+    public boolean equals(final Object o)
+    {
+        if (this == o)
+        {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass())
+        {
+            return false;
+        }
+
+        final ConnectionPrincipalStatisticsImpl that = (ConnectionPrincipalStatisticsImpl) o;
+
+        if (_connectionCount != that._connectionCount)
+        {
+            return false;
+        }
+        return _latestConnectionCreatedTimes.equals(that._latestConnectionCreatedTimes);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        int result = _connectionCount;
+        result = 31 * result + _latestConnectionCreatedTimes.hashCode();
+        return result;
+    }
+}

--- a/broker-core/src/main/java/org/apache/qpid/server/virtualhost/connection/ConnectionPrincipalStatisticsRegistryImpl.java
+++ b/broker-core/src/main/java/org/apache/qpid/server/virtualhost/connection/ConnectionPrincipalStatisticsRegistryImpl.java
@@ -1,0 +1,182 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.qpid.server.virtualhost.connection;
+
+import java.security.Principal;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+import javax.security.auth.Subject;
+
+import org.apache.qpid.server.security.auth.AuthenticatedPrincipal;
+import org.apache.qpid.server.transport.AMQPConnection;
+import org.apache.qpid.server.virtualhost.ConnectionPrincipalStatistics;
+import org.apache.qpid.server.virtualhost.ConnectionPrincipalStatisticsRegistry;
+import org.apache.qpid.server.virtualhost.ConnectionStatisticsRegistrySettings;
+
+public class ConnectionPrincipalStatisticsRegistryImpl implements ConnectionPrincipalStatisticsRegistry
+{
+    private final Map<Principal, ConnectionPrincipalStatisticsImpl> _principalStatistics = new ConcurrentHashMap<>();
+    private final ConnectionStatisticsRegistrySettings _settings;
+
+    public ConnectionPrincipalStatisticsRegistryImpl(final ConnectionStatisticsRegistrySettings settings)
+    {
+        _settings = settings;
+    }
+
+    @Override
+    public ConnectionPrincipalStatistics connectionOpened(final AMQPConnection<?> connection)
+    {
+        final Subject subject = connection.getSubject();
+        final AuthenticatedPrincipal principal = AuthenticatedPrincipal.getAuthenticatedPrincipalFromSubject(subject);
+        return _principalStatistics.compute(principal,
+                                            (p, s) -> connectionOpened(s, connection.getCreatedTime()));
+    }
+
+    @Override
+    public ConnectionPrincipalStatistics connectionClosed(final AMQPConnection<?> connection)
+    {
+        final Subject subject = connection.getSubject();
+        final AuthenticatedPrincipal principal = AuthenticatedPrincipal.getAuthenticatedPrincipalFromSubject(subject);
+        return _principalStatistics.computeIfPresent(principal, (p, s) -> connectionClosed(s));
+    }
+
+    @Override
+    public void reevaluateConnectionStatistics()
+    {
+        new HashSet<>(_principalStatistics.keySet()).forEach(this::reevaluateConnectionStatistics);
+    }
+
+    @Override
+    public void reset()
+    {
+        _principalStatistics.clear();
+    }
+
+    int getConnectionCount(final Principal principal)
+    {
+        ConnectionPrincipalStatistics cs = _principalStatistics.get(principal);
+        if (cs != null)
+        {
+            return cs.getConnectionCount();
+        }
+        return 0;
+    }
+
+    int getConnectionFrequency(final Principal principal)
+    {
+        ConnectionPrincipalStatistics cs = _principalStatistics.get(principal);
+        if (cs != null)
+        {
+            return cs.getConnectionFrequency();
+        }
+        return 0;
+    }
+
+    private ConnectionPrincipalStatisticsImpl connectionOpened(final ConnectionPrincipalStatisticsImpl current,
+                                                           final Date createdTime)
+    {
+        if (current == null)
+        {
+            return new ConnectionPrincipalStatisticsImpl(1, Collections.singletonList(createdTime.getTime()));
+        }
+        else
+        {
+            final long frequencyPeriod = getConnectionFrequencyPeriodMillis();
+            final List<Long> connectionCreatedTimes;
+            if (frequencyPeriod > 0)
+            {
+                connectionCreatedTimes = findTimesWithinPeriod(current.getLatestConnectionCreatedTimes(), frequencyPeriod);
+                connectionCreatedTimes.add(createdTime.getTime());
+            }
+            else
+            {
+                connectionCreatedTimes = Collections.emptyList();
+            }
+            return new ConnectionPrincipalStatisticsImpl(current.getConnectionCount() + 1, connectionCreatedTimes);
+        }
+    }
+
+    private ConnectionPrincipalStatisticsImpl connectionClosed(final ConnectionPrincipalStatisticsImpl current)
+    {
+        return createStatisticsOrNull(Math.max(0, current.getConnectionCount() - 1), current.getLatestConnectionCreatedTimes());
+    }
+
+    private void reevaluateConnectionStatistics(final Principal authenticatedPrincipal)
+    {
+        _principalStatistics.computeIfPresent(authenticatedPrincipal, (principal, current) -> reevaluate(current));
+    }
+
+    private ConnectionPrincipalStatisticsImpl reevaluate(final ConnectionPrincipalStatisticsImpl current)
+    {
+        return createStatisticsOrNull(current.getConnectionCount(), current.getLatestConnectionCreatedTimes());
+    }
+
+    private ConnectionPrincipalStatisticsImpl createStatisticsOrNull(final int openConnectionCount,
+                                                                 final List<Long> currentConnectionCreatedTimes)
+    {
+        final List<Long> connectionCreatedTimes = findTimesWithinPeriod(currentConnectionCreatedTimes, getConnectionFrequencyPeriodMillis());
+        if (openConnectionCount == 0 && connectionCreatedTimes.isEmpty())
+        {
+            return null;
+        }
+        return new ConnectionPrincipalStatisticsImpl(openConnectionCount, connectionCreatedTimes);
+    }
+
+    private List<Long> findTimesWithinPeriod(final Collection<Long> currentConnectionCreatedTimes,
+                                             final long frequencyPeriod)
+    {
+
+        final List<Long> connectionCreatedTimes;
+        if (frequencyPeriod > 0)
+        {
+            final long periodEnd = System.currentTimeMillis();
+            final long periodStart = periodEnd - frequencyPeriod;
+            connectionCreatedTimes = findTimesBetween(currentConnectionCreatedTimes, periodStart, periodEnd);
+        }
+        else
+        {
+            connectionCreatedTimes = Collections.emptyList();
+        }
+        return connectionCreatedTimes;
+    }
+
+    private List<Long> findTimesBetween(final Collection<Long> connectionCreatedTimes,
+                                        final long periodStart,
+                                        final long periodEnd)
+    {
+        return connectionCreatedTimes.stream().mapToLong(Long::longValue)
+                                     .filter(t -> t >= periodStart && t <= periodEnd)
+                                     .boxed()
+                                     .collect(Collectors.toCollection(ArrayList::new));
+    }
+
+    private long getConnectionFrequencyPeriodMillis()
+    {
+        return _settings.getConnectionFrequencyPeriod().toMillis();
+    }
+}

--- a/broker-core/src/test/java/org/apache/qpid/server/virtualhost/ConnectionPrincipalStatisticsCheckingTaskTest.java
+++ b/broker-core/src/test/java/org/apache/qpid/server/virtualhost/ConnectionPrincipalStatisticsCheckingTaskTest.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.qpid.server.virtualhost;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.security.AccessController;
+
+import org.junit.Test;
+
+import org.apache.qpid.test.utils.UnitTestBase;
+
+public class ConnectionPrincipalStatisticsCheckingTaskTest extends UnitTestBase
+{
+    @Test
+    public void execute()
+    {
+        final QueueManagingVirtualHost vh = mock(QueueManagingVirtualHost.class);
+        when(vh.getName()).thenReturn(getTestName());
+        final ConnectionPrincipalStatisticsRegistry registry = mock(ConnectionPrincipalStatisticsRegistry.class);
+        ConnectionPrincipalStatisticsCheckingTask task =
+                new ConnectionPrincipalStatisticsCheckingTask(vh, AccessController.getContext(), registry);
+
+        task.execute();
+
+        verify(registry).reevaluateConnectionStatistics();
+    }
+}

--- a/broker-core/src/test/java/org/apache/qpid/server/virtualhost/connection/ConnectionPrincipalStatisticsImplTest.java
+++ b/broker-core/src/test/java/org/apache/qpid/server/virtualhost/connection/ConnectionPrincipalStatisticsImplTest.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.qpid.server.virtualhost.connection;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Test;
+
+import org.apache.qpid.server.virtualhost.ConnectionPrincipalStatistics;
+import org.apache.qpid.test.utils.UnitTestBase;
+
+public class ConnectionPrincipalStatisticsImplTest extends UnitTestBase
+{
+
+    @Test
+    public void getOpenConnectionCount()
+    {
+        final ConnectionPrincipalStatistics stats =
+                new ConnectionPrincipalStatisticsImpl(1, Collections.singletonList(System.currentTimeMillis()));
+
+        assertEquals(1, stats.getConnectionCount());
+    }
+
+    @Test
+    public void getOpenConnectionFrequency()
+    {
+        final long connectionCreatedTime = System.currentTimeMillis();
+        final ConnectionPrincipalStatistics stats =
+                new ConnectionPrincipalStatisticsImpl(1,
+                                                      Arrays.asList(connectionCreatedTime - 1000, connectionCreatedTime));
+        assertEquals(2, stats.getConnectionFrequency());
+    }
+
+    @Test
+    public void getLatestConnectionCreatedTimes()
+    {
+        final long connectionCreatedTime = System.currentTimeMillis();
+        final List<Long> connectionCreatedTimes = Arrays.asList(connectionCreatedTime - 1000, connectionCreatedTime);
+        final ConnectionPrincipalStatisticsImpl stats = new ConnectionPrincipalStatisticsImpl(1, connectionCreatedTimes);
+        assertEquals(connectionCreatedTimes, stats.getLatestConnectionCreatedTimes());
+    }
+
+    @Test
+    public void equals()
+    {
+        final long connectionCreatedTime = System.currentTimeMillis();
+        final ConnectionPrincipalStatistics stats1 =
+                new ConnectionPrincipalStatisticsImpl(1, Collections.singletonList(connectionCreatedTime));
+        final ConnectionPrincipalStatistics stats2 =
+                new ConnectionPrincipalStatisticsImpl(1, Collections.singletonList(connectionCreatedTime));
+        assertEquals(stats1, stats2);
+
+        final long connectionCreatedTime2 = System.currentTimeMillis();
+        final ConnectionPrincipalStatistics stats3 =
+                new ConnectionPrincipalStatisticsImpl(2, Arrays.asList(connectionCreatedTime, connectionCreatedTime2));
+
+        assertNotEquals(stats2, stats3);
+        assertNotEquals(stats1, stats3);
+    }
+
+    @Test
+    public void testHashCode()
+    {
+        final long connectionCreatedTime = System.currentTimeMillis();
+        final ConnectionPrincipalStatistics stats1 =
+                new ConnectionPrincipalStatisticsImpl(1, Collections.singletonList(connectionCreatedTime));
+        final ConnectionPrincipalStatistics stats2 =
+                new ConnectionPrincipalStatisticsImpl(1, Collections.singletonList(connectionCreatedTime));
+        assertEquals(stats1.hashCode(), stats2.hashCode());
+
+        final long connectionCreatedTime2 = System.currentTimeMillis();
+        final ConnectionPrincipalStatistics stats3 =
+                new ConnectionPrincipalStatisticsImpl(2, Arrays.asList(connectionCreatedTime, connectionCreatedTime2));
+
+        assertNotEquals(stats2.hashCode(), stats3.hashCode());
+        assertNotEquals(stats1.hashCode(), stats3.hashCode());
+    }
+}

--- a/broker-core/src/test/java/org/apache/qpid/server/virtualhost/connection/ConnectionPrincipalStatisticsRegistryImplTest.java
+++ b/broker-core/src/test/java/org/apache/qpid/server/virtualhost/connection/ConnectionPrincipalStatisticsRegistryImplTest.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.qpid.server.virtualhost.connection;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.security.Principal;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Date;
+
+import javax.security.auth.Subject;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import org.apache.qpid.server.security.auth.AuthenticatedPrincipal;
+import org.apache.qpid.server.transport.AMQPConnection;
+import org.apache.qpid.server.virtualhost.ConnectionStatisticsRegistrySettings;
+import org.apache.qpid.test.utils.UnitTestBase;
+
+public class ConnectionPrincipalStatisticsRegistryImplTest extends UnitTestBase
+{
+    private static final Duration CONNECTION_FREQUENCY_PERIOD = Duration.ofMillis(5000);
+    private ConnectionPrincipalStatisticsRegistryImpl _statisticsRegistry;
+    private AuthenticatedPrincipal _authorizedPrincipal;
+    private ConnectionStatisticsRegistrySettings _settings;
+
+    @Before
+    public void setUp()
+    {
+        _settings = mock(ConnectionStatisticsRegistrySettings.class);
+        when(_settings.getConnectionFrequencyPeriod()).thenReturn(CONNECTION_FREQUENCY_PERIOD);
+        _statisticsRegistry = new ConnectionPrincipalStatisticsRegistryImpl(_settings);
+        _authorizedPrincipal = new AuthenticatedPrincipal(mock(Principal.class));
+    }
+
+    @Test
+    public void onConnectionOpen()
+    {
+        final AMQPConnection connection = mockConnection();
+
+        _statisticsRegistry.connectionOpened(connection);
+
+        assertThat(_statisticsRegistry.getConnectionCount(_authorizedPrincipal), is(equalTo(1)));
+        assertThat(_statisticsRegistry.getConnectionCount(_authorizedPrincipal), is(equalTo(1)));
+    }
+
+    @Test
+    public void onConnectionClose()
+    {
+        final AMQPConnection connection1 = mockConnection();
+
+        _statisticsRegistry.connectionOpened(connection1);
+        _statisticsRegistry.connectionClosed(connection1);
+
+        final AMQPConnection connection2 = mockConnection();
+        _statisticsRegistry.connectionOpened(connection2);
+
+        assertThat(_statisticsRegistry.getConnectionCount(_authorizedPrincipal), is(equalTo(1)));
+        assertThat(_statisticsRegistry.getConnectionFrequency(_authorizedPrincipal), is(equalTo(2)));
+    }
+
+    @Test
+    public void reevaluateConnectionPrincipalStatistics() throws InterruptedException
+    {
+        final AMQPConnection connection1 = mockConnection();
+
+        _statisticsRegistry.connectionOpened(connection1);
+        assertThat(_statisticsRegistry.getConnectionFrequency(_authorizedPrincipal), is(equalTo(1)));
+
+        _statisticsRegistry.reevaluateConnectionStatistics();
+        assertThat(_statisticsRegistry.getConnectionFrequency(_authorizedPrincipal), is(equalTo(1)));
+
+        when(_settings.getConnectionFrequencyPeriod()).thenReturn(Duration.ofMillis(1));
+        Thread.sleep(_settings.getConnectionFrequencyPeriod().toMillis() + 1);
+
+        _statisticsRegistry.reevaluateConnectionStatistics();
+        assertThat(_statisticsRegistry.getConnectionCount(_authorizedPrincipal), is(equalTo(1)));
+        assertThat(_statisticsRegistry.getConnectionFrequency(_authorizedPrincipal), is(equalTo(0)));
+    }
+
+    @Test
+    public void getConnectionFrequencyAfterExpirationOfFrequencyPeriod() throws InterruptedException
+    {
+        final AMQPConnection connection1 = mockConnection();
+        _statisticsRegistry.connectionOpened(connection1);
+
+        assertThat(_statisticsRegistry.getConnectionFrequency(_authorizedPrincipal), is(equalTo(1)));
+        assertThat(_statisticsRegistry.getConnectionCount(_authorizedPrincipal), is(equalTo(1)));
+
+        when(_settings.getConnectionFrequencyPeriod()).thenReturn(Duration.ofMillis(1));
+        Thread.sleep(_settings.getConnectionFrequencyPeriod().toMillis() + 1);
+
+        final AMQPConnection connection2 = mockConnection();
+        _statisticsRegistry.connectionOpened(connection2);
+
+        assertThat(_statisticsRegistry.getConnectionCount(_authorizedPrincipal), is(equalTo(2)));
+        assertThat(_statisticsRegistry.getConnectionFrequency(_authorizedPrincipal), is(equalTo(1)));
+    }
+
+    private AMQPConnection mockConnection()
+    {
+        final Subject subject = new Subject(true,
+                                            Collections.singleton(_authorizedPrincipal),
+                                            Collections.emptySet(),
+                                            Collections.emptySet());
+
+        final AMQPConnection connection = mock(AMQPConnection.class);
+        when(connection.getAuthorizedPrincipal()).thenReturn(_authorizedPrincipal);
+        when(connection.getSubject()).thenReturn(subject);
+        when(connection.getCreatedTime()).thenReturn(new Date());
+        return connection;
+    }
+}

--- a/broker-plugins/access-control/src/main/java/org/apache/qpid/server/security/access/config/ClientAction.java
+++ b/broker-plugins/access-control/src/main/java/org/apache/qpid/server/security/access/config/ClientAction.java
@@ -18,9 +18,7 @@
  */
 package org.apache.qpid.server.security.access.config;
 
-import java.net.InetAddress;
-
-import org.apache.qpid.server.security.access.firewall.FirewallRule;
+import javax.security.auth.Subject;
 
 /**
  * I represent an {@link Action} taken by a client from a known address. The address is used to
@@ -30,7 +28,7 @@ public class ClientAction
 {
     private Action _clientAction;
 
-    public ClientAction(Action clientAction)
+    ClientAction(Action clientAction)
     {
         _clientAction = clientAction;
     }
@@ -40,23 +38,15 @@ public class ClientAction
         _clientAction = new Action(operation, objectType, properties);
     }
 
-    public boolean matches(AclAction ruleAction, InetAddress addressOfClient)
+    public boolean matches(AclAction ruleAction, final Subject subject)
     {
         return _clientAction.matches(ruleAction.getAction())
-                && addressOfClientMatches(ruleAction, addressOfClient);
+               && dynamicMatches(ruleAction.getDynamicRule(), subject);
     }
 
-    private boolean addressOfClientMatches(AclAction ruleAction, InetAddress addressOfClient)
+    private boolean dynamicMatches(final DynamicRule dynamicRule, final Subject subject)
     {
-        FirewallRule firewallRule = ruleAction.getFirewallRule();
-        if(firewallRule == null || addressOfClient == null)
-        {
-            return true;
-        }
-        else
-        {
-            return firewallRule.matches(addressOfClient);
-        }
+        return dynamicRule == null || dynamicRule.matches(subject);
     }
 
     public LegacyOperation getOperation()

--- a/broker-plugins/access-control/src/main/java/org/apache/qpid/server/security/access/config/DynamicRule.java
+++ b/broker-plugins/access-control/src/main/java/org/apache/qpid/server/security/access/config/DynamicRule.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.qpid.server.security.access.config;
+
+import java.util.Objects;
+
+import javax.security.auth.Subject;
+
+public interface DynamicRule
+{
+    boolean matches(Subject subject);
+
+    default DynamicRule and(DynamicRule other)
+    {
+        Objects.requireNonNull(other);
+
+        return new DynamicRule()
+        {
+            @Override
+            public boolean matches(final Subject subject)
+            {
+                return DynamicRule.this.matches(subject) && other.matches(subject);
+            }
+
+            @Override
+            public String toString()
+            {
+                return String.format("%s and %s", DynamicRule.this.toString(), other.toString());
+            }
+        };
+    }
+}

--- a/broker-plugins/access-control/src/main/java/org/apache/qpid/server/security/access/config/ObjectProperties.java
+++ b/broker-plugins/access-control/src/main/java/org/apache/qpid/server/security/access/config/ObjectProperties.java
@@ -64,7 +64,9 @@ public class ObjectProperties
         VIRTUALHOST_NAME,
         METHOD_NAME,
         ATTRIBUTES,
-        CREATED_BY;
+        CREATED_BY,
+        CONNECTION_LIMIT,
+        CONNECTION_FREQUENCY_LIMIT;
 
         private static final Map<String, Property> _canonicalNameToPropertyMap = new HashMap<String, ObjectProperties.Property>();
 

--- a/broker-plugins/access-control/src/main/java/org/apache/qpid/server/security/access/config/RuleSet.java
+++ b/broker-plugins/access-control/src/main/java/org/apache/qpid/server/security/access/config/RuleSet.java
@@ -18,7 +18,6 @@
  */
 package org.apache.qpid.server.security.access.config;
 
-import java.net.InetAddress;
 import java.security.Principal;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -123,16 +122,6 @@ public class RuleSet implements EventLoggerProvider
     }
 
     /**
-     * Checks for the case when the client's address is not known.
-     *
-     * @see #check(Subject, LegacyOperation, ObjectType, ObjectProperties, InetAddress)
-     */
-    public Result check(Subject subject, LegacyOperation operation, ObjectType objectType, ObjectProperties properties)
-    {
-        return check(subject, operation, objectType, properties, null);
-    }
-
-    /**
      * Check the authorisation granted to a particular identity for an operation on an object type with
      * specific properties.
      *
@@ -141,7 +130,10 @@ public class RuleSet implements EventLoggerProvider
      * the first match found, or denies access if there are no matching rules. Normally, it would be expected
      * to have a default deny or allow rule at the end of an access configuration however.
      */
-    public Result check(Subject subject, LegacyOperation operation, ObjectType objectType, ObjectProperties properties, InetAddress addressOfClient)
+    public Result check(Subject subject,
+                        LegacyOperation operation,
+                        ObjectType objectType,
+                        ObjectProperties properties)
     {
         ClientAction action = new ClientAction(operation, objectType, properties);
 
@@ -186,7 +178,7 @@ public class RuleSet implements EventLoggerProvider
         {
             LOGGER.debug("Checking against rule: {}", rule);
 
-            if (action.matches(rule.getAclAction(), addressOfClient))
+            if (action.matches(rule.getAclAction(), subject))
             {
                 RuleOutcome ruleOutcome = rule.getRuleOutcome();
                 LOGGER.debug("Action matches.  Result: {}", ruleOutcome);

--- a/broker-plugins/access-control/src/main/java/org/apache/qpid/server/security/access/config/connection/ConnectionPrincipalFrequencyLimitRule.java
+++ b/broker-plugins/access-control/src/main/java/org/apache/qpid/server/security/access/config/connection/ConnectionPrincipalFrequencyLimitRule.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.qpid.server.security.access.config.connection;
+
+import org.apache.qpid.server.security.access.config.ObjectProperties;
+import org.apache.qpid.server.transport.AMQPConnection;
+
+public class ConnectionPrincipalFrequencyLimitRule extends ConnectionPrincipalStatisticsRule
+{
+    public ConnectionPrincipalFrequencyLimitRule(final int limit)
+    {
+        super(limit);
+    }
+
+    @Override
+    boolean matches(final AMQPConnection<?> connection)
+    {
+        return connection.getAuthenticatedPrincipalConnectionFrequency() <= getLimit();
+    }
+
+    @Override
+    public String toString()
+    {
+        return String.format("ConnectionPrincipalFrequencyLimitRule{%s=%d}",
+                             ObjectProperties.Property.CONNECTION_FREQUENCY_LIMIT.name().toLowerCase(),
+                             getLimit());
+    }
+}

--- a/broker-plugins/access-control/src/main/java/org/apache/qpid/server/security/access/config/connection/ConnectionPrincipalLimitRule.java
+++ b/broker-plugins/access-control/src/main/java/org/apache/qpid/server/security/access/config/connection/ConnectionPrincipalLimitRule.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.qpid.server.security.access.config.connection;
+
+import org.apache.qpid.server.security.access.config.ObjectProperties;
+import org.apache.qpid.server.transport.AMQPConnection;
+
+public class ConnectionPrincipalLimitRule extends ConnectionPrincipalStatisticsRule
+{
+    public ConnectionPrincipalLimitRule(final int limit)
+    {
+        super(limit);
+    }
+
+    protected boolean matches(final AMQPConnection<?> connection)
+    {
+        return connection.getAuthenticatedPrincipalConnectionCount() <= getLimit();
+    }
+
+    @Override
+    public String toString()
+    {
+        return String.format("ConnectionPrincipalLimitRule{%s=%d}",
+                             ObjectProperties.Property.CONNECTION_LIMIT.name().toLowerCase(),
+                             getLimit());
+    }
+}

--- a/broker-plugins/access-control/src/main/java/org/apache/qpid/server/security/access/firewall/HostnameFirewallRule.java
+++ b/broker-plugins/access-control/src/main/java/org/apache/qpid/server/security/access/firewall/HostnameFirewallRule.java
@@ -30,9 +30,7 @@ import java.util.regex.Pattern;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import org.apache.qpid.server.security.access.config.ObjectProperties;
-
-public class HostnameFirewallRule implements FirewallRule
+public class HostnameFirewallRule extends FirewallRule
 {
     private static final Logger LOGGER = LoggerFactory.getLogger(HostnameFirewallRule.class);
 
@@ -58,7 +56,7 @@ public class HostnameFirewallRule implements FirewallRule
     }
 
     @Override
-    public boolean matches(InetAddress remote)
+    protected boolean matches(InetAddress remote)
     {
         String hostname = getHostname(remote);
         if (hostname == null)
@@ -84,23 +82,11 @@ public class HostnameFirewallRule implements FirewallRule
         return false;
     }
 
-    @Override
-    public ObjectProperties.Property getPropertyName()
-    {
-        return ObjectProperties.Property.FROM_HOSTNAME;
-    }
-
-    @Override
-    public String getPropertyValue()
-    {
-        return String.join(",", _hostnames);
-    }
-
     /**
      * @param remote
      *            the InetAddress to look up
      * @return the hostname, null if not found, takes longer than
-     *         {@value #DNS_LOOKUP} to find or otherwise fails
+     *         {@link #DNS_LOOKUP} to find or otherwise fails
      */
     private String getHostname(final InetAddress remote) throws AccessControlFirewallException
     {

--- a/broker-plugins/access-control/src/main/java/org/apache/qpid/server/security/access/firewall/NetworkFirewallRule.java
+++ b/broker-plugins/access-control/src/main/java/org/apache/qpid/server/security/access/firewall/NetworkFirewallRule.java
@@ -25,17 +25,13 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import org.apache.qpid.server.security.access.config.ObjectProperties;
-
-public class NetworkFirewallRule implements FirewallRule
+public class NetworkFirewallRule extends FirewallRule
 {
     private static final Logger LOGGER = LoggerFactory.getLogger(NetworkFirewallRule.class);
-    private final String _originalNetworks;
     private List<InetNetwork> _networks;
 
     public NetworkFirewallRule(String... networks)
     {
-        _originalNetworks = String.join(",", networks);
         _networks = new ArrayList<InetNetwork>();
         for (int i = 0; i < networks.length; i++)
         {
@@ -58,7 +54,7 @@ public class NetworkFirewallRule implements FirewallRule
     }
 
     @Override
-    public boolean matches(InetAddress ip)
+    protected boolean matches(InetAddress ip)
     {
         for (InetNetwork network : _networks)
         {
@@ -106,17 +102,5 @@ public class NetworkFirewallRule implements FirewallRule
         return "NetworkFirewallRule[" +
                "networks=" + _networks +
                ']';
-    }
-
-    @Override
-    public ObjectProperties.Property getPropertyName()
-    {
-        return ObjectProperties.Property.FROM_NETWORK;
-    }
-
-    @Override
-    public String getPropertyValue()
-    {
-        return _originalNetworks;
     }
 }

--- a/broker-plugins/access-control/src/test/java/org/apache/qpid/server/security/access/config/AclActionTest.java
+++ b/broker-plugins/access-control/src/test/java/org/apache/qpid/server/security/access/config/AclActionTest.java
@@ -89,7 +89,7 @@ public class AclActionTest extends UnitTestBase
     private AclRulePredicates createAclRulePredicates()
     {
         AclRulePredicates predicates = mock(AclRulePredicates.class);
-        when(predicates.getFirewallRule()).thenReturn(mock(FirewallRule.class));
+        when(predicates.getDynamicRule()).thenReturn(mock(FirewallRule.class));
         when(predicates.getObjectProperties()).thenReturn(mock(ObjectProperties.class));
         return predicates;
     }

--- a/broker-plugins/access-control/src/test/java/org/apache/qpid/server/security/access/config/AclRulePredicatesTest.java
+++ b/broker-plugins/access-control/src/test/java/org/apache/qpid/server/security/access/config/AclRulePredicatesTest.java
@@ -20,16 +20,21 @@ package org.apache.qpid.server.security.access.config;
 
 import static org.apache.qpid.server.security.access.config.ObjectProperties.Property.ATTRIBUTES;
 import static org.apache.qpid.server.security.access.config.ObjectProperties.Property.CLASS;
+import static org.apache.qpid.server.security.access.config.ObjectProperties.Property.CONNECTION_LIMIT;
 import static org.apache.qpid.server.security.access.config.ObjectProperties.Property.FROM_HOSTNAME;
 import static org.apache.qpid.server.security.access.config.ObjectProperties.Property.FROM_NETWORK;
 import static org.apache.qpid.server.security.access.config.ObjectProperties.Property.NAME;
+import static org.hamcrest.CoreMatchers.allOf;
+import static org.hamcrest.collection.IsMapContaining.hasEntry;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.Map;
 import java.util.Set;
 
 import org.junit.Before;
@@ -113,5 +118,19 @@ public class AclRulePredicatesTest extends UnitTestBase
                             attributesSet,
                             _aclRulePredicates.getObjectProperties().getAttributeNames());
 
+    }
+
+    @Test
+    public void testGetParsedProperties()
+    {
+        _aclRulePredicates.parse(ATTRIBUTES.name(), "attribute1,attribute2");
+        _aclRulePredicates.parse(FROM_NETWORK.name(), "network1,network2");
+        _aclRulePredicates.parse(CONNECTION_LIMIT.name(), "20");
+
+        final Map<ObjectProperties.Property, String> properties = _aclRulePredicates.getParsedProperties();
+
+        assertThat(properties, allOf(hasEntry(ATTRIBUTES, "attribute1,attribute2"),
+                                     hasEntry(FROM_NETWORK, "network1,network2"),
+                                     hasEntry(CONNECTION_LIMIT, "20")));
     }
 }

--- a/broker-plugins/access-control/src/test/java/org/apache/qpid/server/security/access/config/ClientActionTest.java
+++ b/broker-plugins/access-control/src/test/java/org/apache/qpid/server/security/access/config/ClientActionTest.java
@@ -22,72 +22,123 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
 import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.security.Principal;
+import java.util.Collections;
+import java.util.Set;
 
+import javax.security.auth.Subject;
+
+import org.junit.Before;
 import org.junit.Test;
 
+import org.apache.qpid.server.connection.ConnectionPrincipal;
 import org.apache.qpid.server.security.access.firewall.FirewallRule;
+import org.apache.qpid.server.transport.AMQPConnection;
+import org.apache.qpid.server.virtualhost.QueueManagingVirtualHost;
 import org.apache.qpid.test.utils.UnitTestBase;
 
 public class ClientActionTest extends UnitTestBase
 {
-    private Action _action = mock(Action.class);
-    private AclAction _ruleAction = mock(AclAction.class);
-    private InetAddress _addressOfClient = mock(InetAddress.class);
+    private Action _action;
+    private AclAction _ruleAction;
+    private ClientAction _clientAction;
+    private Subject _subject;
+    private QueueManagingVirtualHost _addressSpace;
+    private AMQPConnection _connection;
 
-    private ClientAction _clientAction = new ClientAction(_action);
+    @Before
+    public void setUp()
+    {
+        final InetSocketAddress address = InetSocketAddress.createUnresolved("localhost", 5672);
+
+        _addressSpace = mock(QueueManagingVirtualHost.class);
+        _connection = mock(AMQPConnection.class);
+        when(_connection.getAddressSpace()).thenReturn(_addressSpace);
+
+        final ConnectionPrincipal connectionPrincipal = mock(ConnectionPrincipal.class);
+        when(connectionPrincipal.getConnection()).thenReturn(_connection);
+        when(_connection.getRemoteSocketAddress()).thenReturn(address);
+        when(_connection.getAuthorizedPrincipal()).thenReturn(connectionPrincipal);
+        final Set<? extends Principal> principals = Collections.singleton(connectionPrincipal);
+        _subject = new Subject(false, principals, Collections.emptySet(), Collections.emptySet());
+        _ruleAction = mock(AclAction.class);
+        when(_ruleAction.getDynamicRule()).thenReturn(subject -> true);
+        _action = mock(Action.class);
+        _clientAction = new ClientAction(_action);
+    }
 
     @Test
     public void testMatches_returnsTrueWhenActionsMatchAndNoFirewallRule()
     {
         when(_action.matches(any(Action.class))).thenReturn(true);
-        when(_ruleAction.getFirewallRule()).thenReturn(null);
+        when(_ruleAction.getDynamicRule()).thenReturn(null);
         when(_ruleAction.getAction()).thenReturn(mock(Action.class));
 
-        assertTrue(_clientAction.matches(_ruleAction, _addressOfClient));
+        assertTrue(_clientAction.matches(_ruleAction, _subject));
     }
 
     @Test
     public void testMatches_returnsFalseWhenActionsDontMatch()
     {
         FirewallRule firewallRule = mock(FirewallRule.class);
-        when(firewallRule.matches(_addressOfClient)).thenReturn(true);
+        when(firewallRule.matches(_subject)).thenReturn(true);
+        when(_ruleAction.getDynamicRule()).thenReturn(firewallRule);
 
         when(_action.matches(any(Action.class))).thenReturn(false);
-        when(_ruleAction.getFirewallRule()).thenReturn(firewallRule);
+        when(_ruleAction.getDynamicRule()).thenReturn(firewallRule);
         when(_ruleAction.getAction()).thenReturn(mock(Action.class));
 
-        assertFalse(_clientAction.matches(_ruleAction, _addressOfClient));
+        assertFalse(_clientAction.matches(_ruleAction, _subject));
     }
 
     @Test
     public void testMatches_returnsTrueWhenActionsAndFirewallRuleMatch()
     {
         FirewallRule firewallRule = mock(FirewallRule.class);
-        when(firewallRule.matches(_addressOfClient)).thenReturn(true);
+        when(firewallRule.matches(_subject)).thenReturn(true);
+        when(_ruleAction.getDynamicRule()).thenReturn(firewallRule);
 
         when(_action.matches(any(Action.class))).thenReturn(true);
-        when(_ruleAction.getFirewallRule()).thenReturn(firewallRule);
+        when(_ruleAction.getDynamicRule()).thenReturn(firewallRule);
         when(_ruleAction.getAction()).thenReturn(mock(Action.class));
 
-        assertTrue(_clientAction.matches(_ruleAction, _addressOfClient));
+        assertTrue(_clientAction.matches(_ruleAction, _subject));
     }
 
     @Test
     public void testMatches_ignoresFirewallRuleIfClientAddressIsNull()
     {
-        FirewallRule firewallRule = mock(FirewallRule.class);
+        FirewallRule firewallRule = new FirewallRule()
+        {
+            @Override
+            protected boolean matches(final InetAddress addressOfClient)
+            {
+                return false;
+            }
+        };
 
         when(_action.matches(any(Action.class))).thenReturn(true);
-        when(_ruleAction.getFirewallRule()).thenReturn(firewallRule);
+        when(_ruleAction.getDynamicRule()).thenReturn(firewallRule);
         when(_ruleAction.getAction()).thenReturn(mock(Action.class));
 
-        assertTrue(_clientAction.matches(_ruleAction, null));
-
-        verifyZeroInteractions(firewallRule);
+        assertTrue(_clientAction.matches(_ruleAction, _subject));
     }
 
+    @Test
+    public void testMatchesWhenConnectionLimitBreached()
+    {
+        final ObjectProperties properties = new ObjectProperties("foo");
+        final AclRulePredicates predicates = new AclRulePredicates();
+        predicates.parse(ObjectProperties.Property.CONNECTION_LIMIT.name(), "1");
+        final AclAction ruleAction = new AclAction(LegacyOperation.ACCESS, ObjectType.VIRTUALHOST, predicates);
+        final ClientAction clientAction = new ClientAction(LegacyOperation.ACCESS, ObjectType.VIRTUALHOST, properties);
+
+        when(_connection.getAuthenticatedPrincipalConnectionCount()).thenReturn(2);
+        boolean matches = clientAction.matches(ruleAction, _subject);
+        assertFalse(matches);
+    }
 }

--- a/broker-plugins/access-control/src/test/java/org/apache/qpid/server/security/access/config/DynamicRuleTest.java
+++ b/broker-plugins/access-control/src/test/java/org/apache/qpid/server/security/access/config/DynamicRuleTest.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.qpid.server.security.access.config;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.*;
+
+import javax.security.auth.Subject;
+
+import org.junit.Test;
+
+import org.apache.qpid.test.utils.UnitTestBase;
+
+public class DynamicRuleTest extends UnitTestBase
+{
+
+    @Test
+    public void subjectMatchesAllRules()
+    {
+        final Subject subject = new Subject();
+        final DynamicRule rule1 = s -> s.equals(subject);
+        final DynamicRule rule2 = s -> s.equals(subject);
+
+        final DynamicRule combined = rule1.and(rule2);
+
+        assertThat(combined.matches(subject), is(true));
+    }
+
+    @Test
+    public void subjectDoesNotMatchAllRules()
+    {
+        final Subject subject = new Subject();
+        final DynamicRule rule1 = s -> s.equals(subject);
+        final DynamicRule rule2 = s -> !s.equals(subject);
+
+        final DynamicRule combined = rule1.and(rule2);
+
+        assertThat(combined.matches(subject), is(false));
+    }
+}

--- a/broker-plugins/access-control/src/test/java/org/apache/qpid/server/security/access/config/RuleBasedAccessControlTest.java
+++ b/broker-plugins/access-control/src/test/java/org/apache/qpid/server/security/access/config/RuleBasedAccessControlTest.java
@@ -272,7 +272,7 @@ public class RuleBasedAccessControlTest extends UnitTestBase
                 ObjectProperties properties = new ObjectProperties(testVirtualHost);
                 accessControl.authorise(LegacyOperation.ACCESS, ObjectType.VIRTUALHOST, properties);
 
-                verify(mockRuleSet).check(subject, LegacyOperation.ACCESS, ObjectType.VIRTUALHOST, properties, inetAddress);
+                verify(mockRuleSet).check(subject, LegacyOperation.ACCESS, ObjectType.VIRTUALHOST, properties);
                 return null;
             }
         });
@@ -303,8 +303,7 @@ public class RuleBasedAccessControlTest extends UnitTestBase
                         subject,
                         LegacyOperation.ACCESS,
                         ObjectType.VIRTUALHOST,
-                        ObjectProperties.EMPTY,
-                        inetAddress)).thenThrow(new RuntimeException());
+                        ObjectProperties.EMPTY)).thenThrow(new RuntimeException());
 
                 RuleBasedAccessControl accessControl = new RuleBasedAccessControl(mockRuleSet,
                                                                                   BrokerModel.getInstance());

--- a/broker-plugins/access-control/src/test/java/org/apache/qpid/server/security/access/config/connection/ConnectionPrincipalFrequencyLimitRuleTest.java
+++ b/broker-plugins/access-control/src/test/java/org/apache/qpid/server/security/access/config/connection/ConnectionPrincipalFrequencyLimitRuleTest.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.qpid.server.security.access.config.connection;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+
+import javax.security.auth.Subject;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import org.apache.qpid.server.connection.ConnectionPrincipal;
+import org.apache.qpid.server.transport.AMQPConnection;
+import org.apache.qpid.test.utils.UnitTestBase;
+
+public class ConnectionPrincipalFrequencyLimitRuleTest extends UnitTestBase
+{
+
+    private AMQPConnection _connection;
+    private Subject _subject;
+
+    @Before
+    public void setUp()
+    {
+        _connection = mock(AMQPConnection.class);
+
+        final ConnectionPrincipal connectionPrincipal = mock(ConnectionPrincipal.class);
+        when(connectionPrincipal.getConnection()).thenReturn(_connection);
+        when(_connection.getAuthorizedPrincipal()).thenReturn(connectionPrincipal);
+        _subject = new Subject(false,
+                               Collections.singleton(connectionPrincipal),
+                               Collections.emptySet(),
+                               Collections.emptySet());
+    }
+
+    @Test
+    public void limitBreached()
+    {
+        when(_connection.getAuthenticatedPrincipalConnectionFrequency()).thenReturn(2);
+        final ConnectionPrincipalFrequencyLimitRule rule = new ConnectionPrincipalFrequencyLimitRule(1);
+
+        assertThat(rule.matches(_subject), is(false));
+    }
+
+    @Test
+    public void frequencyEqualsLimit()
+    {
+        when(_connection.getAuthenticatedPrincipalConnectionFrequency()).thenReturn(2);
+        final ConnectionPrincipalFrequencyLimitRule rule = new ConnectionPrincipalFrequencyLimitRule(2);
+
+        assertThat(rule.matches(_subject), is(true));
+    }
+
+    @Test
+    public void frequencyBelowLimit()
+    {
+        when(_connection.getAuthenticatedPrincipalConnectionFrequency()).thenReturn(1);
+        final ConnectionPrincipalFrequencyLimitRule rule = new ConnectionPrincipalFrequencyLimitRule(2);
+
+        assertThat(rule.matches(_subject), is(true));
+    }
+}

--- a/broker-plugins/access-control/src/test/java/org/apache/qpid/server/security/access/config/connection/ConnectionPrincipalLimitRuleTest.java
+++ b/broker-plugins/access-control/src/test/java/org/apache/qpid/server/security/access/config/connection/ConnectionPrincipalLimitRuleTest.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.qpid.server.security.access.config.connection;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+
+import javax.security.auth.Subject;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import org.apache.qpid.server.connection.ConnectionPrincipal;
+import org.apache.qpid.server.transport.AMQPConnection;
+import org.apache.qpid.test.utils.UnitTestBase;
+
+public class ConnectionPrincipalLimitRuleTest extends UnitTestBase
+{
+
+    private AMQPConnection _connection;
+    private Subject _subject;
+
+    @Before
+    public void setUp()
+    {
+        _connection = mock(AMQPConnection.class);
+
+        final ConnectionPrincipal connectionPrincipal = mock(ConnectionPrincipal.class);
+        when(connectionPrincipal.getConnection()).thenReturn(_connection);
+        when(_connection.getAuthorizedPrincipal()).thenReturn(connectionPrincipal);
+        _subject = new Subject(false,
+                               Collections.singleton(connectionPrincipal),
+                               Collections.emptySet(),
+                               Collections.emptySet());
+    }
+
+    @Test
+    public void limitBreached()
+    {
+        when(_connection.getAuthenticatedPrincipalConnectionCount()).thenReturn(2);
+        final ConnectionPrincipalLimitRule rule = new ConnectionPrincipalLimitRule(1);
+
+        assertThat(rule.matches(_subject), is(false));
+    }
+
+    @Test
+    public void frequencyEqualsLimit()
+    {
+        when(_connection.getAuthenticatedPrincipalConnectionCount()).thenReturn(2);
+        final ConnectionPrincipalLimitRule rule = new ConnectionPrincipalLimitRule(2);
+
+        assertThat(rule.matches(_subject), is(true));
+    }
+
+    @Test
+    public void frequencyBelowLimit()
+    {
+        when(_connection.getAuthenticatedPrincipalConnectionCount()).thenReturn(1);
+        final ConnectionPrincipalLimitRule rule = new ConnectionPrincipalLimitRule(2);
+
+        assertThat(rule.matches(_subject), is(true));
+    }
+}

--- a/broker-plugins/amqp-0-10-protocol/src/test/java/org/apache/qpid/server/protocol/v0_10/ServerSessionTest.java
+++ b/broker-plugins/amqp-0-10-protocol/src/test/java/org/apache/qpid/server/protocol/v0_10/ServerSessionTest.java
@@ -26,6 +26,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
 import java.util.List;
 
 import javax.security.auth.Subject;
@@ -40,6 +42,7 @@ import org.apache.qpid.server.configuration.updater.CurrentThreadTaskExecutor;
 import org.apache.qpid.server.configuration.updater.TaskExecutor;
 import org.apache.qpid.server.configuration.updater.TaskExecutorImpl;
 import org.apache.qpid.server.logging.EventLogger;
+import org.apache.qpid.server.model.AuthenticationProvider;
 import org.apache.qpid.server.model.Broker;
 import org.apache.qpid.server.model.BrokerModel;
 import org.apache.qpid.server.model.BrokerTestHelper;
@@ -54,6 +57,8 @@ import org.apache.qpid.server.protocol.v0_10.transport.ExecutionErrorCode;
 import org.apache.qpid.server.protocol.v0_10.transport.ExecutionException;
 import org.apache.qpid.server.protocol.v0_10.transport.MessageTransfer;
 import org.apache.qpid.server.protocol.v0_10.transport.Method;
+import org.apache.qpid.server.security.auth.AuthenticatedPrincipal;
+import org.apache.qpid.server.security.auth.UsernamePrincipal;
 import org.apache.qpid.test.utils.UnitTestBase;
 
 public class ServerSessionTest extends UnitTestBase
@@ -120,9 +125,13 @@ public class ServerSessionTest extends UnitTestBase
         when(modelConnection.getModel()).thenReturn(BrokerModel.getInstance());
         when(modelConnection.getPort()).thenReturn(port);
 
-        Subject subject = new Subject();
+        final AuthenticatedPrincipal principal =
+                new AuthenticatedPrincipal(new UsernamePrincipal(getTestName(), mock(AuthenticationProvider.class)));
+        final Subject subject =
+                new Subject(false, Collections.singleton(principal), Collections.emptySet(), Collections.emptySet());
         when(modelConnection.getSubject()).thenReturn(subject);
         when(modelConnection.getMaxMessageSize()).thenReturn(1024l);
+        when(modelConnection.getCreatedTime()).thenReturn(new Date());
         ServerConnection connection = new ServerConnection(1, broker, port, Transport.TCP, modelConnection);
         connection.setVirtualHost(_virtualHost);
 

--- a/doc/java-broker/src/docbkx/security/Java-Broker-Security-AccessControlProviders.xml
+++ b/doc/java-broker/src/docbkx/security/Java-Broker-Security-AccessControlProviders.xml
@@ -283,7 +283,7 @@
           <entry> <command>VIRTUALHOST</command> </entry>
           <entry> <para>A virtualhost</para> </entry>
           <entry><para>ALL, CREATE, UPDATE, DELETE, ACCESS, ACCESS_LOGS, INVOKE</para> </entry>
-          <entry><para>name</para> </entry>
+          <entry><para>name, connection_limit, connection_frequency_limit</para> </entry>
           <entry><para>No</para> </entry>
         </row>
         <row>
@@ -415,6 +415,36 @@
           </entry>
         </row>
         <row>
+          <entry><command>connection_limit</command></entry>
+          <entry>
+            <para>
+              A maximum number of connections the users belonging to the given identity can establish to the Virtual Host
+            </para>
+            <para>
+              Intended for use in ACCESS VIRTUALHOST rules to restrict the number of connections which can be made
+              by the messaging user.
+            </para>
+          </entry>
+        </row>
+        <row>
+          <entry><command>connection_frequency_limit</command></entry>
+          <entry>
+            <para>
+              A maximum number of connections the user belonging to the given identity can establish to the Virtual Host
+              within pre-defined period of time, which is 1 minute by default.
+            </para>
+            <para>
+              Intended for use in ACCESS VIRTUALHOST rules to restrict the frequency of connections which can be made
+              by the messaging user.
+            </para>
+            <para>If required, the frequency period can be changed using context variable
+              <emphasis>qpid.virtualhost.connectionFrequencyPeriodInMillis</emphasis>. As name suggests, its value needs
+              to be specified in milliseconds. Setting it to zero or negative value turns off the
+              <command>connection_frequency</command> evaluation.
+            </para>
+          </entry>
+        </row>
+        <row>
           <entry><command>virtualhost_name</command></entry>
           <entry>
             <para>
@@ -477,6 +507,28 @@
         </programlisting>
 
       </example>
+    </section>
+    <section role="h4" xml:id="Java-Broker-Security-AccessControlProviders-ResourceRestrictions">
+      <title>
+        Resource restrictions
+      </title>
+      <para>
+        The number of Virtual Host connections and frequency of connections can be restricted with
+        <emphasis>ACCESS</emphasis> rule.
+      </para>
+      <example>
+        <title>Restricting user connections to virtual host</title>
+        <programlisting><![CDATA[
+          ACL ALLOW-LOG guest ACCESS VIRTUALHOST connection_limit=1
+          ACL ALLOW-LOG messaging-users ACCESS VIRTUALHOST connection_frequency_limit=100
+          ...]]>
+        </programlisting>
+      </example>
+      <para>In the example above the maximum number of connections allowed to establish to the Virtual Host by user
+        <emphasis>guest</emphasis> is set to <emphasis>1</emphasis>. The maximum connection frequency for every user
+        belonging to the user group <emphasis>messaging-users</emphasis> is set to <emphasis>100</emphasis> (per minute,
+        by default).
+      </para>
     </section>
     <section role="h4" xml:id="Java-Broker-Security-AccessControlProviders-WorkedExample2">
       <title>


### PR DESCRIPTION
The suggested changes allow to set connection limit and connection frequency limit in ACL rule 'ACCESS VIRTUAL HOST'. The corresponding limits can be set in ACL as in examples below
`
ACL ALLOW-LOG guest ACCESS VIRTUALHOST connection_limit='20' 
ACL ALLOW-LOG alex ACCESS VIRTUALHOST connection_frequency_limit='100'
ACL ALLOW-LOG alice ACCESS VIRTUALHOST connection_frequency_limit='100' connection_limit='20' 

The pull request changes  ACL and broker core modules.
A  special `ConnectionPrincipalStatisticsRegistry` is introduced to collect the `AuthenticatedPrincipal` statistics for messaging connections on `AbstractVirtualHost`. The  new checks are implemented for ACL rule "ACCESS  VIRTUALHOST" having new limit parameters set to verify that a number and frequency of connections for the connection principal  do not exceed the limits.

Here is a summary of the changes in the pull request:

- Introduced interface DynamicRule  to allow implementation of ACL rule based on authenticated user specific properties
- FirewallRule is converted into an abstract class which implements DynamicRule
- added 2 new DynamicRule implementations for connection limit and connection frequency limit
- the  DynamicRule implementations are created in AclRulePredicates (based on parsed properties)
- authorization logic in RuleBasedAccessControl, RuleSet  and ClientAction is adjusted to invoke DynamicRules
- interface ConnectionPrincipalStatisticsRegistry is introduced to allow collection of statistics for AuthenticatedPrincipals of open messaging connections
- interface ConnectionPrincipalStatistics is introduced to hold statistics for AuthenticatedPrincipal for Connection (principal connection count and connections opened within the connection frequency period of time)
- Implementations ConnectionPrincipalStatisticsImpl and ConnectionPrincipalStatisticsRegistryImpl are added to collect AuthenticatedPrincipal statistics
- New methods was added into interface AMQPConnection expose principal statistics at the time when connection was opened
- Implementations for new methods in AMQPConnection are added into AbstractAMQPConnection
- AbstractVirtualHost#registerConnection was modified to call ConnectionPrincipalStatisticsRegistry#connectionOpened(AMQPConnection) to update the principal statistics on new connection open
- AbstractVirtualHost#deregisterConnection was modified to call ConnectionPrincipalStatisticsRegistry#connectionClosed(AMQPConnection) to update the principal statistics on connection close
- A new house keeping task `ConnectionPrincipalStatisticsCheckingTask` is now invoked to clean obsolete connection statistics in ConnectionPrincipalStatisticsRegistry for connections opened beyond connection frequency period 
- A new context variable is added into QueueManagingVirtualHost to set the  connection frequency period
- A broker documentation was updated to reflect the ACL changes
- A number of unit tests added to cover the changes

 