### PR TITLE
QPID-8473:[Broker-J]Added operational logs for sender links

### DIFF
--- a/broker-core/src/main/java/org/apache/qpid/server/exchange/AbstractExchange.java
+++ b/broker-core/src/main/java/org/apache/qpid/server/exchange/AbstractExchange.java
@@ -51,6 +51,7 @@ import org.apache.qpid.server.logging.EventLogger;
 import org.apache.qpid.server.logging.LogSubject;
 import org.apache.qpid.server.logging.messages.BindingMessages;
 import org.apache.qpid.server.logging.messages.ExchangeMessages;
+import org.apache.qpid.server.logging.messages.SenderMessages;
 import org.apache.qpid.server.logging.subjects.ExchangeLogSubject;
 import org.apache.qpid.server.message.InstanceProperties;
 import org.apache.qpid.server.message.MessageDestination;
@@ -1036,6 +1037,10 @@ public abstract class AbstractExchange<T extends AbstractExchange<T>>
         {
             _linkedSenders.put(sender, oldValue+1);
         }
+        if( link.TYPE_LINK.equals(link.getType()))
+        {
+            getEventLogger().message(SenderMessages.CREATE(link.getName(), link.getDestination()));
+        }
     }
 
     @Override
@@ -1045,6 +1050,10 @@ public abstract class AbstractExchange<T extends AbstractExchange<T>>
         if(oldValue != 1)
         {
             _linkedSenders.put(sender, oldValue-1);
+        }
+        if( link.TYPE_LINK.equals(link.getType()))
+        {
+            getEventLogger().message(SenderMessages.CLOSE(link.getName(), link.getDestination()));
         }
     }
 

