### PR TITLE
QPID-8592: [Broker-J] Pass context value from parent query into the subquery

### DIFF
--- a/broker-plugins/broker-query-engine/pom.xml
+++ b/broker-plugins/broker-query-engine/pom.xml
@@ -93,7 +93,6 @@
       <plugin>
         <groupId>com.helger.maven</groupId>
         <artifactId>ph-javacc-maven-plugin</artifactId>
-        <version>4.1.4</version>
         <executions>
           <execution>
             <id>expression-parser-generated</id>

--- a/broker-plugins/broker-query-engine/src/main/grammar/ExpressionParser.jj
+++ b/broker-plugins/broker-query-engine/src/main/grammar/ExpressionParser.jj
@@ -587,14 +587,14 @@ ExpressionNode<T, R> comparisonExpression() :
     left = (ExpressionNode<T, R>) ComparisonExpressionFactory.inExpression(left, (SelectExpression) right);
 }
         |
-        LOOKAHEAD(3) <NOT> <IN> <LBRACKET> right = orExpression() { list = new ArrayList<>(); list.add( right ); }
+        LOOKAHEAD(6) <NOT> <IN> <LBRACKET> right = orExpression() { list = new ArrayList<>(); list.add( right ); }
         ( <COMMA> right = orExpression() { list.add( right ); } )* <RBRACKET>
         {
             stringBuilder.append(")");
             left = (ExpressionNode<T, R>) LogicExpressionFactory.negate(LogicExpressionFactory.toFunction(ComparisonExpressionFactory.inExpression(left, list)));
         }
         |
