### PR TITLE
QPID:8525:[Broker-J]Fixed child deletion issue in group providers

### DIFF
--- a/broker-core/src/main/java/org/apache/qpid/server/model/adapter/FileBasedGroupProviderImpl.java
+++ b/broker-core/src/main/java/org/apache/qpid/server/model/adapter/FileBasedGroupProviderImpl.java
@@ -205,17 +205,22 @@ public class FileBasedGroupProviderImpl
             {
                 throw new IllegalConfigurationException(String.format("Group provider '%s' is not activated. Cannot create a group.", getName()));
             }
+            Set<String> availableGroups = _groupDatabase.getAllGroups();
+            if(!availableGroups.contains(groupName))
+            {
+                _groupDatabase.createGroup(groupName);
 
-            _groupDatabase.createGroup(groupName);
-
-            Map<String,Object> attrMap = new HashMap<String, Object>();
-            UUID id = UUID.randomUUID();
-            attrMap.put(ConfiguredObject.ID, id);
-            attrMap.put(ConfiguredObject.NAME, groupName);
-            GroupAdapter groupAdapter = new GroupAdapter(attrMap);
-            groupAdapter.create();
-            return Futures.immediateFuture((C) groupAdapter);
-
+                Map<String, Object> attrMap = new HashMap<String, Object>();
+                UUID id = UUID.randomUUID();
+                attrMap.put(ConfiguredObject.ID, id);
+                attrMap.put(ConfiguredObject.NAME, groupName);
+                GroupAdapter groupAdapter = new GroupAdapter(attrMap);
+                groupAdapter.create();
+                return Futures.immediateFuture((C) groupAdapter);
+            }
+            else{
+                throw new IllegalConfigurationException(String.format("Group with name '%s' already exists", groupName));
+            }
         }
         else
         {
@@ -359,16 +364,21 @@ public class FileBasedGroupProviderImpl
             if (childClass == GroupMember.class)
             {
                 String memberName = (String) attributes.get(GroupMember.NAME);
-
-                _groupDatabase.addUserToGroup(memberName, getName());
-                UUID id = UUID.randomUUID();
-                Map<String,Object> attrMap = new HashMap<String, Object>();
-                attrMap.put(GroupMember.ID,id);
-                attrMap.put(GroupMember.NAME, memberName);
-                GroupMemberAdapter groupMemberAdapter = new GroupMemberAdapter(attrMap);
-                groupMemberAdapter.create();
-                return Futures.immediateFuture((C) groupMemberAdapter);
-
+                Set<String> users = _groupDatabase.getUsersInGroup(getName());
+                if(!users.contains(memberName))
+                {
+                    _groupDatabase.addUserToGroup(memberName, getName());
+                    UUID id = UUID.randomUUID();
+                    Map<String, Object> attrMap = new HashMap<String, Object>();
+                    attrMap.put(GroupMember.ID, id);
+                    attrMap.put(GroupMember.NAME, memberName);
+                    GroupMemberAdapter groupMemberAdapter = new GroupMemberAdapter(attrMap);
+                    groupMemberAdapter.create();
+                    return Futures.immediateFuture((C) groupMemberAdapter);
+                }
+                else{
+                    throw new IllegalConfigurationException(String.format("Group member with name'%s' already exists", memberName));
+                }
             }
             else
             {


### PR DESCRIPTION
Any duplicate creation of a group and a group member resulted in deletion of such child objects and takes effect on subsequent restart.
 Fixed the issue and added appropriate exception