### PR TITLE
QPID-8586: [Broker-J] Nashorn script engine dependency for java 11/17 compatibility

### DIFF
--- a/perftests/pom.xml
+++ b/perftests/pom.xml
@@ -187,6 +187,7 @@
       </plugin>
     </plugins>
   </build>
+
   <profiles>
     <profile>
       <id>addJms11IfNecessary</id>
@@ -413,6 +414,19 @@
           <groupId>org.glassfish.jaxb</groupId>
           <artifactId>jaxb-runtime</artifactId>
           <scope>runtime</scope>
+        </dependency>
+      </dependencies>
+    </profile>
+    <profile>
+      <id>nashorn</id>
+      <activation>
+        <jdk>[15,)</jdk>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>org.openjdk.nashorn</groupId>
+          <artifactId>nashorn-core</artifactId>
+          <scope>test</scope>
         </dependency>
       </dependencies>
     </profile>

--- a/pom.xml
+++ b/pom.xml
@@ -138,6 +138,7 @@
     <qpid-jms-client-version>0.61.0</qpid-jms-client-version>
     <qpid-jms-client-amqp-0-x-version>6.3.4</qpid-jms-client-amqp-0-x-version>
     <jaxb-api-version>2.3.1</jaxb-api-version>
+    <nashorn-version>15.3</nashorn-version>
 
     <exec-maven-plugin-version>1.6.0</exec-maven-plugin-version>
     <javacc-maven-plugin-version>2.6</javacc-maven-plugin-version>
@@ -673,6 +674,12 @@
         <groupId>org.mockito</groupId>
         <artifactId>mockito-core</artifactId>
         <version>${mockito-version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.openjdk.nashorn</groupId>
+        <artifactId>nashorn-core</artifactId>
+        <version>${nashorn-version}</version>
         <scope>test</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
This PR addresses [QPID-8586](https://issues.apache.org/jira/browse/QPID-8586), adding nashorn dependency to perftests module to make it compatible with java 17