-        LOOKAHEAD(3) <NOT> <IN> <LBRACKET> right = select()  <RBRACKET>
+        LOOKAHEAD(6) <NOT> <IN> <LBRACKET> right = select()  <RBRACKET>
         {
             stringBuilder.append(")");
             left = (ExpressionNode<T, R>) LogicExpressionFactory.negate(LogicExpressionFactory.toFunction(ComparisonExpressionFactory.inExpression(left, (SelectExpression) right)));
@@ -1001,9 +1001,9 @@ ExpressionNode<T, R> functionPosition() :
 {
     t = <POSITION> { builder.append(token.image); } <LBRACKET> { builder.append("("); } ( expr = addExpression()
     { builder.append(expr.getAlias()); args.add(expr); } )?
-    ( LOOKAHEAD(2) ( <IN> { builder.append(token.image); } | <COMMA> { builder.append(token.image); } ) expr = addExpression()
+    ( LOOKAHEAD(2) ( <IN> { builder.append(" " + token.image + " "); } | <COMMA> { builder.append(token.image); } ) expr = addExpression()
     { builder.append(expr.getAlias()); args.add(expr); } ) ?
-    ( <COMMA> expr = addExpression() { builder.append(expr.getAlias()); args.add(expr); } )*
+    ( <COMMA> { builder.append(","); } expr = addExpression() { builder.append(expr.getAlias()); args.add(expr); } )*
     <RBRACKET> { builder.append(")"); }
     {
         String functionName = t.image;

--- a/broker-plugins/broker-query-engine/src/main/java/org/apache/qpid/server/query/engine/parsing/query/FromExpression.java
+++ b/broker-plugins/broker-query-engine/src/main/java/org/apache/qpid/server/query/engine/parsing/query/FromExpression.java
@@ -37,6 +37,7 @@ import org.apache.qpid.server.model.Binding;
 import org.apache.qpid.server.model.Broker;
 import org.apache.qpid.server.model.ConfiguredObject;
 import org.apache.qpid.server.model.Model;
+import org.apache.qpid.server.model.Session;
 import org.apache.qpid.server.query.engine.exception.Errors;
 import org.apache.qpid.server.query.engine.exception.QueryParsingException;
 import org.apache.qpid.server.query.engine.model.Domain;
@@ -50,6 +51,7 @@ import org.apache.qpid.server.query.engine.retriever.ConfiguredObjectRetriever;
 import org.apache.qpid.server.query.engine.retriever.ConnectionLimitRuleRetriever;
 import org.apache.qpid.server.query.engine.retriever.DomainRetriever;
 import org.apache.qpid.server.query.engine.retriever.EntityRetriever;
+import org.apache.qpid.server.query.engine.retriever.SessionRetriever;
 import org.apache.qpid.server.security.access.plugins.AclRule;
 import org.apache.qpid.server.user.connection.limits.plugins.ConnectionLimitRule;
 
@@ -95,6 +97,11 @@ public class FromExpression<T, R extends Stream<?>, C extends ConfiguredObject<?
     private final EntityRetriever<C> _domainRetriever = new DomainRetriever<>();
 
     /**
+     * Retrieves data from Session entities
+     */
+    private final EntityRetriever<C> _sessionRetriever = new SessionRetriever<>();
+
+    /**
      * Additional domains allowed to be queried
      */
     private final Map<Class<?>, EntityRetriever<C>> _allowedClasses = ImmutableMap.<Class<?>, EntityRetriever<C>> builder()
@@ -103,6 +110,7 @@ public class FromExpression<T, R extends Stream<?>, C extends ConfiguredObject<?
         .put(Certificate.class, _certificateRetriever)
         .put(ConnectionLimitRule.class, _connectionLimitRuleRetriever)
         .put(Domain.class, _domainRetriever)
+        .put(Session.class, _sessionRetriever)
         .build();
 
     /**

--- a/broker-plugins/broker-query-engine/src/main/java/org/apache/qpid/server/query/engine/retriever/AclRuleRetriever.java
+++ b/broker-plugins/broker-query-engine/src/main/java/org/apache/qpid/server/query/engine/retriever/AclRuleRetriever.java
@@ -20,12 +20,12 @@
  */
 package org.apache.qpid.server.query.engine.retriever;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -62,14 +62,18 @@ public class AclRuleRetriever<C extends ConfiguredObject<?>> extends ConfiguredO
     /**
      * List of entity field names
      */
-    private final List<String> _fieldNames = Arrays.asList(
-        "identity", "attributes", "objectType", "operation", "outcome"
-    );
+    private final List<String> _fieldNames = new ImmutableList.Builder<String>()
+        .add("identity")
+        .add("attributes")
+        .add("objectType")
+        .add("operation")
+        .add("outcome")
+        .build();
 
     /**
      * Mapping function for a Rule
      */
-    private final Function<Rule, Map<String, Object>> _ruleMapping = rule -> ImmutableMap.<String, Object> builder()
+    private final Function<Rule, Map<String, Object>> _ruleMapping = rule -> ImmutableMap.<String, Object>builder()
         .put(_fieldNames.get(0), rule.getIdentity())
         .put(_fieldNames.get(1), rule.getAttributes())
         .put(_fieldNames.get(2), rule.getObjectType())

--- a/broker-plugins/broker-query-engine/src/main/java/org/apache/qpid/server/query/engine/retriever/BindingRetriever.java
+++ b/broker-plugins/broker-query-engine/src/main/java/org/apache/qpid/server/query/engine/retriever/BindingRetriever.java
@@ -20,12 +20,12 @@
  */
 package org.apache.qpid.server.query.engine.retriever;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.function.BiFunction;
 import java.util.stream.Stream;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
 import org.apache.qpid.server.model.Binding;
@@ -50,15 +50,20 @@ public class BindingRetriever<C extends ConfiguredObject<?>> extends ConfiguredO
     /**
      * List of entity field names
      */
-    private final List<String> _fieldNames = Arrays.asList(
-        "exchange", "bindingKey", "name", "type", "arguments", "destination"
-    );
+    private final List<String> _fieldNames = new ImmutableList.Builder<String>()
+        .add("exchange")
+        .add("bindingKey")
+        .add("name")
+        .add("type")
+        .add("arguments")
+        .add("destination")
+        .build();
 
     /**
      * Mapping function for a Binding
      */
     private final BiFunction<ConfiguredObject<?>, Binding, Map<String, Object>> _bindingMapping =
-        (ConfiguredObject<?> parent, Binding binding) ->  ImmutableMap.<String, Object> builder()
+        (ConfiguredObject<?> parent, Binding binding) ->  ImmutableMap.<String, Object>builder()
             .put(_fieldNames.get(0), parent.getName())
             .put(_fieldNames.get(1), binding.getBindingKey())
             .put(_fieldNames.get(2), binding.getName())

--- a/broker-plugins/broker-query-engine/src/main/java/org/apache/qpid/server/query/engine/retriever/CertificateRetriever.java
+++ b/broker-plugins/broker-query-engine/src/main/java/org/apache/qpid/server/query/engine/retriever/CertificateRetriever.java
@@ -21,12 +21,12 @@
 package org.apache.qpid.server.query.engine.retriever;
 
 import java.math.BigInteger;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.function.BiFunction;
 import java.util.stream.Stream;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
 import org.apache.qpid.server.model.ConfiguredObject;
@@ -58,16 +58,25 @@ public class CertificateRetriever<C extends ConfiguredObject<?>> extends Configu
     /**
      * List of entity field names
      */
-    private final List<String> _fieldNames = Arrays.asList(
-        "store", "alias", "issuerName", "serialNumber", "hexSerialNumber", "signatureAlgorithm", "subjectAltNames",
-        "subjectName", "validFrom", "validUntil", "version"
-    );
+    private final List<String> _fieldNames = new ImmutableList.Builder<String>()
+        .add("store")
+        .add("alias")
+        .add("issuerName")
+        .add("serialNumber")
+        .add("hexSerialNumber")
+        .add("signatureAlgorithm")
+        .add("subjectAltNames")
+        .add("subjectName")
+        .add("validFrom")
+        .add("validUntil")
+        .add("version")
+        .build();
 
     /**
      * Mapping function for a CertificateDetails
      */
     private final BiFunction<ConfiguredObject<?>, CertificateDetails, Map<String, Object>> certificateMapping =
-        (ConfiguredObject<?> parent, CertificateDetails certificate) -> ImmutableMap.<String, Object> builder()
+        (ConfiguredObject<?> parent, CertificateDetails certificate) -> ImmutableMap.<String, Object>builder()
             .put(_fieldNames.get(0), parent.getName())
             .put(_fieldNames.get(1), certificate.getAlias())
             .put(_fieldNames.get(2), certificate.getIssuerName())

--- a/broker-plugins/broker-query-engine/src/main/java/org/apache/qpid/server/query/engine/retriever/ConnectionLimitRuleRetriever.java
+++ b/broker-plugins/broker-query-engine/src/main/java/org/apache/qpid/server/query/engine/retriever/ConnectionLimitRuleRetriever.java
@@ -20,12 +20,12 @@
  */
 package org.apache.qpid.server.query.engine.retriever;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
 import org.apache.qpid.server.model.BrokerConnectionLimitProvider;
@@ -53,14 +53,19 @@ public class ConnectionLimitRuleRetriever<C extends ConfiguredObject<?>> extends
     /**
      * List of entity field names
      */
-    private final List<String> _fieldNames = Arrays.asList(
-        "blocked", "countLimit", "frequencyLimit", "frequencyPeriod", "identity", "port"
-    );
+    private final List<String> _fieldNames = new ImmutableList.Builder<String>()
+        .add("blocked")
+        .add("countLimit")
+        .add("frequencyLimit")
+        .add("frequencyPeriod")
+        .add("identity")
+        .add("port")
+        .build();
 
     /**
      * Mapping function for a ConnectionLimitRule
      */
-    private final Function<ConnectionLimitRule, Map<String, Object>> _connectionLimitRuleMapping = rule -> ImmutableMap.<String, Object> builder()
+    private final Function<ConnectionLimitRule, Map<String, Object>> _connectionLimitRuleMapping = rule -> ImmutableMap.<String, Object>builder()
         .put(_fieldNames.get(0), rule.getBlocked())
         .put(_fieldNames.get(1), rule.getCountLimit())
         .put(_fieldNames.get(2), rule.getFrequencyLimit())

--- a/broker-plugins/broker-query-engine/src/main/java/org/apache/qpid/server/query/engine/retriever/SessionRetriever.java
+++ b/broker-plugins/broker-query-engine/src/main/java/org/apache/qpid/server/query/engine/retriever/SessionRetriever.java
@@ -1,0 +1,127 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package org.apache.qpid.server.query.engine.retriever;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiFunction;
+import java.util.stream.Stream;
+
+import com.google.common.collect.ImmutableList;
+
+import org.apache.qpid.server.model.ConfiguredObject;
+import org.apache.qpid.server.model.Connection;
+import org.apache.qpid.server.model.Session;
+
+/**
+ * Retrieves Session entities
+ *
+ * @param <C> Descendant of ConfiguredObject
+ */
+// sonar complains about underscores in variable names
+@SuppressWarnings("java:S116")
+public class SessionRetriever<C extends ConfiguredObject<?>> extends ConfiguredObjectRetriever<C> implements EntityRetriever<C>
+{
+    /**
+     * Target type
+     */
+    @SuppressWarnings({"java:S1170", "rawtypes", "RedundantCast", "unchecked"})
+    private final Class<C> _type = (Class<C>) (Class<? extends ConfiguredObject>) Connection.class;
+
+    /**
+     * List of entity field names
+     */
+    private final List<String> _fieldNames = new ImmutableList.Builder<String>()
+        .add("connectionId")
+        .add("id")
+        .add("name")
+        .add("description")
+        .add("type")
+        .add("desiredState")
+        .add("state")
+        .add("durable")
+        .add("lifetimePolicy")
+        .add("channelId")
+        .add("lastOpenedTime")
+        .add("producerFlowBlocked")
+        .add("lastUpdatedTime")
+        .add("lastUpdatedBy")
+        .add("createdBy")
+        .add("createdTime")
+        .add("statistics")
+        .build();
+
+    /**
+     * Mapping function for a Session
+     */
+    private final BiFunction<ConfiguredObject<?>, Session<?>, Map<String, Object>> _sessionMapping =
+        (ConfiguredObject<?> parent, Session<?> session) ->
+        {
+            final Map<String, Object> result = new LinkedHashMap<>();
+            result.put(_fieldNames.get(0), parent.getId());
+            result.put(_fieldNames.get(1), session.getId());
+            result.put(_fieldNames.get(2), session.getName());
+            result.put(_fieldNames.get(3), session.getDescription());
+            result.put(_fieldNames.get(4), session.getType());
+            result.put(_fieldNames.get(5), session.getDesiredState());
+            result.put(_fieldNames.get(6), session.getState());
+            result.put(_fieldNames.get(7), session.isDurable());
+            result.put(_fieldNames.get(8), session.getLifetimePolicy());
+            result.put(_fieldNames.get(9), session.getChannelId());
+            result.put(_fieldNames.get(10), session.getLastOpenedTime());
+            result.put(_fieldNames.get(11), session.isProducerFlowBlocked());
+            result.put(_fieldNames.get(12), session.getLastUpdatedTime());
+            result.put(_fieldNames.get(13), session.getLastUpdatedBy());
+            result.put(_fieldNames.get(14), session.getCreatedBy());
+            result.put(_fieldNames.get(15), session.getCreatedTime());
+            result.put(_fieldNames.get(16), session.getStatistics());
+            return result;
+        };
+
+    /**
+     * Returns stream of Session entities
+     *
+     * @param broker Broker instance
+     *
+     * @return Stream of entities
+     */
+    @Override()
+    public Stream<Map<String, ?>> retrieve(final C broker)
+    {
+        final Stream<Connection<?>> stream = retrieve(broker, _type).map(connection -> ((Connection<?>) connection));
+        return stream.flatMap(connection -> connection.getSessions().stream()
+            .map(session -> _sessionMapping.apply(connection, session)));
+    }
+
+    /**
+     * Returns list of entity field names
+     *
+     * @return List of field names
+     */
+    @Override()
+    @SuppressWarnings("findbugs:EI_EXPOSE_REP")
+    // List of field names already is an immutable collection
+    public List<String> getFieldNames()
+    {
+        return _fieldNames;
+    }
+}

--- a/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/broker/BrokerDigestQueryTest.java
+++ b/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/broker/BrokerDigestQueryTest.java
@@ -30,6 +30,9 @@ import org.junit.Test;
 import org.apache.qpid.server.query.engine.TestBroker;
 import org.apache.qpid.server.query.engine.evaluator.QueryEvaluator;
 
+/**
+ * Tests designed to verify the broker digests retrieval
+ */
 public class BrokerDigestQueryTest
 {
     private final QueryEvaluator _queryEvaluator = new QueryEvaluator(TestBroker.createBroker());
@@ -37,22 +40,66 @@ public class BrokerDigestQueryTest
     @Test()
     public void selectBrokerDigest()
     {
-        String query = "select "
-                       + "name as label, "
-                       + "null as objectsState, "
-                       + "'UNAVAILABLE' as diskUsageState, "
-                       + "'UNAVAILABLE' as memoryUsageState, "
-                       + "'UNAVAILABLE' as cpuUsageState, "
-                       + "(select count(*) from connection) as connectionCount, "
-                       + "(select count(*) from exchange) as exchangesCount, "
-                       + "(select count(*) from binding) as bindingsCount, "
-                       + "(select count(*) from queue) as queuesCount, "
-                       + "0 as goodQueuesCount, "
-                       + "0 as badQueuesCount, "
-                       + "0 as criticalQueuesCount "
-                       + "from broker";
+        String query = "with important_queues as "
+            + "(select name from queue where name in ("
+            + "'QUEUE_55','QUEUE_56', 'QUEUE_57',"
+            + "'QUEUE_60','QUEUE_61')) "
+            + "select "
+            + "name as label, "
+            + "null as objectsState, "
+            + "usedHeapMemorySize as heapMemoryUsage, "
+            + "maximumHeapMemorySize as maximumHeapMemorySize, "
+            + "usedDirectMemorySize as directMemoryUsage, "
+            + "maximumDirectMemorySize as maximumDirectMemorySize, "
+            + "(statistics.processCpuLoad * 100) as cpuUsage, "
+            + "(select count(*) from certificate) as certificatesCount, "
+            + "(select count(*) from connection) as connectionCount, "
+            + "(select count(*) from exchange) as exchangesCount, "
+            + "(select count(*) from binding) as bindingsCount, "
+            + "(select count(*) from queue) as queuesCount, "
+            + "(select count(*) from user) as usersCount, "
+            // good queues have depth < 60%
+            + "(select count(*) "
+            + "from queue "
+            + "where name not in (select name from important_queues) "
+            + "or maximumQueueDepthMessages = -1 or maximumQueueDepthBytes = -1 "
+            + "or overflowPolicy = 'RING' "
+            + "and (queueDepthMessages < maximumQueueDepthMessages * 0.6 "
+            + "or queueDepthBytes < maximumQueueDepthBytes * 0.6)) as goodQueuesCount, "
+            // bad queues have depth > 60% and < 90%
+            + "(select count(*) "
+            + "from queue "
+            + "where name in (select name from important_queues) "
+            + "and maximumQueueDepthMessages != -1 and maximumQueueDepthBytes != -1 "
+            + "and overflowPolicy != 'RING' "
+            + "and (queueDepthMessages between (maximumQueueDepthMessages * 0.6, maximumQueueDepthMessages * 0.9) "
+            + "or queueDepthBytes between (maximumQueueDepthBytes * 0.6, maximumQueueDepthBytes * 0.9))) as badQueuesCount, "
+            // critical queues have depth > 90%
+            + "(select count(*) "
+            + "from queue "
+            + "where name in (select name from important_queues) "
+            + "and maximumQueueDepthMessages != -1 and maximumQueueDepthBytes != -1 "
+            + "and overflowPolicy != 'RING' "
+            + "and (queueDepthMessages > maximumQueueDepthMessages * 0.9 "
+            + "or queueDepthBytes > maximumQueueDepthBytes * 0.9)) as criticalQueuesCount "
+            + "from broker";
 
         List<Map<String, Object>> result = _queryEvaluator.execute(query).getResults();
         assertEquals(1, result.size());
+        assertEquals("mock", result.get(0).get("label"));
+        assertEquals(6_000_000_000L, result.get(0).get("heapMemoryUsage"));
+        assertEquals(10_000_000_000L, result.get(0).get("maximumHeapMemorySize"));
+        assertEquals(500_000_000L, result.get(0).get("directMemoryUsage"));
+        assertEquals(1_500_000_000L, result.get(0).get("maximumDirectMemorySize"));
+        assertEquals(5.2, result.get(0).get("cpuUsage"));
+        assertEquals(10, result.get(0).get("certificatesCount"));
+        assertEquals(30, result.get(0).get("connectionCount"));
+        assertEquals(10, result.get(0).get("exchangesCount"));
+        assertEquals(10, result.get(0).get("bindingsCount"));
+        assertEquals(70, result.get(0).get("queuesCount"));
+        assertEquals(0, result.get(0).get("usersCount"));
+        assertEquals(65, result.get(0).get("goodQueuesCount"));
+        assertEquals(3, result.get(0).get("badQueuesCount"));
+        assertEquals(2, result.get(0).get("criticalQueuesCount"));
     }
 }

--- a/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/broker/CertificateQueryTest.java
+++ b/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/broker/CertificateQueryTest.java
@@ -35,12 +35,15 @@ import org.apache.qpid.server.query.engine.evaluator.settings.DefaultQuerySettin
 import org.apache.qpid.server.query.engine.evaluator.settings.QuerySettings;
 import org.apache.qpid.server.query.engine.utils.QuerySettingsBuilder;
 
+/**
+ * Tests designed to verify the certificates retrieval
+ */
 public class CertificateQueryTest
 {
     private final QueryEvaluator _queryEvaluator = new QueryEvaluator(TestBroker.createBroker());
 
     private final QuerySettings _querySettings = new QuerySettingsBuilder()
-        .zoneId(ZoneId.of(DefaultQuerySettings.ZONE_ID)).build();
+            .zoneId(ZoneId.of(DefaultQuerySettings.ZONE_ID)).build();
 
     @Test()
     public void selectAllCertificates()

--- a/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/broker/ConnectionQueryTest.java
+++ b/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/broker/ConnectionQueryTest.java
@@ -30,6 +30,9 @@ import org.junit.Test;
 import org.apache.qpid.server.query.engine.TestBroker;
 import org.apache.qpid.server.query.engine.evaluator.QueryEvaluator;
 
+/**
+ * Tests designed to verify the connections retrieval
+ */
 public class ConnectionQueryTest
 {
     private final QueryEvaluator _queryEvaluator = new QueryEvaluator(TestBroker.createBroker());

--- a/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/broker/ConsumerQueryTest.java
+++ b/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/broker/ConsumerQueryTest.java
@@ -1,0 +1,84 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package org.apache.qpid.server.query.engine.broker;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Test;
+
+import org.apache.qpid.server.query.engine.TestBroker;
+import org.apache.qpid.server.query.engine.evaluator.QueryEvaluator;
+
+/**
+ * Tests designed to verify the consumers retrieval
+ */
+public class ConsumerQueryTest
+{
+    private final QueryEvaluator _queryEvaluator = new QueryEvaluator(TestBroker.createBroker());
+
+    @Test()
+    public void selectAllConsumers()
+    {
+        String query = "select * from consumer";
+        List<Map<String, Object>> result = _queryEvaluator.execute(query).getResults();
+        assertEquals(10, result.size());
+    }
+
+    @Test()
+    public void countConsumers()
+    {
+        String query = "select count(*) from consumer";
+        List<Map<String, Object>> result = _queryEvaluator.execute(query).getResults();
+        assertEquals(1, result.size());
+        assertEquals(10, result.get(0).get("count(*)"));
+    }
+
+    @Test()
+    public void extractConnectionNameAndSessionName()
+    {
+        String query = "select "
+            + "id, name, "
+            + "(select id from connection where substring(name, 1, position(']' in name)) = '[' + substring(c.name, 1, position('|' in c.name) - 1) + ']') as connectionId, "
+            + "(select name from connection where substring(name, 1, position(']' in name)) = '[' + substring(c.name, 1, position('|' in c.name) - 1) + ']') as connection, "
+            + "(select name from session where id = c.session.id) as session, "
+            + "session.id as sessionId "
+            + "from consumer c "
+            + "order by name";
+
+        List<Map<String, Object>> result = _queryEvaluator.execute(query).getResults();
+
+        assertEquals(10, result.size());
+
+        for (Map<String, Object> stringObjectMap : result)
+        {
+            String connectionQuery = "select id from connection where name = '" + stringObjectMap.get("connection") + "'";
+            String connectionId = (String) _queryEvaluator.execute(connectionQuery).getResults().get(0).get("id");
+            assertEquals(stringObjectMap.get("connectionId"), connectionId);
+
+            String sessionQuery = "select name as name from session where id = '" + stringObjectMap.get("sessionId") + "'";
+            String sessionName = (String) _queryEvaluator.execute(sessionQuery).getResults().get(0).get("name");
+            assertEquals(stringObjectMap.get("session"), sessionName);
+        }
+    }
+}

--- a/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/broker/DomainQueryTest.java
+++ b/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/broker/DomainQueryTest.java
@@ -30,6 +30,9 @@ import org.junit.Test;
 import org.apache.qpid.server.query.engine.TestBroker;
 import org.apache.qpid.server.query.engine.evaluator.QueryEvaluator;
 
+/**
+ * Tests designed to verify the domains retrieval
+ */
 public class DomainQueryTest
 {
     private final QueryEvaluator _queryEvaluator = new QueryEvaluator(TestBroker.createBroker());

--- a/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/broker/PortQueryTest.java
+++ b/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/broker/PortQueryTest.java
@@ -18,8 +18,7 @@
  * under the License.
  *
  */
-package org.apache.qpid.server.query.engine.parsing.expression.accessor;
-
+package org.apache.qpid.server.query.engine.broker;
 
 import static org.junit.Assert.assertEquals;
 
@@ -32,38 +31,28 @@ import org.apache.qpid.server.query.engine.TestBroker;
 import org.apache.qpid.server.query.engine.evaluator.QueryEvaluator;
 
 /**
- * Tests designed to verify the {@link ChainedObjectAccessor} functionality
+ * Tests designed to verify the ports retrieval
  */
-public class ChainedAccessorTest
+public class PortQueryTest
 {
     private final QueryEvaluator _queryEvaluator = new QueryEvaluator(TestBroker.createBroker());
 
     @Test()
-    public void getStatisticsField()
+    public void allPorts()
     {
-        String query = "select statistics.availableMessages from queue where name = 'QUEUE_0'";
+        String query = "select * from port";
         List<Map<String, Object>> result = _queryEvaluator.execute(query).getResults();
-        assertEquals(1, result.size());
-        assertEquals(0, result.get(0).get("statistics.availableMessages"));
-
-        query = "select statistics['availableMessages'] from queue where name = 'QUEUE_0'";
-        result = _queryEvaluator.execute(query).getResults();
-        assertEquals(1, result.size());
-        assertEquals(0, result.get(0).get("statistics['availableMessages']"));
+        assertEquals(2, result.size());
+        assertEquals("amqpPort", result.get(0).get("name"));
+        assertEquals("httpPort", result.get(1).get("name"));
     }
 
     @Test()
-    public void getByDomainAlias()
+    public void countPorts()
     {
-        String query = "select q.statistics.availableMessages from queue as q where q.name = 'QUEUE_0'";
+        String query = "select count(*) from port";
         List<Map<String, Object>> result = _queryEvaluator.execute(query).getResults();
         assertEquals(1, result.size());
-        assertEquals(0, result.get(0).get("q.statistics.availableMessages"));
-
-        query = "select q.statistics['availableMessages'] from queue as q where q.name = 'QUEUE_0'";
-        result =_queryEvaluator.execute(query).getResults();
-        assertEquals(1, result.size());
-        assertEquals(0, result.get(0).get("q.statistics['availableMessages']"));
+        assertEquals(2, result.get(0).get("count(*)"));
     }
-
 }

--- a/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/broker/QueueQueryTest.java
+++ b/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/broker/QueueQueryTest.java
@@ -34,6 +34,9 @@ import org.apache.qpid.server.query.engine.evaluator.QueryEvaluator;
 import org.apache.qpid.server.query.engine.evaluator.settings.DefaultQuerySettings;
 import org.apache.qpid.server.query.engine.evaluator.settings.QuerySettings;
 
+/**
+ * Tests designed to verify the queues retrieval
+ */
 public class QueueQueryTest
 {
     private final QueryEvaluator _queryEvaluator = new QueryEvaluator(TestBroker.createBroker());
@@ -98,10 +101,10 @@ public class QueueQueryTest
     public void queuesByMessageDepth()
     {
         String query = "select * from queue "
-        + "where maximumQueueDepthMessages != -1 "
-        + "and maximumQueueDepthBytes != -1 "
-        + "and ((queueDepthMessages > maximumQueueDepthMessages * 0.6 and queueDepthMessages < maximumQueueDepthMessages * 0.9)"
-        + "or (queueDepthBytes > maximumQueueDepthBytes * 0.6 and queueDepthBytes < maximumQueueDepthBytes * 0.9))";
+            + "where maximumQueueDepthMessages != -1 "
+            + "and maximumQueueDepthBytes != -1 "
+            + "and ((queueDepthMessages > maximumQueueDepthMessages * 0.6 and queueDepthMessages < maximumQueueDepthMessages * 0.9)"
+            + "or (queueDepthBytes > maximumQueueDepthBytes * 0.6 and queueDepthBytes < maximumQueueDepthBytes * 0.9))";
         List<Map<String, Object>> result = _queryEvaluator.execute(query).getResults();
         assertEquals(10, result.size());
         for (int i = 50; i < 60; i++)
@@ -110,10 +113,10 @@ public class QueueQueryTest
         }
 
         query = "select * from queue "
-                + "where maximumQueueDepthMessages != -1 "
-                + "and maximumQueueDepthBytes != -1 "
-                + "and (queueDepthMessages > maximumQueueDepthMessages * 0.9"
-                + "or queueDepthBytes > maximumQueueDepthBytes * 0.9)";
+            + "where maximumQueueDepthMessages != -1 "
+            + "and maximumQueueDepthBytes != -1 "
+            + "and (queueDepthMessages > maximumQueueDepthMessages * 0.9"
+            + "or queueDepthBytes > maximumQueueDepthBytes * 0.9)";
         result = _queryEvaluator.execute(query).getResults();
         assertEquals(10, result.size());
         for (int i = 60; i < 70; i++)
@@ -122,8 +125,8 @@ public class QueueQueryTest
         }
 
         query = "select * from queue "
-                + "where maximumQueueDepthMessages != -1 " 
-                + "and maximumQueueDepthBytes != -1 ";
+            + "where maximumQueueDepthMessages != -1 "
+            + "and maximumQueueDepthBytes != -1 ";
         result = _queryEvaluator.execute(query).getResults();
         assertEquals(60, result.size());
         for (int i = 10; i < 70; i++)

--- a/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/broker/SessionQueryTest.java
+++ b/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/broker/SessionQueryTest.java
@@ -18,8 +18,7 @@
  * under the License.
  *
  */
-package org.apache.qpid.server.query.engine.parsing.expression.accessor;
-
+package org.apache.qpid.server.query.engine.broker;
 
 import static org.junit.Assert.assertEquals;
 
@@ -32,38 +31,31 @@ import org.apache.qpid.server.query.engine.TestBroker;
 import org.apache.qpid.server.query.engine.evaluator.QueryEvaluator;
 
 /**
- * Tests designed to verify the {@link ChainedObjectAccessor} functionality
+ * Tests designed to verify the sessions retrieval
  */
-public class ChainedAccessorTest
+public class SessionQueryTest
 {
     private final QueryEvaluator _queryEvaluator = new QueryEvaluator(TestBroker.createBroker());
 
     @Test()
-    public void getStatisticsField()
+    public void selectAllSessions()
     {
-        String query = "select statistics.availableMessages from queue where name = 'QUEUE_0'";
+        String query = "select * from session";
         List<Map<String, Object>> result = _queryEvaluator.execute(query).getResults();
-        assertEquals(1, result.size());
-        assertEquals(0, result.get(0).get("statistics.availableMessages"));
+        assertEquals(30, result.size());
 
-        query = "select statistics['availableMessages'] from queue where name = 'QUEUE_0'";
-        result = _queryEvaluator.execute(query).getResults();
-        assertEquals(1, result.size());
-        assertEquals(0, result.get(0).get("statistics['availableMessages']"));
+        for (Map<String, Object> stringObjectMap : result) {
+            String connectionQuery = "select name from connection where id = '" + stringObjectMap.get("connectionId") + "'";
+            assertEquals(1, _queryEvaluator.execute(connectionQuery).getResults().size());
+        }
     }
 
     @Test()
-    public void getByDomainAlias()
+    public void countSessions()
     {
-        String query = "select q.statistics.availableMessages from queue as q where q.name = 'QUEUE_0'";
+        String query = "select count(*) from session";
         List<Map<String, Object>> result = _queryEvaluator.execute(query).getResults();
         assertEquals(1, result.size());
-        assertEquals(0, result.get(0).get("q.statistics.availableMessages"));
-
-        query = "select q.statistics['availableMessages'] from queue as q where q.name = 'QUEUE_0'";
-        result =_queryEvaluator.execute(query).getResults();
-        assertEquals(1, result.size());
-        assertEquals(0, result.get(0).get("q.statistics['availableMessages']"));
+        assertEquals(30, result.get(0).get("count(*)"));
     }
-
 }

--- a/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/broker/VirtualHostNodeQueryTest.java
+++ b/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/broker/VirtualHostNodeQueryTest.java
@@ -18,8 +18,7 @@
  * under the License.
  *
  */
-package org.apache.qpid.server.query.engine.parsing.expression.accessor;
-
+package org.apache.qpid.server.query.engine.broker;
 
 import static org.junit.Assert.assertEquals;
 
@@ -32,38 +31,28 @@ import org.apache.qpid.server.query.engine.TestBroker;
 import org.apache.qpid.server.query.engine.evaluator.QueryEvaluator;
 
 /**
- * Tests designed to verify the {@link ChainedObjectAccessor} functionality
+ * Tests designed to verify the virtual host nodes retrieval
  */
-public class ChainedAccessorTest
+public class VirtualHostNodeQueryTest
 {
     private final QueryEvaluator _queryEvaluator = new QueryEvaluator(TestBroker.createBroker());
 
     @Test()
-    public void getStatisticsField()
+    public void allVirtualhostNodes()
     {
-        String query = "select statistics.availableMessages from queue where name = 'QUEUE_0'";
+        String query = "select * from virtualhostnode";
         List<Map<String, Object>> result = _queryEvaluator.execute(query).getResults();
-        assertEquals(1, result.size());
-        assertEquals(0, result.get(0).get("statistics.availableMessages"));
-
-        query = "select statistics['availableMessages'] from queue where name = 'QUEUE_0'";
-        result = _queryEvaluator.execute(query).getResults();
-        assertEquals(1, result.size());
-        assertEquals(0, result.get(0).get("statistics['availableMessages']"));
+        assertEquals(2, result.size());
+        assertEquals("default", result.get(0).get("name"));
+        assertEquals("mock", result.get(1).get("name"));
     }
 
     @Test()
-    public void getByDomainAlias()
+    public void countVirtualhostNodes()
     {
-        String query = "select q.statistics.availableMessages from queue as q where q.name = 'QUEUE_0'";
+        String query = "select count(*) from virtualhostnode";
         List<Map<String, Object>> result = _queryEvaluator.execute(query).getResults();
         assertEquals(1, result.size());
-        assertEquals(0, result.get(0).get("q.statistics.availableMessages"));
-
-        query = "select q.statistics['availableMessages'] from queue as q where q.name = 'QUEUE_0'";
-        result =_queryEvaluator.execute(query).getResults();
-        assertEquals(1, result.size());
-        assertEquals(0, result.get(0).get("q.statistics['availableMessages']"));
+        assertEquals(2, result.get(0).get("count(*)"));
     }
-
 }

--- a/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/broker/VirtualHostQueryTest.java
+++ b/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/broker/VirtualHostQueryTest.java
@@ -18,8 +18,7 @@
  * under the License.
  *
  */
-package org.apache.qpid.server.query.engine.parsing.expression.accessor;
-
+package org.apache.qpid.server.query.engine.broker;
 
 import static org.junit.Assert.assertEquals;
 
@@ -32,38 +31,27 @@ import org.apache.qpid.server.query.engine.TestBroker;
 import org.apache.qpid.server.query.engine.evaluator.QueryEvaluator;
 
 /**
- * Tests designed to verify the {@link ChainedObjectAccessor} functionality
+ * Tests designed to verify the virtual hosts retrieval
  */
-public class ChainedAccessorTest
+public class VirtualHostQueryTest
 {
     private final QueryEvaluator _queryEvaluator = new QueryEvaluator(TestBroker.createBroker());
 
     @Test()
-    public void getStatisticsField()
+    public void allVirtualhosts()
     {
-        String query = "select statistics.availableMessages from queue where name = 'QUEUE_0'";
+        String query = "select * from virtualhost";
         List<Map<String, Object>> result = _queryEvaluator.execute(query).getResults();
         assertEquals(1, result.size());
-        assertEquals(0, result.get(0).get("statistics.availableMessages"));
-
-        query = "select statistics['availableMessages'] from queue where name = 'QUEUE_0'";
-        result = _queryEvaluator.execute(query).getResults();
-        assertEquals(1, result.size());
-        assertEquals(0, result.get(0).get("statistics['availableMessages']"));
+        assertEquals("default", result.get(0).get("name"));
     }
 
     @Test()
-    public void getByDomainAlias()
+    public void countVirtualhosts()
     {
-        String query = "select q.statistics.availableMessages from queue as q where q.name = 'QUEUE_0'";
+        String query = "select count(*) from virtualhost";
         List<Map<String, Object>> result = _queryEvaluator.execute(query).getResults();
         assertEquals(1, result.size());
-        assertEquals(0, result.get(0).get("q.statistics.availableMessages"));
-
-        query = "select q.statistics['availableMessages'] from queue as q where q.name = 'QUEUE_0'";
-        result =_queryEvaluator.execute(query).getResults();
-        assertEquals(1, result.size());
-        assertEquals(0, result.get(0).get("q.statistics['availableMessages']"));
+        assertEquals(1, result.get(0).get("count(*)"));
     }
-
 }

--- a/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/evaluator/QueryEvaluatorTest.java
+++ b/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/evaluator/QueryEvaluatorTest.java
@@ -30,6 +30,9 @@ import org.apache.qpid.server.query.engine.evaluator.settings.QuerySettings;
 import org.apache.qpid.server.query.engine.exception.Errors;
 import org.apache.qpid.server.query.engine.exception.QueryValidationException;
 
+/**
+ * Tests designed to verify the {@link QueryEvaluator} functionality
+ */
 public class QueryEvaluatorTest
 {
     @Test()

--- a/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/converter/DateTimeConverterTest.java
+++ b/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/converter/DateTimeConverterTest.java
@@ -40,14 +40,16 @@ import org.junit.Test;
 
 import org.apache.qpid.server.query.engine.evaluator.EvaluationContext;
 import org.apache.qpid.server.query.engine.evaluator.EvaluationContextHolder;
-import org.apache.qpid.server.query.engine.evaluator.settings.DefaultQuerySettings;
 import org.apache.qpid.server.query.engine.evaluator.settings.QuerySettings;
 
+/**
+ * Tests designed to verify the {@link DateTimeConverter} functionality
+ */
 public class DateTimeConverterTest
 {
-    private final DateTimeFormatter _formatter = new DateTimeFormatterBuilder().appendPattern(DefaultQuerySettings.DATE_TIME_PATTERN)
+    private final DateTimeFormatter _formatter = new DateTimeFormatterBuilder().appendPattern("uuuu-MM-dd HH:mm:ss")
         .appendFraction(ChronoField.NANO_OF_SECOND, 0, 6, true)
-        .toFormatter().withZone(ZoneId.of(DefaultQuerySettings.ZONE_ID)).withResolverStyle(ResolverStyle.STRICT);
+        .toFormatter().withZone(ZoneId.of("UTC")).withResolverStyle(ResolverStyle.STRICT);
 
     @Test()
     public void isDateTime()

--- a/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/expression/arithmetic/ArithmeticExpressionsTest.java
+++ b/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/expression/arithmetic/ArithmeticExpressionsTest.java
@@ -35,6 +35,9 @@ import org.apache.qpid.server.query.engine.TestBroker;
 import org.apache.qpid.server.query.engine.evaluator.QueryEvaluator;
 import org.apache.qpid.server.query.engine.exception.QueryParsingException;
 
+/**
+ * Tests designed to verify the arithmetic expressions functionality
+ */
 public class ArithmeticExpressionsTest
 {
     private final QueryEvaluator _queryEvaluator = new QueryEvaluator(TestBroker.createBroker());

--- a/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/expression/arithmetic/NumericTypeConversionsTest.java
+++ b/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/expression/arithmetic/NumericTypeConversionsTest.java
@@ -32,6 +32,9 @@ import org.junit.Test;
 import org.apache.qpid.server.query.engine.TestBroker;
 import org.apache.qpid.server.query.engine.evaluator.QueryEvaluator;
 
+/**
+ * Tests designed to verify the numeric type conversions functionality
+ */
 public class NumericTypeConversionsTest
 {
     private final QueryEvaluator _queryEvaluator = new QueryEvaluator(TestBroker.createBroker());

--- a/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/expression/comparison/BetweenExpressionTest.java
+++ b/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/expression/comparison/BetweenExpressionTest.java
@@ -33,6 +33,9 @@ import org.apache.qpid.server.query.engine.TestBroker;
 import org.apache.qpid.server.query.engine.exception.QueryEvaluationException;
 import org.apache.qpid.server.query.engine.evaluator.QueryEvaluator;
 
+/**
+ * Tests designed to verify the {@link BetweenExpression} functionality
+ */
 public class BetweenExpressionTest
 {
     private final QueryEvaluator _queryEvaluator = new QueryEvaluator(TestBroker.createBroker());

--- a/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/expression/comparison/EqualExpressionTest.java
+++ b/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/expression/comparison/EqualExpressionTest.java
@@ -33,6 +33,9 @@ import org.apache.qpid.server.query.engine.TestBroker;
 import org.apache.qpid.server.query.engine.exception.QueryEvaluationException;
 import org.apache.qpid.server.query.engine.evaluator.QueryEvaluator;
 
+/**
+ * Tests designed to verify the {@link EqualExpression} functionality
+ */
 public class EqualExpressionTest
 {
     private final QueryEvaluator _queryEvaluator = new QueryEvaluator(TestBroker.createBroker());

--- a/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/expression/comparison/GreaterThanExpressionTest.java
+++ b/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/expression/comparison/GreaterThanExpressionTest.java
@@ -33,6 +33,9 @@ import org.apache.qpid.server.query.engine.TestBroker;
 import org.apache.qpid.server.query.engine.exception.QueryEvaluationException;
 import org.apache.qpid.server.query.engine.evaluator.QueryEvaluator;
 
+/**
+ * Tests designed to verify the {@link GreaterThanExpression} functionality
+ */
 public class GreaterThanExpressionTest
 {
     private final QueryEvaluator _queryEvaluator = new QueryEvaluator(TestBroker.createBroker());

--- a/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/expression/comparison/GreaterThanOrEqualExpressionTest.java
+++ b/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/expression/comparison/GreaterThanOrEqualExpressionTest.java
@@ -33,6 +33,9 @@ import org.apache.qpid.server.query.engine.TestBroker;
 import org.apache.qpid.server.query.engine.exception.QueryEvaluationException;
 import org.apache.qpid.server.query.engine.evaluator.QueryEvaluator;
 
+/**
+ * Tests designed to verify the public class {@link GreaterThanOrEqualExpression} functionality
+ */
 public class GreaterThanOrEqualExpressionTest
 {
     private final QueryEvaluator _queryEvaluator = new QueryEvaluator(TestBroker.createBroker());

--- a/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/expression/comparison/InExpressionTest.java
+++ b/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/expression/comparison/InExpressionTest.java
@@ -31,6 +31,9 @@ import org.junit.Test;
 import org.apache.qpid.server.query.engine.TestBroker;
 import org.apache.qpid.server.query.engine.evaluator.QueryEvaluator;
 
+/**
+ * Tests designed to verify the public class {@link InExpression} functionality
+ */
 public class InExpressionTest
 {
     private final QueryEvaluator _queryEvaluator = new QueryEvaluator(TestBroker.createBroker());
@@ -211,6 +214,40 @@ public class InExpressionTest
         result = _queryEvaluator.execute(query).getResults();
         assertEquals(1, result.size());
         assertEquals(false, result.get(0).get("result"));
+    }
+
+    @Test()
+    public void notInSelect()
+    {
+        String query = "select 'FLOW_TO_DISK' not in (select distinct overflowPolicy from queue) as result";
+        List<Map<String, Object>> result = _queryEvaluator.execute(query).getResults();
+        assertEquals(1, result.size());
+        assertEquals(false, result.get(0).get("result"));
+
+        query = "select 'RING' not in (select distinct overflowPolicy from queue) as result";
+        result = _queryEvaluator.execute(query).getResults();
+        assertEquals(1, result.size());
+        assertEquals(false, result.get(0).get("result"));
+
+        query = "select 'REJECT' not  in (select distinct overflowPolicy from queue) as result";
+        result = _queryEvaluator.execute(query).getResults();
+        assertEquals(1, result.size());
+        assertEquals(false, result.get(0).get("result"));
+
+        query = "select 'PRODUCER_FLOW_CONTROL' not in (select distinct overflowPolicy from queue) as result";
+        result = _queryEvaluator.execute(query).getResults();
+        assertEquals(1, result.size());
+        assertEquals(false, result.get(0).get("result"));
+
+        query = "select 'NONE' not in (select distinct overflowPolicy from queue) as result";
+        result = _queryEvaluator.execute(query).getResults();
+        assertEquals(1, result.size());
+        assertEquals(false, result.get(0).get("result"));
+
+        query = "select 'UNKNOWN' not in (select distinct overflowPolicy from queue) as result";
+        result = _queryEvaluator.execute(query).getResults();
+        assertEquals(1, result.size());
+        assertEquals(true, result.get(0).get("result"));
     }
 
     @Test()

--- a/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/expression/comparison/IsNullExpressionTest.java
+++ b/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/expression/comparison/IsNullExpressionTest.java
@@ -31,6 +31,9 @@ import org.junit.Test;
 import org.apache.qpid.server.query.engine.TestBroker;
 import org.apache.qpid.server.query.engine.evaluator.QueryEvaluator;
 
+/**
+ * Tests designed to verify the public class {@link IsNullExpression} functionality
+ */
 public class IsNullExpressionTest
 {
     private final QueryEvaluator _queryEvaluator = new QueryEvaluator(TestBroker.createBroker());

--- a/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/expression/comparison/LessThanExpressionTest.java
+++ b/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/expression/comparison/LessThanExpressionTest.java
@@ -33,6 +33,9 @@ import org.apache.qpid.server.query.engine.TestBroker;
 import org.apache.qpid.server.query.engine.exception.QueryEvaluationException;
 import org.apache.qpid.server.query.engine.evaluator.QueryEvaluator;
 
+/**
+ * Tests designed to verify the public class {@link LessThanExpression} functionality
+ */
 public class LessThanExpressionTest
 {
     private final QueryEvaluator _queryEvaluator = new QueryEvaluator(TestBroker.createBroker());

--- a/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/expression/comparison/LessThanOrEqualExpressionTest.java
+++ b/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/expression/comparison/LessThanOrEqualExpressionTest.java
@@ -33,6 +33,9 @@ import org.apache.qpid.server.query.engine.TestBroker;
 import org.apache.qpid.server.query.engine.exception.QueryEvaluationException;
 import org.apache.qpid.server.query.engine.evaluator.QueryEvaluator;
 
+/**
+ * Tests designed to verify the public class {@link LessThanOrEqualExpression} functionality
+ */
 public class LessThanOrEqualExpressionTest
 {
     private final QueryEvaluator _queryEvaluator = new QueryEvaluator(TestBroker.createBroker());

--- a/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/expression/comparison/LikeExpressionTest.java
+++ b/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/expression/comparison/LikeExpressionTest.java
@@ -30,6 +30,9 @@ import org.junit.Test;
 import org.apache.qpid.server.query.engine.TestBroker;
 import org.apache.qpid.server.query.engine.evaluator.QueryEvaluator;
 
+/**
+ * Tests designed to verify the public class {@link LikeExpression} functionality
+ */
 public class LikeExpressionTest
 {
     private final QueryEvaluator _queryEvaluator = new QueryEvaluator(TestBroker.createBroker());

--- a/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/expression/conditional/CaseExpressionTest.java
+++ b/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/expression/conditional/CaseExpressionTest.java
@@ -30,6 +30,9 @@ import org.junit.Test;
 import org.apache.qpid.server.query.engine.TestBroker;
 import org.apache.qpid.server.query.engine.evaluator.QueryEvaluator;
 
+/**
+ * Tests designed to verify the public class {@link CaseExpression} functionality
+ */
 public class CaseExpressionTest
 {
     private final QueryEvaluator _queryEvaluator = new QueryEvaluator(TestBroker.createBroker());

--- a/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/expression/function/aggregation/AvgExpressionTest.java
+++ b/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/expression/function/aggregation/AvgExpressionTest.java
@@ -33,6 +33,9 @@ import org.apache.qpid.server.query.engine.exception.QueryEvaluationException;
 import org.apache.qpid.server.query.engine.exception.QueryParsingException;
 import org.apache.qpid.server.query.engine.evaluator.QueryEvaluator;
 
+/**
+ * Tests designed to verify the public class {@link AvgExpression} functionality
+ */
 public class AvgExpressionTest
 {
     private final QueryEvaluator _queryEvaluator = new QueryEvaluator(TestBroker.createBroker());

--- a/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/expression/function/aggregation/CountExpressionTest.java
+++ b/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/expression/function/aggregation/CountExpressionTest.java
@@ -32,6 +32,9 @@ import org.apache.qpid.server.query.engine.TestBroker;
 import org.apache.qpid.server.query.engine.exception.QueryParsingException;
 import org.apache.qpid.server.query.engine.evaluator.QueryEvaluator;
 
+/**
+ * Tests designed to verify the public class {@link CountExpression} functionality
+ */
 public class CountExpressionTest
 {
     private final QueryEvaluator _queryEvaluator = new QueryEvaluator(TestBroker.createBroker());

--- a/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/expression/function/aggregation/GroupByTest.java
+++ b/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/expression/function/aggregation/GroupByTest.java
@@ -33,6 +33,9 @@ import org.apache.qpid.server.query.engine.evaluator.QueryEvaluator;
 import org.apache.qpid.server.query.engine.exception.QueryEvaluationException;
 import org.apache.qpid.server.query.engine.exception.QueryParsingException;
 
+/**
+ * Tests designed to verify the public class grouping functionality
+ */
 public class GroupByTest
 {
     private final QueryEvaluator _queryEvaluator = new QueryEvaluator(TestBroker.createBroker());

--- a/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/expression/function/aggregation/MaxExpressionTest.java
+++ b/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/expression/function/aggregation/MaxExpressionTest.java
@@ -43,6 +43,9 @@ import org.apache.qpid.server.query.engine.exception.QueryParsingException;
 import org.apache.qpid.server.query.engine.evaluator.EvaluationContextHolder;
 import org.apache.qpid.server.query.engine.evaluator.QueryEvaluator;
 
+/**
+ * Tests designed to verify the public class {@link MaxExpression} functionality
+ */
 public class MaxExpressionTest
 {
     private final QueryEvaluator _queryEvaluator = new QueryEvaluator(TestBroker.createBroker());

--- a/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/expression/function/aggregation/MinExpressionTest.java
+++ b/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/expression/function/aggregation/MinExpressionTest.java
@@ -43,6 +43,9 @@ import org.apache.qpid.server.query.engine.exception.QueryParsingException;
 import org.apache.qpid.server.query.engine.evaluator.EvaluationContextHolder;
 import org.apache.qpid.server.query.engine.evaluator.QueryEvaluator;
 
+/**
+ * Tests designed to verify the public class {@link MinExpression} functionality
+ */
 public class MinExpressionTest
 {
     private final QueryEvaluator _queryEvaluator = new QueryEvaluator(TestBroker.createBroker());

--- a/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/expression/function/aggregation/SumExpressionTest.java
+++ b/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/expression/function/aggregation/SumExpressionTest.java
@@ -32,6 +32,9 @@ import org.apache.qpid.server.query.engine.TestBroker;
 import org.apache.qpid.server.query.engine.exception.QueryParsingException;
 import org.apache.qpid.server.query.engine.evaluator.QueryEvaluator;
 
+/**
+ * Tests designed to verify the public class {@link SumExpression} functionality
+ */
 public class SumExpressionTest
 {
     private final QueryEvaluator _queryEvaluator = new QueryEvaluator(TestBroker.createBroker());

--- a/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/expression/function/datetime/CurrentTimestampExpressionTest.java
+++ b/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/expression/function/datetime/CurrentTimestampExpressionTest.java
@@ -36,6 +36,9 @@ import org.apache.qpid.server.query.engine.evaluator.settings.QuerySettings;
 import org.apache.qpid.server.query.engine.parsing.converter.DateTimeConverter;
 import org.apache.qpid.server.query.engine.utils.QuerySettingsBuilder;
 
+/**
+ * Tests designed to verify the public class {@link CurrentTimestampExpression} functionality
+ */
 public class CurrentTimestampExpressionTest
 {
     private final QueryEvaluator _queryEvaluator = new QueryEvaluator(TestBroker.createBroker());
@@ -53,7 +56,7 @@ public class CurrentTimestampExpressionTest
     @Test()
     public void comparingDatetimes()
     {
-        QuerySettings querySettings = new QuerySettingsBuilder().zoneId(ZoneId.systemDefault()).build();
+        QuerySettings querySettings = new QuerySettingsBuilder().zoneId(ZoneId.of("UTC")).build();
 
         String query = "select name from virtualhostnode where createdTime < '2001-01-01 12:55:31.000'";
         List<Map<String, Object>> result = _queryEvaluator.execute(query, querySettings).getResults();

--- a/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/expression/function/datetime/DateAddExpressionTest.java
+++ b/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/expression/function/datetime/DateAddExpressionTest.java
@@ -34,6 +34,9 @@ import org.apache.qpid.server.query.engine.evaluator.settings.QuerySettings;
 import org.apache.qpid.server.query.engine.exception.QueryEvaluationException;
 import org.apache.qpid.server.query.engine.exception.QueryParsingException;
 
+/**
+ * Tests designed to verify the public class {@link DateAddExpression} functionality
+ */
 public class DateAddExpressionTest
 {
     private final QueryEvaluator _queryEvaluator = new QueryEvaluator(TestBroker.createBroker());

--- a/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/expression/function/datetime/DateDiffExpressionTest.java
+++ b/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/expression/function/datetime/DateDiffExpressionTest.java
@@ -34,6 +34,9 @@ import org.apache.qpid.server.query.engine.evaluator.settings.QuerySettings;
 import org.apache.qpid.server.query.engine.exception.QueryEvaluationException;
 import org.apache.qpid.server.query.engine.exception.QueryParsingException;
 
+/**
+ * Tests designed to verify the public class {@link DateDiffExpression} functionality
+ */
 public class DateDiffExpressionTest
 {
     private final QueryEvaluator _queryEvaluator = new QueryEvaluator(TestBroker.createBroker());

--- a/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/expression/function/datetime/DateExpressionTest.java
+++ b/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/expression/function/datetime/DateExpressionTest.java
@@ -13,6 +13,9 @@ import org.apache.qpid.server.query.engine.TestBroker;
 import org.apache.qpid.server.query.engine.evaluator.QueryEvaluator;
 import org.apache.qpid.server.query.engine.evaluator.settings.QuerySettings;
 
+/**
+ * Tests designed to verify the public class {@link DateExpression} functionality
+ */
 public class DateExpressionTest
 {
     private final QueryEvaluator _queryEvaluator = new QueryEvaluator(TestBroker.createBroker());

--- a/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/expression/function/datetime/ExtractExpressionTest.java
+++ b/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/expression/function/datetime/ExtractExpressionTest.java
@@ -34,6 +34,9 @@ import org.apache.qpid.server.query.engine.evaluator.QueryEvaluator;
 import org.apache.qpid.server.query.engine.evaluator.settings.QuerySettings;
 import org.apache.qpid.server.query.engine.exception.QueryParsingException;
 
+/**
+ * Tests designed to verify the public class {@link ExtractExpression} functionality
+ */
 public class ExtractExpressionTest
 {
     private final QueryEvaluator _queryEvaluator = new QueryEvaluator(TestBroker.createBroker());

--- a/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/expression/function/nulls/CoalesceExpressionTest.java
+++ b/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/expression/function/nulls/CoalesceExpressionTest.java
@@ -33,6 +33,9 @@ import org.apache.qpid.server.query.engine.TestBroker;
 import org.apache.qpid.server.query.engine.evaluator.QueryEvaluator;
 import org.apache.qpid.server.query.engine.exception.QueryParsingException;
 
+/**
+ * Tests designed to verify the public class {@link CoalesceExpression} functionality
+ */
 public class CoalesceExpressionTest
 {
     private final QueryEvaluator _queryEvaluator = new QueryEvaluator(TestBroker.createBroker());

--- a/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/expression/function/numeric/AbsExpressionTest.java
+++ b/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/expression/function/numeric/AbsExpressionTest.java
@@ -34,6 +34,9 @@ import org.apache.qpid.server.query.engine.evaluator.QueryEvaluator;
 import org.apache.qpid.server.query.engine.exception.QueryEvaluationException;
 import org.apache.qpid.server.query.engine.exception.QueryParsingException;
 
+/**
+ * Tests designed to verify the public class {@link AbsExpression} functionality
+ */
 public class AbsExpressionTest
 {
     private final QueryEvaluator _queryEvaluator = new QueryEvaluator(TestBroker.createBroker());

--- a/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/expression/function/numeric/RoundExpressionTest.java
+++ b/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/expression/function/numeric/RoundExpressionTest.java
@@ -34,6 +34,9 @@ import org.apache.qpid.server.query.engine.exception.QueryEvaluationException;
 import org.apache.qpid.server.query.engine.exception.QueryParsingException;
 import org.apache.qpid.server.query.engine.evaluator.QueryEvaluator;
 
+/**
+ * Tests designed to verify the public class {@link RoundExpression} functionality
+ */
 public class RoundExpressionTest
 {
     private final QueryEvaluator _queryEvaluator = new QueryEvaluator(TestBroker.createBroker());

--- a/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/expression/function/numeric/TruncExpressionTest.java
+++ b/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/expression/function/numeric/TruncExpressionTest.java
@@ -34,6 +34,9 @@ import org.apache.qpid.server.query.engine.exception.QueryEvaluationException;
 import org.apache.qpid.server.query.engine.exception.QueryParsingException;
 import org.apache.qpid.server.query.engine.evaluator.QueryEvaluator;
 
+/**
+ * Tests designed to verify the public class {@link TruncExpression} functionality
+ */
 public class TruncExpressionTest
 {
     private final QueryEvaluator _queryEvaluator = new QueryEvaluator(TestBroker.createBroker());

--- a/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/expression/function/string/ConcatExpressionTest.java
+++ b/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/expression/function/string/ConcatExpressionTest.java
@@ -21,7 +21,6 @@
 package org.apache.qpid.server.query.engine.parsing.expression.function.string;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 
 import java.math.BigDecimal;
@@ -39,6 +38,9 @@ import org.apache.qpid.server.query.engine.exception.QueryParsingException;
 import org.apache.qpid.server.query.engine.evaluator.QueryEvaluator;
 import org.apache.qpid.server.query.engine.parsing.converter.DateTimeConverter;
 
+/**
+ * Tests designed to verify the public class {@link ConcatExpression} functionality
+ */
 public class ConcatExpressionTest
 {
     private final QueryEvaluator _queryEvaluator = new QueryEvaluator(TestBroker.createBroker());

--- a/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/expression/function/string/LeftTrimExpressionTest.java
+++ b/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/expression/function/string/LeftTrimExpressionTest.java
@@ -40,6 +40,9 @@ import org.apache.qpid.server.query.engine.exception.QueryEvaluationException;
 import org.apache.qpid.server.query.engine.exception.QueryParsingException;
 import org.apache.qpid.server.query.engine.parsing.converter.DateTimeConverter;
 
+/**
+ * Tests designed to verify the public class {@link LeftTrimExpression} functionality
+ */
 public class LeftTrimExpressionTest
 {
     private final QueryEvaluator _queryEvaluator = new QueryEvaluator(TestBroker.createBroker());

--- a/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/expression/function/string/LengthExpressionTest.java
+++ b/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/expression/function/string/LengthExpressionTest.java
@@ -21,7 +21,6 @@
 package org.apache.qpid.server.query.engine.parsing.expression.function.string;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 
 import java.math.BigDecimal;
@@ -35,6 +34,9 @@ import org.apache.qpid.server.query.engine.exception.QueryEvaluationException;
 import org.apache.qpid.server.query.engine.exception.QueryParsingException;
 import org.apache.qpid.server.query.engine.evaluator.QueryEvaluator;
 
+/**
+ * Tests designed to verify the public class {@link LengthExpression} functionality
+ */
 public class LengthExpressionTest
 {
     private final QueryEvaluator _queryEvaluator = new QueryEvaluator(TestBroker.createBroker());

--- a/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/expression/function/string/LowerExpressionTest.java
+++ b/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/expression/function/string/LowerExpressionTest.java
@@ -40,6 +40,9 @@ import org.apache.qpid.server.query.engine.exception.QueryParsingException;
 import org.apache.qpid.server.query.engine.evaluator.QueryEvaluator;
 import org.apache.qpid.server.query.engine.parsing.converter.DateTimeConverter;
 
+/**
+ * Tests designed to verify the public class {@link LowerExpression} functionality
+ */
 public class LowerExpressionTest
 {
     private final QueryEvaluator _queryEvaluator = new QueryEvaluator(TestBroker.createBroker());

--- a/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/expression/function/string/PositionExpressionTest.java
+++ b/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/expression/function/string/PositionExpressionTest.java
@@ -33,6 +33,9 @@ import org.apache.qpid.server.query.engine.evaluator.QueryEvaluator;
 import org.apache.qpid.server.query.engine.exception.QueryEvaluationException;
 import org.apache.qpid.server.query.engine.exception.QueryParsingException;
 
+/**
+ * Tests designed to verify the public class {@link PositionExpression} functionality
+ */
 public class PositionExpressionTest
 {
     private final QueryEvaluator _queryEvaluator = new QueryEvaluator(TestBroker.createBroker());

--- a/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/expression/function/string/ReplaceExpressionTest.java
+++ b/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/expression/function/string/ReplaceExpressionTest.java
@@ -34,6 +34,9 @@ import org.apache.qpid.server.query.engine.evaluator.QueryEvaluator;
 import org.apache.qpid.server.query.engine.exception.QueryEvaluationException;
 import org.apache.qpid.server.query.engine.exception.QueryParsingException;
 
+/**
+ * Tests designed to verify the {@link ReplaceExpression} functionality
+ */
 public class ReplaceExpressionTest
 {
     private final QueryEvaluator _queryEvaluator = new QueryEvaluator(TestBroker.createBroker());

--- a/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/expression/function/string/RightTrimExpressionTest.java
+++ b/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/expression/function/string/RightTrimExpressionTest.java
@@ -40,6 +40,9 @@ import org.apache.qpid.server.query.engine.exception.QueryEvaluationException;
 import org.apache.qpid.server.query.engine.exception.QueryParsingException;
 import org.apache.qpid.server.query.engine.parsing.converter.DateTimeConverter;
 
+/**
+ * Tests designed to verify the {@link RightTrimExpression} functionality
+ */
 public class RightTrimExpressionTest
 {
     private final QueryEvaluator _queryEvaluator = new QueryEvaluator(TestBroker.createBroker());

--- a/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/expression/function/string/SubstringExpressionTest.java
+++ b/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/expression/function/string/SubstringExpressionTest.java
@@ -36,11 +36,13 @@ import java.util.Map;
 import org.junit.Test;
 
 import org.apache.qpid.server.query.engine.TestBroker;
-import org.apache.qpid.server.query.engine.evaluator.settings.DefaultQuerySettings;
 import org.apache.qpid.server.query.engine.exception.QueryEvaluationException;
 import org.apache.qpid.server.query.engine.exception.QueryParsingException;
 import org.apache.qpid.server.query.engine.evaluator.QueryEvaluator;
 
+/**
+ * Tests designed to verify the {@link SubstringExpression} functionality
+ */
 public class SubstringExpressionTest
 {
     private final QueryEvaluator _queryEvaluator = new QueryEvaluator(TestBroker.createBroker());
@@ -352,9 +354,9 @@ public class SubstringExpressionTest
     @Test()
     public void dateArgument()
     {
-        DateTimeFormatter formatter = new DateTimeFormatterBuilder().appendPattern(DefaultQuerySettings.DATE_TIME_PATTERN)
+        DateTimeFormatter formatter = new DateTimeFormatterBuilder().appendPattern("uuuu-MM-dd HH:mm:ss")
             .appendFraction(ChronoField.NANO_OF_SECOND, 0, 6, true)
-            .toFormatter().withZone(ZoneId.of(DefaultQuerySettings.ZONE_ID)).withResolverStyle(ResolverStyle.STRICT);
+            .toFormatter().withZone(ZoneId.of("UTC")).withResolverStyle(ResolverStyle.STRICT);
 
         String query = "select substring(lastUpdatedTime, 1) as result from queue where name='QUEUE_0'";
         List<Map<String, Object>> result = _queryEvaluator.execute(query).getResults();

--- a/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/expression/function/string/TrimExpressionTest.java
+++ b/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/expression/function/string/TrimExpressionTest.java
@@ -40,6 +40,9 @@ import org.apache.qpid.server.query.engine.exception.QueryParsingException;
 import org.apache.qpid.server.query.engine.evaluator.QueryEvaluator;
 import org.apache.qpid.server.query.engine.parsing.converter.DateTimeConverter;
 
+/**
+ * Tests designed to verify the {@link TrimExpression} functionality
+ */
 public class TrimExpressionTest
 {
     private final QueryEvaluator _queryEvaluator = new QueryEvaluator(TestBroker.createBroker());

--- a/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/expression/function/string/UpperExpressionTest.java
+++ b/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/expression/function/string/UpperExpressionTest.java
@@ -40,6 +40,9 @@ import org.apache.qpid.server.query.engine.exception.QueryParsingException;
 import org.apache.qpid.server.query.engine.evaluator.QueryEvaluator;
 import org.apache.qpid.server.query.engine.parsing.converter.DateTimeConverter;
 
+/**
+ * Tests designed to verify the {@link UpperExpression} functionality
+ */
 public class UpperExpressionTest
 {
     private final QueryEvaluator _queryEvaluator = new QueryEvaluator(TestBroker.createBroker());

--- a/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/expression/literal/LiteralExpressionTest.java
+++ b/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/expression/literal/LiteralExpressionTest.java
@@ -32,6 +32,9 @@ import org.junit.Test;
 import org.apache.qpid.server.query.engine.TestBroker;
 import org.apache.qpid.server.query.engine.evaluator.QueryEvaluator;
 
+/**
+ * Tests designed to verify the literal expressions functionality
+ */
 public class LiteralExpressionTest
 {
     private final QueryEvaluator _queryEvaluator = new QueryEvaluator(TestBroker.createBroker());

--- a/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/expression/logic/AndExpressionTest.java
+++ b/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/expression/logic/AndExpressionTest.java
@@ -30,6 +30,9 @@ import org.junit.Test;
 import org.apache.qpid.server.query.engine.TestBroker;
 import org.apache.qpid.server.query.engine.evaluator.QueryEvaluator;
 
+/**
+ * Tests designed to verify the {@link AndExpression} functionality
+ */
 public class AndExpressionTest
 {
     private final QueryEvaluator _queryEvaluator = new QueryEvaluator(TestBroker.createBroker());

--- a/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/expression/logic/NotExpressionTest.java
+++ b/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/expression/logic/NotExpressionTest.java
@@ -30,6 +30,9 @@ import org.junit.Test;
 import org.apache.qpid.server.query.engine.TestBroker;
 import org.apache.qpid.server.query.engine.evaluator.QueryEvaluator;
 
+/**
+ * Tests designed to verify the {@link NotExpression} functionality
+ */
 public class NotExpressionTest
 {
     private final QueryEvaluator _queryEvaluator = new QueryEvaluator(TestBroker.createBroker());

--- a/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/expression/logic/OrExpressionTest.java
+++ b/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/expression/logic/OrExpressionTest.java
@@ -30,6 +30,9 @@ import org.junit.Test;
 import org.apache.qpid.server.query.engine.TestBroker;
 import org.apache.qpid.server.query.engine.evaluator.QueryEvaluator;
 
+/**
+ * Tests designed to verify the {@link OrExpression} functionality
+ */
 public class OrExpressionTest
 {
     private final QueryEvaluator _queryEvaluator = new QueryEvaluator(TestBroker.createBroker());

--- a/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/expression/set/IntersectExpressionTest.java
+++ b/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/expression/set/IntersectExpressionTest.java
@@ -32,6 +32,9 @@ import org.apache.qpid.server.query.engine.TestBroker;
 import org.apache.qpid.server.query.engine.evaluator.QueryEvaluator;
 import org.apache.qpid.server.query.engine.exception.QueryParsingException;
 
+/**
+ * Tests designed to verify the {@link IntersectExpression} functionality
+ */
 public class IntersectExpressionTest
 {
     private final QueryEvaluator _queryEvaluator = new QueryEvaluator(TestBroker.createBroker());

--- a/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/expression/set/MinusExpressionTest.java
+++ b/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/expression/set/MinusExpressionTest.java
@@ -32,6 +32,9 @@ import org.apache.qpid.server.query.engine.TestBroker;
 import org.apache.qpid.server.query.engine.evaluator.QueryEvaluator;
 import org.apache.qpid.server.query.engine.exception.QueryParsingException;
 
+/**
+ * Tests designed to verify the {@link MinusExpression} functionality
+ */
 public class MinusExpressionTest
 {
     private final QueryEvaluator _queryEvaluator = new QueryEvaluator(TestBroker.createBroker());

--- a/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/expression/set/UnionExpressionTest.java
+++ b/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/expression/set/UnionExpressionTest.java
@@ -32,6 +32,9 @@ import org.apache.qpid.server.query.engine.TestBroker;
 import org.apache.qpid.server.query.engine.evaluator.QueryEvaluator;
 import org.apache.qpid.server.query.engine.exception.QueryParsingException;
 
+/**
+ * Tests designed to verify the {@link UnionExpression} functionality
+ */
 public class UnionExpressionTest
 {
     private final QueryEvaluator _queryEvaluator = new QueryEvaluator(TestBroker.createBroker());

--- a/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/factory/AccessorExpressionFactoryTest.java
+++ b/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/factory/AccessorExpressionFactoryTest.java
@@ -39,6 +39,9 @@ import org.apache.qpid.server.query.engine.parsing.expression.accessor.Delegatin
 import org.apache.qpid.server.query.engine.parsing.expression.accessor.DelegatingObjectAccessor;
 import org.apache.qpid.server.query.engine.parsing.expression.literal.ConstantExpression;
 
+/**
+ * Tests designed to verify the {@link AccessorExpressionFactory} functionality
+ */
 public class AccessorExpressionFactoryTest
 {
     @Before()

--- a/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/factory/ArithmeticExpressionFactoryTest.java
+++ b/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/factory/ArithmeticExpressionFactoryTest.java
@@ -36,6 +36,9 @@ import org.apache.qpid.server.query.engine.exception.QueryParsingException;
 import org.apache.qpid.server.query.engine.parsing.expression.ExpressionNode;
 import org.apache.qpid.server.query.engine.parsing.expression.literal.ConstantExpression;
 
+/**
+ * Tests designed to verify the {@link ArithmeticExpressionFactory} functionality
+ */
 public class ArithmeticExpressionFactoryTest
 {
     @Before()

--- a/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/factory/CollectorFactoryTest.java
+++ b/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/factory/CollectorFactoryTest.java
@@ -40,6 +40,9 @@ import org.apache.qpid.server.query.engine.exception.Errors;
 import org.apache.qpid.server.query.engine.parsing.collector.CollectorType;
 import org.apache.qpid.server.query.engine.parsing.expression.accessor.MapObjectAccessor;
 
+/**
+ * Tests designed to verify the {@link CollectorFactory} functionality
+ */
 public class CollectorFactoryTest
 {
     private final List<Map<String, Object>> _entities = Arrays.asList(

--- a/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/factory/ComparisonExpressionFactoryTest.java
+++ b/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/factory/ComparisonExpressionFactoryTest.java
@@ -48,6 +48,9 @@ import org.apache.qpid.server.query.engine.parsing.expression.literal.ConstantEx
 import org.apache.qpid.server.query.engine.parsing.expression.logic.NotExpression;
 import org.apache.qpid.server.query.engine.parsing.query.SelectExpression;
 
+/**
+ * Tests designed to verify the {@link ComparisonExpressionFactory} functionality
+ */
 public class ComparisonExpressionFactoryTest
 {
     @Before()

--- a/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/factory/ConditionalExpressionFactoryTest.java
+++ b/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/factory/ConditionalExpressionFactoryTest.java
@@ -38,6 +38,9 @@ import org.apache.qpid.server.query.engine.exception.Errors;
 import org.apache.qpid.server.query.engine.exception.QueryValidationException;
 import org.apache.qpid.server.query.engine.parsing.expression.literal.ConstantExpression;
 
+/**
+ * Tests designed to verify the {@link ConditionalExpressionFactory} functionality
+ */
 public class ConditionalExpressionFactoryTest
 {
     @Before()

--- a/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/factory/FunctionExpressionFactoryTest.java
+++ b/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/factory/FunctionExpressionFactoryTest.java
@@ -62,6 +62,9 @@ import org.apache.qpid.server.query.engine.parsing.expression.function.string.Tr
 import org.apache.qpid.server.query.engine.parsing.expression.function.string.UpperExpression;
 import org.apache.qpid.server.query.engine.parsing.expression.literal.ConstantExpression;
 
+/**
+ * Tests designed to verify the {@link FunctionExpressionFactory} functionality
+ */
 public class FunctionExpressionFactoryTest
 {
     @Before()

--- a/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/factory/LiteralExpressionFactoryTest.java
+++ b/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/factory/LiteralExpressionFactoryTest.java
@@ -37,6 +37,9 @@ import org.apache.qpid.server.query.engine.parsing.expression.literal.NumberLite
 import org.apache.qpid.server.query.engine.parsing.expression.literal.StringLiteralExpression;
 import org.apache.qpid.server.query.engine.parsing.expression.literal.TrueLiteralExpression;
 
+/**
+ * Tests designed to verify the {@link LiteralExpressionFactory} functionality
+ */
 public class LiteralExpressionFactoryTest
 {
     @Before()

--- a/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/factory/LogicExpressionFactoryTest.java
+++ b/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/factory/LogicExpressionFactoryTest.java
@@ -39,6 +39,9 @@ import org.apache.qpid.server.query.engine.parsing.expression.logic.AndExpressio
 import org.apache.qpid.server.query.engine.parsing.expression.logic.NotExpression;
 import org.apache.qpid.server.query.engine.parsing.expression.logic.OrExpression;
 
+/**
+ * Tests designed to verify the {@link LogicExpressionFactory} functionality
+ */
 public class LogicExpressionFactoryTest
 {
     @Before()

--- a/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/factory/NumberExpressionFactoryTest.java
+++ b/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/factory/NumberExpressionFactoryTest.java
@@ -31,6 +31,9 @@ import org.apache.qpid.server.query.engine.evaluator.EvaluationContext;
 import org.apache.qpid.server.query.engine.evaluator.EvaluationContextHolder;
 import org.apache.qpid.server.query.engine.evaluator.settings.QuerySettings;
 
+/**
+ * Tests designed to verify the {@link NumberExpressionFactory} functionality
+ */
 public class NumberExpressionFactoryTest
 {
 

--- a/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/factory/ProjectionExpressionFactoryTest.java
+++ b/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/factory/ProjectionExpressionFactoryTest.java
@@ -35,6 +35,9 @@ import org.apache.qpid.server.query.engine.exception.Errors;
 import org.apache.qpid.server.query.engine.exception.QueryValidationException;
 import org.apache.qpid.server.query.engine.parsing.expression.literal.ConstantExpression;
 
+/**
+ * Tests designed to verify the {@link ProjectionExpressionFactory} functionality
+ */
 public class ProjectionExpressionFactoryTest
 {
     @Before()

--- a/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/factory/SetExpressionFactoryTest.java
+++ b/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/factory/SetExpressionFactoryTest.java
@@ -38,6 +38,9 @@ import org.apache.qpid.server.query.engine.parsing.expression.set.MinusExpressio
 import org.apache.qpid.server.query.engine.parsing.expression.set.UnionExpression;
 import org.apache.qpid.server.query.engine.parsing.query.SelectExpression;
 
+/**
+ * Tests designed to verify the {@link SetExpressionFactory} functionality
+ */
 public class SetExpressionFactoryTest
 {
     @Before()

--- a/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/factory/UnaryExpressionFactoryTest.java
+++ b/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/factory/UnaryExpressionFactoryTest.java
@@ -37,6 +37,9 @@ import org.apache.qpid.server.query.engine.exception.QueryParsingException;
 import org.apache.qpid.server.query.engine.parsing.expression.ExpressionNode;
 import org.apache.qpid.server.query.engine.parsing.expression.literal.NullLiteralExpression;
 
+/**
+ * Tests designed to verify the {@link UnaryExpressionFactory} functionality
+ */
 public class UnaryExpressionFactoryTest
 {
     @Before()

--- a/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/query/AliasTest.java
+++ b/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/query/AliasTest.java
@@ -30,6 +30,9 @@ import org.junit.Test;
 import org.apache.qpid.server.query.engine.TestBroker;
 import org.apache.qpid.server.query.engine.evaluator.QueryEvaluator;
 
+/**
+ * Tests designed to verify the aliases functionality
+ */
 public class AliasTest
 {
     private final QueryEvaluator _queryEvaluator = new QueryEvaluator(TestBroker.createBroker());
@@ -205,7 +208,7 @@ public class AliasTest
     {
         String query = "select e.name from exchange e";
         List<Map<String, Object>> result = _queryEvaluator.execute(query).getResults();
-        assertEquals(14, result.size());
+        assertEquals(10, result.size());
         assertEquals("e.name", result.get(0).keySet().iterator().next());
     }
 
@@ -231,6 +234,77 @@ public class AliasTest
     }
 
     @Test()
+    public void date()
+    {
+        String query = "select date(validUntil) from certificate";
+        List<Map<String, Object>> result = _queryEvaluator.execute(query).getResults();
+        assertEquals(10, result.size());
+        assertEquals("date(validUntil)", result.get(0).keySet().iterator().next());
+    }
+
+    @Test()
+    public void dateadd()
+    {
+        String query = "select dateadd(day, -30, validUntil) from certificate";
+        List<Map<String, Object>> result = _queryEvaluator.execute(query).getResults();
+        assertEquals(10, result.size());
+        assertEquals("dateadd(day, -30, validUntil)", result.get(0).keySet().iterator().next());
+    }
+
+    @Test()
+    public void datediff()
+    {
+        String query = "select datediff(day, current_timestamp(), validUntil) from certificate";
+        List<Map<String, Object>> result = _queryEvaluator.execute(query).getResults();
+        assertEquals(10, result.size());
+        assertEquals("datediff(day, current_timestamp(), validUntil)", result.get(0).keySet().iterator().next());
+    }
+
+    @Test()
+    public void extract()
+    {
+        String query = "select extract(year from validUntil) from certificate";
+        List<Map<String, Object>> result = _queryEvaluator.execute(query).getResults();
+        assertEquals(10, result.size());
+        assertEquals("extract(year from validUntil)", result.get(0).keySet().iterator().next());
+
+        query = "select extract(month from validUntil) from certificate";
+        result = _queryEvaluator.execute(query).getResults();
+        assertEquals(10, result.size());
+        assertEquals("extract(month from validUntil)", result.get(0).keySet().iterator().next());
+
+        query = "select extract(week from validUntil) from certificate";
+        result = _queryEvaluator.execute(query).getResults();
+        assertEquals(10, result.size());
+        assertEquals("extract(week from validUntil)", result.get(0).keySet().iterator().next());
+
+        query = "select extract(day from validUntil) from certificate";
+        result = _queryEvaluator.execute(query).getResults();
+        assertEquals(10, result.size());
+        assertEquals("extract(day from validUntil)", result.get(0).keySet().iterator().next());
+
+        query = "select extract(hour from validUntil) from certificate";
+        result = _queryEvaluator.execute(query).getResults();
+        assertEquals(10, result.size());
+        assertEquals("extract(hour from validUntil)", result.get(0).keySet().iterator().next());
+
+        query = "select extract(minute from validUntil) from certificate";
+        result = _queryEvaluator.execute(query).getResults();
+        assertEquals(10, result.size());
+        assertEquals("extract(minute from validUntil)", result.get(0).keySet().iterator().next());
+
+        query = "select extract(second from validUntil) from certificate";
+        result = _queryEvaluator.execute(query).getResults();
+        assertEquals(10, result.size());
+        assertEquals("extract(second from validUntil)", result.get(0).keySet().iterator().next());
+
+        query = "select extract(millisecond from validUntil) from certificate";
+        result = _queryEvaluator.execute(query).getResults();
+        assertEquals(10, result.size());
+        assertEquals("extract(millisecond from validUntil)", result.get(0).keySet().iterator().next());
+    }
+
+    @Test()
     public void in()
     {
         String query = "select 1 in ('1', 'test', 1.0)";
@@ -240,6 +314,34 @@ public class AliasTest
         query = "select 1 not in ('1', 'test', 1.0)";
         result = _queryEvaluator.execute(query).getResults();
         assertEquals("1 not in ('1','test',1)", result.get(0).keySet().iterator().next());
+    }
+
+    @Test()
+    public void len()
+    {
+        String query = "select len(name) from queue";
+        List<Map<String, Object>> result = _queryEvaluator.execute(query).getResults();
+        assertEquals("len(name)", result.get(0).keySet().iterator().next());
+
+        query = "select length(name) from queue";
+        result = _queryEvaluator.execute(query).getResults();
+        assertEquals("length(name)", result.get(0).keySet().iterator().next());
+    }
+
+    @Test()
+    public void lower()
+    {
+        String query = "select lower(name) from queue";
+        List<Map<String, Object>> result = _queryEvaluator.execute(query).getResults();
+        assertEquals("lower(name)", result.get(0).keySet().iterator().next());
+    }
+
+    @Test()
+    public void ltrim()
+    {
+        String query = "select ltrim(name) from queue";
+        List<Map<String, Object>> result = _queryEvaluator.execute(query).getResults();
+        assertEquals("ltrim(name)", result.get(0).keySet().iterator().next());
     }
 
     @Test()
@@ -259,6 +361,42 @@ public class AliasTest
     }
 
     @Test()
+    public void position()
+    {
+        String query = "select position('_' in name) from queue";
+        List<Map<String, Object>> result = _queryEvaluator.execute(query).getResults();
+        assertEquals("position('_' in name)", result.get(0).keySet().iterator().next());
+
+        query = "select position('_' in name, 1) from queue";
+        result = _queryEvaluator.execute(query).getResults();
+        assertEquals("position('_' in name,1)", result.get(0).keySet().iterator().next());
+
+        query = "select position('_', name) from queue";
+        result = _queryEvaluator.execute(query).getResults();
+        assertEquals("position('_',name)", result.get(0).keySet().iterator().next());
+
+        query = "select position('_', name, 1) from queue";
+        result = _queryEvaluator.execute(query).getResults();
+        assertEquals("position('_',name,1)", result.get(0).keySet().iterator().next());
+    }
+
+    @Test()
+    public void replace()
+    {
+        String query = "select replace(name, '_', '') from queue";
+        List<Map<String, Object>> result = _queryEvaluator.execute(query).getResults();
+        assertEquals("replace(name, '_', '')", result.get(0).keySet().iterator().next());
+    }
+
+    @Test()
+    public void rtrim()
+    {
+        String query = "select rtrim(name) from queue";
+        List<Map<String, Object>> result = _queryEvaluator.execute(query).getResults();
+        assertEquals("rtrim(name)", result.get(0).keySet().iterator().next());
+    }
+
+    @Test()
     public void subquery()
     {
         String query = "select (select count(*) from queue where queueDepthMessages > 0.6 * maximumQueueDepthMessages) from broker";
@@ -267,10 +405,38 @@ public class AliasTest
     }
 
     @Test()
+    public void substring()
+    {
+        String query = "select substring(name, 2) from queue";
+        List<Map<String, Object>> result = _queryEvaluator.execute(query).getResults();
+        assertEquals("substring(name, 2)", result.get(0).keySet().iterator().next());
+
+        query = "select substring(name, 2, 5) from queue";
+        result = _queryEvaluator.execute(query).getResults();
+        assertEquals("substring(name, 2, 5)", result.get(0).keySet().iterator().next());
+    }
+
+    @Test()
     public void sum()
     {
         String query = "select sum(queueDepthMessages) from queue";
         List<Map<String, Object>> result = _queryEvaluator.execute(query).getResults();
         assertEquals("sum(queueDepthMessages)", result.get(0).keySet().iterator().next());
+    }
+
+    @Test()
+    public void trim()
+    {
+        String query = "select trim(name) from queue";
+        List<Map<String, Object>> result = _queryEvaluator.execute(query).getResults();
+        assertEquals("trim(name)", result.get(0).keySet().iterator().next());
+    }
+
+    @Test()
+    public void upper()
+    {
+        String query = "select upper(name) from queue";
+        List<Map<String, Object>> result = _queryEvaluator.execute(query).getResults();
+        assertEquals("upper(name)", result.get(0).keySet().iterator().next());
     }
 }

--- a/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/query/HavingTest.java
+++ b/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/query/HavingTest.java
@@ -32,6 +32,9 @@ import org.apache.qpid.server.query.engine.TestBroker;
 import org.apache.qpid.server.query.engine.evaluator.QueryEvaluator;
 import org.apache.qpid.server.query.engine.exception.QueryValidationException;
 
+/**
+ * Tests designed to verify the {@link HavingExpression} functionality
+ */
 @SuppressWarnings("unchecked")
 public class HavingTest
 {

--- a/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/query/OrderByTest.java
+++ b/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/query/OrderByTest.java
@@ -38,6 +38,9 @@ import org.apache.qpid.server.query.engine.evaluator.settings.QuerySettings;
 import org.apache.qpid.server.query.engine.exception.QueryEvaluationException;
 import org.apache.qpid.server.query.engine.exception.QueryParsingException;
 
+/**
+ * Tests designed to verify the ordering functionality
+ */
 public class OrderByTest
 {
     private final QueryEvaluator _queryEvaluator = new QueryEvaluator(TestBroker.createBroker());

--- a/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/query/QuerySettingsTest.java
+++ b/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/query/QuerySettingsTest.java
@@ -48,6 +48,9 @@ import org.apache.qpid.server.query.engine.evaluator.settings.QuerySettings;
 import org.apache.qpid.server.query.engine.exception.QueryParsingException;
 import org.apache.qpid.server.query.engine.utils.QuerySettingsBuilder;
 
+/**
+ * Tests designed to verify the {@link QuerySettings} functionality
+ */
 public class QuerySettingsTest
 {
     private final Broker<?> _broker = TestBroker.createBroker();

--- a/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/query/QueryValidatorTest.java
+++ b/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/query/QueryValidatorTest.java
@@ -30,6 +30,9 @@ import org.apache.qpid.server.query.engine.evaluator.QueryEvaluator;
 import org.apache.qpid.server.query.engine.exception.QueryParsingException;
 import org.apache.qpid.server.query.engine.exception.QueryValidationException;
 
+/**
+ * Tests designed to verify the query validation functionality
+ */
 public class QueryValidatorTest
 {
     private final QueryEvaluator _queryEvaluator = new QueryEvaluator(TestBroker.createBroker());

--- a/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/query/SubqueryTest.java
+++ b/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/query/SubqueryTest.java
@@ -33,6 +33,9 @@ import org.apache.qpid.server.query.engine.evaluator.QueryEvaluator;
 import org.apache.qpid.server.query.engine.exception.QueryEvaluationException;
 import org.apache.qpid.server.query.engine.exception.QueryParsingException;
 
+/**
+ * Tests designed to verify the subqueries functionality
+ */
 public class SubqueryTest
 {
     private final QueryEvaluator _queryEvaluator = new QueryEvaluator(TestBroker.createBroker());

--- a/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/query/WithTest.java
+++ b/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/query/WithTest.java
@@ -32,6 +32,9 @@ import org.apache.qpid.server.query.engine.TestBroker;
 import org.apache.qpid.server.query.engine.evaluator.QueryEvaluator;
 import org.apache.qpid.server.query.engine.exception.QueryParsingException;
 
+/**
+ * Tests designed to verify the WITH clause functionality
+ */
 public class WithTest
 {
     private final QueryEvaluator _queryEvaluator = new QueryEvaluator(TestBroker.createBroker());

--- a/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/utils/QuerySettingsBuilder.java
+++ b/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/utils/QuerySettingsBuilder.java
@@ -26,6 +26,9 @@ import java.time.ZoneId;
 import org.apache.qpid.server.query.engine.evaluator.DateFormat;
 import org.apache.qpid.server.query.engine.evaluator.settings.QuerySettings;
 
+/**
+ * Helper class for building {@link QuerySettings} instances
+ */
 public class QuerySettingsBuilder
 {
     private DateFormat _dateTimeFormat;

--- a/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/validation/FunctionParameterTypePredicateTest.java
+++ b/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/validation/FunctionParameterTypePredicateTest.java
@@ -1,3 +1,23 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
 package org.apache.qpid.server.query.engine.validation;
 
 import static org.junit.Assert.assertEquals;
@@ -18,6 +38,9 @@ import org.apache.qpid.server.model.OverflowPolicy;
 import org.apache.qpid.server.query.engine.exception.Errors;
 import org.apache.qpid.server.query.engine.exception.QueryValidationException;
 
+/**
+ * Tests designed to verify the {@link FunctionParameterTypePredicate} functionality
+ */
 public class FunctionParameterTypePredicateTest
 {
     @Test()

--- a/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/validation/FunctionParametersValidatorTest.java
+++ b/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/validation/FunctionParametersValidatorTest.java
@@ -1,3 +1,23 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
 package org.apache.qpid.server.query.engine.validation;
 
 import static org.junit.Assert.assertEquals;
@@ -19,6 +39,9 @@ import org.apache.qpid.server.query.engine.parsing.expression.function.AbstractF
 import org.apache.qpid.server.query.engine.parsing.expression.literal.ConstantExpression;
 import org.apache.qpid.server.query.engine.parsing.factory.FunctionExpressionFactory;
 
+/**
+ * Tests designed to verify the {@link FunctionParametersValidator} functionality
+ */
 public class FunctionParametersValidatorTest
 {
     @Before()

--- a/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/validation/QueryExpressionValidatorTest.java
+++ b/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/validation/QueryExpressionValidatorTest.java
@@ -1,3 +1,23 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
 package org.apache.qpid.server.query.engine.validation;
 
 import static org.junit.Assert.assertEquals;
@@ -15,6 +35,9 @@ import org.apache.qpid.server.query.engine.exception.Errors;
 import org.apache.qpid.server.query.engine.exception.QueryValidationException;
 import org.apache.qpid.server.query.engine.parsing.query.QueryExpression;
 
+/**
+ * Tests designed to verify the {@link QueryExpressionValidator} functionality
+ */
 public class QueryExpressionValidatorTest
 {
     private final QueryExpressionValidator _validator = new QueryExpressionValidator();

--- a/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/validation/SelectExpressionValidatorTest.java
+++ b/broker-plugins/broker-query-engine/src/test/java/org/apache/qpid/server/query/engine/validation/SelectExpressionValidatorTest.java
@@ -1,3 +1,23 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
 package org.apache.qpid.server.query.engine.validation;
 
 import static org.junit.Assert.assertEquals;
@@ -17,6 +37,9 @@ import org.apache.qpid.server.query.engine.parsing.ExpressionParser;
 import org.apache.qpid.server.query.engine.parsing.query.QueryExpression;
 import org.apache.qpid.server.query.engine.parsing.query.SelectExpression;
 
+/**
+ * Tests designed to verify the {@link SelectExpressionValidator} functionality
+ */
 public class SelectExpressionValidatorTest
 {
     private final SelectExpressionValidator _validator = new SelectExpressionValidator();

--- a/doc/java-broker/src/docbkx/management/channels/Java-Broker-Management-Channel-REST-Query-Engine.xml
+++ b/doc/java-broker/src/docbkx/management/channels/Java-Broker-Management-Channel-REST-Query-Engine.xml
@@ -3405,6 +3405,115 @@
         </programlisting>
     </section>
 
+    <section xml:id="Java-Broker-Management-Channel-REST-Query-Engine-Subqueries">
+        <title>Subqueries</title>
+        <para>
+            When executing subquery parent query domain mat be passed into the subquery using alias.
+            E.g. this query
+        </para>
+        <programlisting language="sql">
+    SELECT
+        id,
+        name,
+        (SELECT name FROM connection WHERE SUBSTRING(name, 1, POSITION(']' IN name)) = '[' + SUBSTRING(c.name, 1, POSITION('|' IN c.name) - 1) + ']') as connection,
+        (SELECT id FROM connection WHERE SUBSTRING(name, 1, POSITION(']' IN name)) = '[' + SUBSTRING(c.name, 1, POSITION('|' IN c.name) - 1) + ']') as connectionId,
+        (SELECT name FROM session WHERE id = c.session.id) as session
+    FROM consumer c
+        </programlisting>
+        <para>
+            returns following result:
+        </para>
+        <programlisting language="javascript">
+    {
+        "results": [
+            {
+                "id": "7a4d7a86-652b-4112-b535-61272b936b57",
+                "name": "1|1|qpid-jms:receiver:ID:6bd18833-3c96-4936-b9ee-9dec5f408b5c:1:1:1:broadcast.amqp_user1.public",
+                "connection": "[1] 127.0.0.1:39134",
+                "connectionId": "afbd0480-43b1-4b39-bc00-260c077095f3",
+                "session": "1"
+            }
+        ],
+        "total": 1
+    }
+        </programlisting>
+        <para>
+            Query
+        </para>
+        <programlisting language="sql">
+    SELECT
+        name,
+        destination,
+        (SELECT id FROM queue WHERE name = b.destination) AS destinationId,
+        exchange,
+        (SELECT id FROM exchange WHERE name = b.exchange) AS exchangeId
+    FROM binding b
+    WHERE name = 'broadcast.amqp_user1.xxx.#'
+        </programlisting>
+        <para>
+            returns following result:
+        </para>
+        <programlisting language="javascript">
+    {
+        "results": [
+            {
+                "name": "broadcast.amqp_user1.xxx.#",
+                "destination": "broadcast.amqp_user1.xxx",
+                "destinationId": "d5ce9e78-8558-40db-8690-15abf69ab255",
+                "exchange": "broadcast",
+                "exchangeId": "470273aa-7243-4cb7-80ec-13e698c36158"
+            },
+            {
+                "name": "broadcast.amqp_user1.xxx.#",
+                "destination": "broadcast.amqp_user2.xxx",
+                "destinationId": "88357d15-a590-4ccf-aee8-2d5cda77752e",
+                "exchange": "broadcast",
+                "exchangeId": "470273aa-7243-4cb7-80ec-13e698c36158"
+            },
+            {
+                "name": "broadcast.amqp_user1.xxx.#",
+                "destination": "broadcast.amqp_user3.xxx",
+                "destinationId": "c8200f89-2587-4b0c-a8f6-120cda975d03",
+                "exchange": "broadcast",
+                "exchangeId": "470273aa-7243-4cb7-80ec-13e698c36158"
+            }
+        ],
+        "total": 3
+    }
+        </programlisting>
+        <para>
+            Query
+        </para>
+        <programlisting language="sql">
+    SELECT
+        alias,
+        (SELECT COUNT(id) FROM queue WHERE POSITION(UPPER(c.alias) IN name) > 0) AS queueCount
+    FROM certificate c
+        </programlisting>
+        <para>
+            returns following result:
+        </para>
+        <programlisting language="javascript">
+    {
+        "results": [
+            {
+                "alias": "xxx",
+                "queueCount": 5
+            },
+            {
+                "alias": "xxy",
+                "queueCount": 5
+            },
+            {
+                "alias": "xxz",
+                "queueCount": 7
+            }
+        ],
+        "total": 3
+    }
+        </programlisting>
+    </section>
+
     <section xml:id="Java-Broker-Management-Channel-REST-Query-Engine-Performance-Tips">
         <title>Performance Tips</title>
         <para>

--- a/pom.xml
+++ b/pom.xml
@@ -142,6 +142,8 @@
 
     <exec-maven-plugin-version>1.6.0</exec-maven-plugin-version>
     <javacc-maven-plugin-version>2.6</javacc-maven-plugin-version>
+    <ph-javacc-maven-plugin-version>4.1.5</ph-javacc-maven-plugin-version>
+    <maven-enforcer-plugin-version>3.0.0-M2</maven-enforcer-plugin-version>
     <maven-rar-plugin-version>2.4</maven-rar-plugin-version>
     <license-maven-plugin-version>1.8</license-maven-plugin-version>
     <maven-jxr-plugin-version>3.0.0</maven-jxr-plugin-version>
@@ -939,7 +941,17 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-enforcer-plugin</artifactId>
-          <version>3.0.0-M2</version>
+          <version>${maven-enforcer-plugin-version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>javacc-maven-plugin</artifactId>
+          <version>${javacc-maven-plugin-version}</version>
+        </plugin>
+        <plugin>
+          <groupId>com.helger.maven</groupId>
+          <artifactId>ph-javacc-maven-plugin</artifactId>
+          <version>${ph-javacc-maven-plugin-version}</version>
         </plugin>
       </plugins>
     </pluginManagement>


### PR DESCRIPTION
This PR addresses [QPID-8592](https://issues.apache.org/jira/browse/QPID-8592), improving broker query engine functionality 
 by allowing to pass context from parent query to the subquery.