### PR TITLE
QPID-8584: [Broker-J] Compile warning unknown enum constant com.google.j2objc.annotations.ReflectionSupport.Level.FULL

### DIFF
--- a/apache-qpid-broker-j/src/main/assembly/bin.xml
+++ b/apache-qpid-broker-j/src/main/assembly/bin.xml
@@ -54,6 +54,9 @@
     <dependencySet>
       <outputDirectory>/lib</outputDirectory>
       <useProjectArtifact>false</useProjectArtifact>
+      <excludes>
+        <exclude>com.google.j2objc:j2objc-annotations</exclude>
+      </excludes>
     </dependencySet>
   </dependencySets>
 </assembly>

--- a/pom.xml
+++ b/pom.xml
@@ -533,10 +533,6 @@
         <version>${guava-version}</version>
         <exclusions>
           <exclusion>
-            <groupId>com.google.j2objc</groupId>
-            <artifactId>j2objc-annotations</artifactId>
-          </exclusion>
-          <exclusion>
             <groupId>com.google.errorprone</groupId>
             <artifactId>error_prone_annotations</artifactId>
           </exclusion>


### PR DESCRIPTION
This PR addresses [QPID-8584](https://issues.apache.org/jira/browse/QPID-8584), removing compilation warning "unknown enum constant com.google.j2objc.annotations.ReflectionSupport.Level.FULL"