--- a/broker-core/src/main/java/org/apache/qpid/server/logging/messages/SenderMessages.java
+++ b/broker-core/src/main/java/org/apache/qpid/server/logging/messages/SenderMessages.java
@@ -1,0 +1,203 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
+ *
+ */
+package org.apache.qpid.server.logging.messages;
+
+import static org.apache.qpid.server.logging.AbstractMessageLogger.DEFAULT_LOG_HIERARCHY_PREFIX;
+
+import java.text.MessageFormat;
+import java.util.Locale;
+import java.util.ResourceBundle;
+
+import org.slf4j.LoggerFactory;
+
+import org.apache.qpid.server.logging.LogMessage;
+
+/**
+ * DO NOT EDIT DIRECTLY, THIS FILE WAS GENERATED.
+ *
+ * Generated using GenerateLogMessages and LogMessages.vm
+ * This file is based on the content of Sender_logmessages.properties
+ *
+ * To regenerate, use Maven lifecycle generates-sources with -Dgenerate=true
+ */
+public class SenderMessages
+{
+    private static ResourceBundle _messages;
+    private static Locale _currentLocale;
+
+    static
+    {
+        Locale locale = Locale.US;
+        String localeSetting = System.getProperty("qpid.broker_locale");
+        if (localeSetting != null)
+        {
+            String[] localeParts = localeSetting.split("_");
+            String language = (localeParts.length > 0 ? localeParts[0] : "");
+            String country = (localeParts.length > 1 ? localeParts[1] : "");
+            String variant = "";
+            if (localeParts.length > 2)
+            {
+                variant = localeSetting.substring(language.length() + 1 + country.length() + 1);
+            }
+            locale = new Locale(language, country, variant);
+        }
+        _currentLocale = locale;
+    }
+
+    public static final String SENDER_LOG_HIERARCHY = DEFAULT_LOG_HIERARCHY_PREFIX + "sender";
+    public static final String CLOSE_LOG_HIERARCHY = DEFAULT_LOG_HIERARCHY_PREFIX + "sender.close";
+    public static final String CREATE_LOG_HIERARCHY = DEFAULT_LOG_HIERARCHY_PREFIX + "sender.create";
+
+    static
+    {
+        LoggerFactory.getLogger(SENDER_LOG_HIERARCHY);
+        LoggerFactory.getLogger(CLOSE_LOG_HIERARCHY);
+        LoggerFactory.getLogger(CREATE_LOG_HIERARCHY);
+
+        _messages = ResourceBundle.getBundle("org.apache.qpid.server.logging.messages.Sender_logmessages", _currentLocale);
+    }
+
+    /**
+     * Log a Sender message of the Format:
+     * <pre>SND-1002 : Close : {0} : {1}</pre>
+     * Optional values are contained in [square brackets] and are numbered
+     * sequentially in the method call.
+     *
+     */
+    public static LogMessage CLOSE(String param1, String param2)
+    {
+        String rawMessage = _messages.getString("CLOSE");
+
+        final Object[] messageArguments = {param1, param2};
+        // Create a new MessageFormat to ensure thread safety.
+        // Sharing a MessageFormat and using applyPattern is not thread safe
+        MessageFormat formatter = new MessageFormat(rawMessage, _currentLocale);
+
+        final String message = formatter.format(messageArguments);
+
+        return new LogMessage()
+        {
+            @Override
+            public String toString()
+            {
+                return message;
+            }
+
+            @Override
+            public String getLogHierarchy()
+            {
+                return CLOSE_LOG_HIERARCHY;
+            }
+
+            @Override
+            public boolean equals(final Object o)
+            {
+                if (this == o)
+                {
+                    return true;
+                }
+                if (o == null || getClass() != o.getClass())
+                {
+                    return false;
+                }
+
+                final LogMessage that = (LogMessage) o;
+
+                return getLogHierarchy().equals(that.getLogHierarchy()) && toString().equals(that.toString());
+
+            }
+
+            @Override
+            public int hashCode()
+            {
+                int result = toString().hashCode();
+                result = 31 * result + getLogHierarchy().hashCode();
+                return result;
+            }
+        };
+    }
+
+    /**
+     * Log a Sender message of the Format:
+     * <pre>SND-1001 : Create : {0} : {1}</pre>
+     * Optional values are contained in [square brackets] and are numbered
+     * sequentially in the method call.
+     *
+     */
+    public static LogMessage CREATE(String param1, String param2)
+    {
+        String rawMessage = _messages.getString("CREATE");
+
+        final Object[] messageArguments = {param1, param2};
+        // Create a new MessageFormat to ensure thread safety.
+        // Sharing a MessageFormat and using applyPattern is not thread safe
+        MessageFormat formatter = new MessageFormat(rawMessage, _currentLocale);
+
+        final String message = formatter.format(messageArguments);
+
+        return new LogMessage()
+        {
+            @Override
+            public String toString()
+            {
+                return message;
+            }
+
+            @Override
+            public String getLogHierarchy()
+            {
+                return CREATE_LOG_HIERARCHY;
+            }
+
+            @Override
+            public boolean equals(final Object o)
+            {
+                if (this == o)
+                {
+                    return true;
+                }
+                if (o == null || getClass() != o.getClass())
+                {
+                    return false;
+                }
+
+                final LogMessage that = (LogMessage) o;
+
+                return getLogHierarchy().equals(that.getLogHierarchy()) && toString().equals(that.toString());
+
+            }
+
+            @Override
+            public int hashCode()
+            {
+                int result = toString().hashCode();
+                result = 31 * result + getLogHierarchy().hashCode();
+                return result;
+            }
+        };
+    }
+
+
+    private SenderMessages()
+    {
+    }
+
+}

--- a/broker-core/src/main/java/org/apache/qpid/server/logging/messages/Sender_logmessages.properties
+++ b/broker-core/src/main/java/org/apache/qpid/server/logging/messages/Sender_logmessages.properties
@@ -1,0 +1,21 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+#
+CREATE = SND-1001 : Create : {0} : {1}
+CLOSE = SND-1002 : Close : {0} : {1}

--- a/broker-core/src/main/java/org/apache/qpid/server/model/PublishingLink.java
+++ b/broker-core/src/main/java/org/apache/qpid/server/model/PublishingLink.java
@@ -23,6 +23,7 @@ package org.apache.qpid.server.model;
 @ManagedAttributeValueType(isAbstract = true)
 public interface PublishingLink extends ManagedAttributeValue
 {
+    String TYPE_LINK = "link";
     String getName();
     String getType();
     String getDestination();


### PR DESCRIPTION
Added operational logs for sender links attaching to queue and exchange. 
This is implemented specifically for clients using AMQP 1.0 protocol only.