### PR TITLE
QPID-8572: [Broker-J] The binding is broken when queue and exchange have the same name

### DIFF
--- a/broker-core/src/main/java/org/apache/qpid/server/exchange/AbstractExchange.java
+++ b/broker-core/src/main/java/org/apache/qpid/server/exchange/AbstractExchange.java
@@ -30,6 +30,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -798,12 +799,12 @@ public abstract class AbstractExchange<T extends AbstractExchange<T>>
     private MessageDestination getOpenedMessageDestination(final String name)
     {
         MessageDestination destination = getVirtualHost().getSystemDestination(name);
-        if(destination == null)
+        if (destination == null)
         {
             destination = getVirtualHost().getChildByName(Exchange.class, name);
         }
-
-        if(destination == null)
+        // handle same exchange and queue name (QPID-8572)
+        if (destination == null || Objects.equals(this, destination))
         {
             destination = getVirtualHost().getChildByName(Queue.class, name);
         }

--- a/broker-core/src/test/java/org/apache/qpid/server/exchange/TopicExchangeTest.java
+++ b/broker-core/src/test/java/org/apache/qpid/server/exchange/TopicExchangeTest.java
@@ -29,6 +29,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -37,6 +38,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import org.apache.qpid.server.binding.BindingImpl;
 import org.apache.qpid.server.message.AMQMessageHeader;
 import org.apache.qpid.server.message.InstanceProperties;
 import org.apache.qpid.server.message.RoutingResult;
@@ -655,6 +657,27 @@ public class TopicExchangeTest extends UnitTestBase
 
         final RoutingResult<ServerMessage<?>> result2 = _exchange.route(testMessage, queueName, _instanceProperties);
         assertTrue("Message should be be possible to route using old binding", result2.hasRoutes());
+    }
+
+    @Test
+    public void testBindingWithSameDestinationName()
+    {
+        String name = "test123";
+
+        Map<String, Object> queueAttributes = new HashMap<>();
+        queueAttributes.put(Queue.NAME, name);
+        queueAttributes.put(Queue.DURABLE, false);
+        Queue<?> queue = (Queue<?>) _vhost.createChild(Queue.class, queueAttributes);
+
+        Map<String, Object> exchangeAttributes = new HashMap<>();
+        exchangeAttributes.put(Exchange.NAME, name);
+        exchangeAttributes.put(Exchange.DURABLE, false);
+        exchangeAttributes.put(Exchange.TYPE, ExchangeDefaults.TOPIC_EXCHANGE_CLASS);
+        exchangeAttributes.put(Exchange.DURABLE_BINDINGS, Arrays.asList(new BindingImpl("#", name, new HashMap<>())));
+        Exchange<?> exchange = (Exchange<?>) _vhost.createChild(Exchange.class, exchangeAttributes);
+
+        assertEquals(1, queue.getBindingCount());
+        assertEquals(1, exchange.getBindingCount());
     }
 
     private ServerMessage<?> createTestMessage(Map<String, Object> headerValues)


### PR DESCRIPTION
This PR addresses issue [QPID-8572](https://issues.apache.org/jira/browse/QPID-8572) adding a fix and new unit test.