### PR TITLE
QPID-8490 - Java broker crashes on sending non-LDH virtual hostname f…

### DIFF
--- a/broker-core/src/main/java/org/apache/qpid/server/transport/NonBlockingConnectionTLSDelegate.java
+++ b/broker-core/src/main/java/org/apache/qpid/server/transport/NonBlockingConnectionTLSDelegate.java
@@ -102,7 +102,7 @@ public class NonBlockingConnectionTLSDelegate implements NonBlockingConnectionDe
                     {
                         _parent.setSelectedHost(hostName);
                         SSLParameters sslParameters = _sslEngine.getSSLParameters();
-                        sslParameters.setServerNames(Collections.singletonList(new SNIHostName(hostName)));
+                        sslParameters.setServerNames(Collections.singletonList(SSLUtil.createSNIHostName(hostName)));
                         _sslEngine.setSSLParameters(sslParameters);
                     }
                     _hostChecked = true;

--- a/broker-core/src/main/java/org/apache/qpid/server/transport/network/security/ssl/SSLUtil.java
+++ b/broker-core/src/main/java/org/apache/qpid/server/transport/network/security/ssl/SSLUtil.java
@@ -75,6 +75,7 @@ import javax.net.ssl.StandardConstants;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
 
+import org.apache.qpid.server.util.ConnectionScopedRuntimeException;
 import org.apache.qpid.server.util.ServerScopedRuntimeException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -897,7 +898,7 @@ public class SSLUtil
 
                                     if (code == StandardConstants.SNI_HOST_NAME)
                                     {
-                                        return new SNIHostName(encoded).getAsciiName();
+                                        return createSNIHostName(encoded).getAsciiName();
                                     }
                                     extensionDataRemaining -= serverNameLength + 3;
                                 }
@@ -1063,6 +1064,30 @@ public class SSLUtil
             }
         }
         return certificates;
+    }
+
+    public static SNIHostName createSNIHostName(String hostName)
+    {
+        try
+        {
+            return new SNIHostName(hostName);
+        }
+        catch (IllegalArgumentException e)
+        {
+            throw new ConnectionScopedRuntimeException("Failed to create SNIHostName from string '" + hostName + "'", e);
+        }
+    }
+
+    public static SNIHostName createSNIHostName(byte[] hostName)
+    {
+        try
+        {
+            return new SNIHostName(hostName);
+        }
+        catch (IllegalArgumentException e)
+        {
+            throw new ConnectionScopedRuntimeException("Failed to create SNIHostName from byte array '" + new String(hostName) + "'", e);
+        }
     }
 
     public interface KeyCertPair

--- a/broker-core/src/test/java/org/apache/qpid/server/transport/SNITest.java
+++ b/broker-core/src/test/java/org/apache/qpid/server/transport/SNITest.java
@@ -42,6 +42,7 @@ import javax.net.ssl.X509TrustManager;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.qpid.server.util.ConnectionScopedRuntimeException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -156,6 +157,12 @@ public class SNITest extends UnitTestBase
         performTest(false, "fooinvalid", "foo", _fooInvalid);
     }
 
+    @Test(expected = ConnectionScopedRuntimeException.class)
+    public void testInvalidHostname() throws Exception
+    {
+        performTest(false, "fooinvalid", "_foo", _fooInvalid);
+    }
+
 
     private void performTest(final boolean useMatching,
                              final String defaultAlias,
@@ -194,7 +201,7 @@ public class SNITest extends UnitTestBase
                 SSLParameters parameters = socket.getSSLParameters();
                 if (sniHostName != null)
                 {
-                    parameters.setServerNames(Collections.singletonList(new SNIHostName(sniHostName)));
+                    parameters.setServerNames(Collections.singletonList(SSLUtil.createSNIHostName(sniHostName)));
                 }
                 socket.setSSLParameters(parameters);
                 InetSocketAddress address = new InetSocketAddress("localhost", _boundPort);


### PR DESCRIPTION
Wrapped SNIHostName creation in utility method, handling IllegalArgumentException and rethrowing it as ConnectionScopedRuntimeException.