### PR TITLE
QPID-8597: [Broker-J] SNI hostname handling for java 11/17 compatibility

### DIFF
--- a/broker-core/src/main/java/org/apache/qpid/server/model/port/AmqpPort.java
+++ b/broker-core/src/main/java/org/apache/qpid/server/model/port/AmqpPort.java
@@ -82,6 +82,12 @@ public interface AmqpPort<X extends AmqpPort<X>> extends Port<X>
 
     String PORT_IGNORE_INVALID_SNI = "qpid.port.amqp.ignoreInvalidSni";
 
+    /**
+     * In Java 17 logic SNI hostname validation became stricter and this flag will not help with the syntax errors
+     * in SNI hostnames provided by client. They will result in SSLPeerUnverifiedException thrown by SSLEngine.
+     * Therefore, usage of this flag is discouraged. It may be deleted in one of the future broker releases.
+     */
+    @Deprecated
     @SuppressWarnings("unused")
     @ManagedContextDefault(name = PORT_IGNORE_INVALID_SNI)
     boolean DEFAULT_PORT_IGNORE_INVALID_SNI = false;

--- a/broker-core/src/test/java/org/apache/qpid/server/transport/SNITest.java
+++ b/broker-core/src/test/java/org/apache/qpid/server/transport/SNITest.java
@@ -20,7 +20,11 @@
 
 package org.apache.qpid.server.transport;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.number.OrderingComparison.greaterThanOrEqualTo;
+import static org.hamcrest.number.OrderingComparison.lessThan;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assume.assumeThat;
 
 import java.io.File;
 import java.net.InetSocketAddress;
@@ -65,6 +69,7 @@ import org.apache.qpid.server.model.Transport;
 import org.apache.qpid.server.security.FileKeyStore;
 import org.apache.qpid.server.security.auth.manager.AnonymousAuthenticationManager;
 import org.apache.qpid.server.transport.network.security.ssl.SSLUtil;
+import org.apache.qpid.test.utils.JvmVersion;
 import org.apache.qpid.test.utils.TestFileUtils;
 import org.apache.qpid.test.utils.UnitTestBase;
 import org.apache.qpid.test.utils.tls.AltNameType;
@@ -169,9 +174,16 @@ public class SNITest extends UnitTestBase
     @Test
     public void testBypassInvalidSniHostname() throws Exception
     {
-        performTest(false, "foovalid", "_foo", _fooValid,true);
+        assumeThat(JvmVersion.getVersion(), is(lessThan(17)));
+        performTest(false, "foovalid", "_foo", _fooValid, true);
     }
 
+    @Test(expected = SSLPeerUnverifiedException.class)
+    public void testBypassInvalidSniHostnameWithJava17() throws Exception
+    {
+        assumeThat(JvmVersion.getVersion(), is(greaterThanOrEqualTo(17)));
+        performTest(false, "foovalid", "_foo", _fooValid, true);
+    }
 
     private void performTest(final boolean useMatching,
                              final String defaultAlias,

--- a/qpid-test-utils/src/main/java/org/apache/qpid/test/utils/JvmVersion.java
+++ b/qpid-test-utils/src/main/java/org/apache/qpid/test/utils/JvmVersion.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package org.apache.qpid.test.utils;
+
+public class JvmVersion
+{
+    public static int getVersion()
+    {
+        String version = System.getProperty("java.version");
+        if (version.startsWith("1."))
+        {
+            version = version.substring(2, 3);
+        }
+        else
+        {
+            final int dot = version.indexOf(".");
+            if (dot != -1)
+            {
+                version = version.substring(0, dot);
+            }
+        }
+        return Integer.parseInt(version);
+    }
+}


### PR DESCRIPTION
This PR affects [QPID-8597](https://issues.apache.org/jira/browse/QPID-8587) fixing unit tests for java 17 compatibility