### PR TITLE
QPID-8489 - Connection thread looping

### DIFF
--- a/broker-core/src/main/java/org/apache/qpid/server/transport/AbstractAMQPConnection.java
+++ b/broker-core/src/main/java/org/apache/qpid/server/transport/AbstractAMQPConnection.java
@@ -212,8 +212,8 @@ public abstract class AbstractAMQPConnection<C extends AbstractAMQPConnection<C,
     protected void onOpen()
     {
         super.onOpen();
-        long maxAuthDelay = _port.getContextValue(Long.class, Port.CONNECTION_MAXIMUM_AUTHENTICATION_DELAY);
-        SlowConnectionOpenTicker slowConnectionOpenTicker = new SlowConnectionOpenTicker(maxAuthDelay);
+        final long maxAuthDelay = _port.getContextValue(Long.class, Port.CONNECTION_MAXIMUM_AUTHENTICATION_DELAY);
+        final SlowConnectionOpenTicker slowConnectionOpenTicker = new SlowConnectionOpenTicker(maxAuthDelay);
         _aggregateTicker.addTicker(slowConnectionOpenTicker);
         _lastReadTime = _lastWriteTime = _lastMessageInboundTime = _lastMessageOutboundTime = getCreatedTime().getTime();
         _maxUncommittedInMemorySize = getContextValue(Long.class, Connection.MAX_UNCOMMITTED_IN_MEMORY_SIZE);


### PR DESCRIPTION
The main problem with connection loss is that it's difficult to detect invalidity of the connection programmatically based on state of java.nio.channels.Selector / java.nio.channels.SelectionKey / java.nio.channels.ServerSocketChannel. One of the clues allowing to suspect that connection is lost are the times of last read and last write of _protocolEngine variable, as they don't change and remain same during loop iterations.
I suggest to implement new Ticker implementation which will detect lost connections by checking whether actual read / write operation were performed or not and if they weren't, it will send a heartbeat signal to the lost connection. That will invalidate it (broken pipe) and end the looping.