### PR TITLE
Qpid 8546 implement slow consumers fix

### DIFF
--- a/bdbstore/src/main/java/org/apache/qpid/server/store/berkeleydb/EnvironmentFacade.java
+++ b/bdbstore/src/main/java/org/apache/qpid/server/store/berkeleydb/EnvironmentFacade.java
@@ -67,7 +67,7 @@ public interface EnvironmentFacade
 
     Transaction beginTransaction(TransactionConfig transactionConfig);
 
-    void commit(Transaction tx, boolean sync);
+    void commit(Transaction tx);
     <X> ListenableFuture<X> commitAsync(Transaction tx, X val);
 
     RuntimeException handleDatabaseException(String contextMessage, RuntimeException e);
@@ -98,4 +98,6 @@ public interface EnvironmentFacade
     Map<String,Object> getDatabaseStatistics(String database, boolean reset);
 
     void deleteDatabase(String databaseName);
+
+    void commitNoSync(final Transaction tx);
 }

--- a/bdbstore/src/main/java/org/apache/qpid/server/store/berkeleydb/StandardEnvironmentFacade.java
+++ b/bdbstore/src/main/java/org/apache/qpid/server/store/berkeleydb/StandardEnvironmentFacade.java
@@ -166,7 +166,12 @@ public class StandardEnvironmentFacade implements EnvironmentFacade
     }
 
     @Override
-    public void commit(com.sleepycat.je.Transaction tx, boolean syncCommit)
+    public void commit(Transaction tx)
+    {
+        commitInternal(tx, true);
+    }
+
+    private void commitInternal(final Transaction tx, final boolean syncCommit)
     {
         try
         {
@@ -181,6 +186,12 @@ public class StandardEnvironmentFacade implements EnvironmentFacade
             throw handleDatabaseException("Got DatabaseException on commit", de);
         }
         _committer.commit(tx, syncCommit);
+    }
+
+    @Override
+    public void commitNoSync(final Transaction tx)
+    {
+        commitInternal(tx, false);
     }
 
     @Override

--- a/bdbstore/src/test/java/org/apache/qpid/server/store/berkeleydb/BDBMessageStoreTest.java
+++ b/bdbstore/src/test/java/org/apache/qpid/server/store/berkeleydb/BDBMessageStoreTest.java
@@ -116,7 +116,7 @@ public class BDBMessageStoreTest extends MessageStoreTestCase
         StoredMessage<MessageMetaData> storedMessage_0_8 = createAndStoreSingleChunkMessage_0_8(bdbStore);
         long messageid_0_8 = storedMessage_0_8.getMessageNumber();
 
-        bdbStore.removeMessage(messageid_0_8, true);
+        bdbStore.removeMessage(messageid_0_8);
 
         //verify the removal using the BDB store implementation methods directly
         try


### PR DESCRIPTION
Consumer is slow on a BDB HA environment, due to synchronous execution of remove messages. Made it asynchronous by adding a new context variable to pass the transaction sync durability.