### PR TITLE
QPID-8604: [Broker-J] static inner classes

### DIFF
--- a/bdbstore/src/main/java/org/apache/qpid/server/store/berkeleydb/CoalescingCommiter.java
+++ b/bdbstore/src/main/java/org/apache/qpid/server/store/berkeleydb/CoalescingCommiter.java
@@ -338,7 +338,7 @@ public class CoalescingCommiter implements Committer
         }
     }
 
-    private class SynchronousCommitThreadJob implements CommitThreadJob
+    private static class SynchronousCommitThreadJob implements CommitThreadJob
     {
         private boolean _done;
         private RuntimeException _exception;

--- a/bdbstore/src/test/java/org/apache/qpid/server/store/berkeleydb/replication/ReplicatedEnvironmentFacadeTest.java
+++ b/bdbstore/src/test/java/org/apache/qpid/server/store/berkeleydb/replication/ReplicatedEnvironmentFacadeTest.java
@@ -554,13 +554,15 @@ public class ReplicatedEnvironmentFacadeTest extends UnitTestBase
     public void testRemoveNodeFromGroup() throws Exception
     {
         TestStateChangeListener stateChangeListener = new TestStateChangeListener();
-        ReplicatedEnvironmentFacade environmentFacade = addNode(TEST_NODE_NAME, TEST_NODE_HOST_PORT, true, stateChangeListener, new NoopReplicationGroupListener());
+        ReplicatedEnvironmentFacade environmentFacade = addNode(TEST_NODE_NAME, TEST_NODE_HOST_PORT, true, stateChangeListener,
+                                                                new NoopReplicationGroupListener());
         assertTrue("Environment was not created", stateChangeListener.awaitForStateChange(State.MASTER,
                                                                                           _timeout, TimeUnit.SECONDS));
 
         String node2Name = TEST_NODE_NAME + "_2";
         String node2NodeHostPort = "localhost:" + _portHelper.getNextAvailable();
-        ReplicatedEnvironmentFacade ref2 = createReplica(node2Name, node2NodeHostPort, new NoopReplicationGroupListener());
+        ReplicatedEnvironmentFacade ref2 = createReplica(node2Name, node2NodeHostPort,
+                                                         new NoopReplicationGroupListener());
 
         assertEquals("Unexpected group members count",
                      (long) 2,
@@ -653,7 +655,8 @@ public class ReplicatedEnvironmentFacadeTest extends UnitTestBase
         int replica1Port = _portHelper.getNextAvailable();
         String node1NodeHostPort = "localhost:" + replica1Port;
         masterEnvironment.setPermittedNodes(Arrays.asList(masterEnvironment.getHostPort(), node1NodeHostPort));
-        ReplicatedEnvironmentFacade replica = createReplica(replicaName, node1NodeHostPort, new NoopReplicationGroupListener());
+        ReplicatedEnvironmentFacade replica = createReplica(replicaName, node1NodeHostPort,
+                                                            new NoopReplicationGroupListener());
 
         assertTrue("Node should be added", nodeAddedLatch.await(_timeout, TimeUnit.SECONDS));
 
@@ -722,7 +725,8 @@ public class ReplicatedEnvironmentFacadeTest extends UnitTestBase
         // make sure that node is re-elected as MASTER on second start-up
         ReplicatedEnvironmentConfiguration config = createReplicatedEnvironmentConfiguration(TEST_NODE_NAME, TEST_NODE_HOST_PORT, TEST_DESIGNATED_PRIMARY);
         when(config.getPriority()).thenReturn(2);
-        createReplicatedEnvironmentFacade(TEST_NODE_NAME, stateChangeListener, new NoopReplicationGroupListener(), config);
+        createReplicatedEnvironmentFacade(TEST_NODE_NAME, stateChangeListener,
+                                          new NoopReplicationGroupListener(), config);
 
         assertTrue("Master was not started", masterLatch.await(_timeout, TimeUnit.SECONDS));
 
@@ -731,8 +735,10 @@ public class ReplicatedEnvironmentFacadeTest extends UnitTestBase
         int replica2Port = _portHelper.getNextAvailable();
         String node2NodeHostPort = "localhost:" + replica2Port;
 
-        ReplicatedEnvironmentFacade replica1 = createReplica(TEST_NODE_NAME + "_1", node1NodeHostPort, new NoopReplicationGroupListener());
-        ReplicatedEnvironmentFacade replica2 = createReplica(TEST_NODE_NAME + "_2", node2NodeHostPort, new NoopReplicationGroupListener());
+        ReplicatedEnvironmentFacade replica1 = createReplica(TEST_NODE_NAME + "_1", node1NodeHostPort,
+                                                             new NoopReplicationGroupListener());
+        ReplicatedEnvironmentFacade replica2 = createReplica(TEST_NODE_NAME + "_2", node2NodeHostPort,
+                                                             new NoopReplicationGroupListener());
 
         // close replicas
         replica1.close();
@@ -781,7 +787,8 @@ public class ReplicatedEnvironmentFacadeTest extends UnitTestBase
 
         int replica1Port = _portHelper.getNextAvailable();
         String node1NodeHostPort = "localhost:" + replica1Port;
-        ReplicatedEnvironmentFacade secondNode = createReplica(TEST_NODE_NAME + "_1", node1NodeHostPort, new NoopReplicationGroupListener());
+        ReplicatedEnvironmentFacade secondNode = createReplica(TEST_NODE_NAME + "_1", node1NodeHostPort,
+                                                               new NoopReplicationGroupListener());
         assertEquals("Unexpected state", State.REPLICA.name(), secondNode.getNodeState());
 
         int replica2Port = _portHelper.getNextAvailable();
@@ -805,7 +812,8 @@ public class ReplicatedEnvironmentFacadeTest extends UnitTestBase
             }
         };
         ReplicatedEnvironmentFacade thirdNode = addNode(TEST_NODE_NAME + "_2", node2NodeHostPort, TEST_DESIGNATED_PRIMARY,
-                                                        testStateChangeListener, new NoopReplicationGroupListener());
+                                                        testStateChangeListener,
+                                                        new NoopReplicationGroupListener());
         assertTrue("Environment did not become a replica", replicaStateLatch.await(_timeout, TimeUnit.SECONDS));
         assertEquals((long) 3, (long) thirdNode.getNumberOfElectableGroupMembers());
 
@@ -843,7 +851,8 @@ public class ReplicatedEnvironmentFacadeTest extends UnitTestBase
 
         int replica1Port = _portHelper.getNextAvailable();
         String node1NodeHostPort = "localhost:" + replica1Port;
-        ReplicatedEnvironmentFacade secondNode = createReplica(TEST_NODE_NAME + "_1", node1NodeHostPort, new NoopReplicationGroupListener());
+        ReplicatedEnvironmentFacade secondNode = createReplica(TEST_NODE_NAME + "_1", node1NodeHostPort,
+                                                               new NoopReplicationGroupListener());
         assertEquals("Unexpected state", State.REPLICA.name(), secondNode.getNodeState());
 
         int replica2Port = _portHelper.getNextAvailable();
@@ -976,13 +985,15 @@ public class ReplicatedEnvironmentFacadeTest extends UnitTestBase
         DatabaseConfig createConfig = createDatabaseConfig();
 
         TestStateChangeListener masterListener = new TestStateChangeListener();
-        ReplicatedEnvironmentFacade node1 = addNode(TEST_NODE_NAME, TEST_NODE_HOST_PORT, true, masterListener, new NoopReplicationGroupListener());
+        ReplicatedEnvironmentFacade node1 = addNode(TEST_NODE_NAME, TEST_NODE_HOST_PORT, true, masterListener,
+                                                    new NoopReplicationGroupListener());
         assertTrue("Environment was not created", masterListener.awaitForStateChange(State.MASTER,
                                                                                      _timeout, TimeUnit.SECONDS));
 
         String replicaNodeHostPort = "localhost:" + _portHelper.getNextAvailable();
         String replicaName = TEST_NODE_NAME + 1;
-        ReplicatedEnvironmentFacade node2 = createReplica(replicaName, replicaNodeHostPort, new NoopReplicationGroupListener());
+        ReplicatedEnvironmentFacade node2 = createReplica(replicaName, replicaNodeHostPort,
+                                                          new NoopReplicationGroupListener());
 
         Database db = node1.openDatabase("mydb", createConfig);
 
@@ -1002,7 +1013,8 @@ public class ReplicatedEnvironmentFacadeTest extends UnitTestBase
         LOGGER.debug("RESTARTING " + replicaName);
         // Restart the node2, making it primary so it becomes master
         TestStateChangeListener node2StateChangeListener = new TestStateChangeListener();
-        node2 = addNode(replicaName, replicaNodeHostPort, true, node2StateChangeListener, new NoopReplicationGroupListener());
+        node2 = addNode(replicaName, replicaNodeHostPort, true, node2StateChangeListener,
+                        new NoopReplicationGroupListener());
         boolean awaitForStateChange = node2StateChangeListener.awaitForStateChange(State.MASTER,
                                                                                    _timeout, TimeUnit.SECONDS);
         assertTrue(replicaName + " did not go into desired state; current actual state is "
@@ -1049,7 +1061,8 @@ public class ReplicatedEnvironmentFacadeTest extends UnitTestBase
         int port = _portHelper.getNextAvailable();
         String node2NodeHostPort = host + ":" + port;
 
-        final ReplicatedEnvironmentFacade replica = createReplica(nodeName2, node2NodeHostPort, new NoopReplicationGroupListener() );
+        final ReplicatedEnvironmentFacade replica = createReplica(nodeName2, node2NodeHostPort,
+                                                                  new NoopReplicationGroupListener());
 
         // close the master
         master.close();
@@ -1087,7 +1100,8 @@ public class ReplicatedEnvironmentFacadeTest extends UnitTestBase
         int port = _portHelper.getNextAvailable();
         String node2NodeHostPort = host + ":" + port;
 
-        final ReplicatedEnvironmentFacade replica = createReplica(nodeName2, node2NodeHostPort, new NoopReplicationGroupListener() );
+        final ReplicatedEnvironmentFacade replica = createReplica(nodeName2, node2NodeHostPort,
+                                                                  new NoopReplicationGroupListener());
 
         // close the master
         master.close();
@@ -1132,8 +1146,10 @@ public class ReplicatedEnvironmentFacadeTest extends UnitTestBase
 
         master.setPermittedNodes(Arrays.asList(master.getHostPort(), node1NodeHostPort, node2NodeHostPort));
 
-        ReplicatedEnvironmentFacade replica1 = createReplica(TEST_NODE_NAME + "_1", node1NodeHostPort, new NoopReplicationGroupListener());
-        ReplicatedEnvironmentFacade replica2 = createReplica(TEST_NODE_NAME + "_2", node2NodeHostPort, new NoopReplicationGroupListener());
+        ReplicatedEnvironmentFacade replica1 = createReplica(TEST_NODE_NAME + "_1", node1NodeHostPort,
+                                                             new NoopReplicationGroupListener());
+        ReplicatedEnvironmentFacade replica2 = createReplica(TEST_NODE_NAME + "_2", node2NodeHostPort,
+                                                             new NoopReplicationGroupListener());
 
         replica1.close();
         replica2.close();
@@ -1179,7 +1195,8 @@ public class ReplicatedEnvironmentFacadeTest extends UnitTestBase
 
         master.setPermittedNodes(Arrays.asList(master.getHostPort(), replicaNodeHostPort));
 
-        ReplicatedEnvironmentFacade replica1 = createReplica(TEST_NODE_NAME + "_1", replicaNodeHostPort, new NoopReplicationGroupListener());
+        ReplicatedEnvironmentFacade replica1 = createReplica(TEST_NODE_NAME + "_1", replicaNodeHostPort,
+                                                             new NoopReplicationGroupListener());
         replica1.close();
 
         assertTrue("Node that was master did not become detached after the replica closed",
@@ -1374,7 +1391,7 @@ public class ReplicatedEnvironmentFacadeTest extends UnitTestBase
     }
     private ReplicatedEnvironmentFacade createMaster(final boolean disableCoalescing) throws Exception
     {
-        return createMaster(new NoopReplicationGroupListener(),disableCoalescing);
+        return createMaster(new NoopReplicationGroupListener(), disableCoalescing);
     }
     private ReplicatedEnvironmentFacade createMaster(ReplicationGroupListener replicationGroupListener) throws Exception
     {
@@ -1497,7 +1514,7 @@ public class ReplicatedEnvironmentFacadeTest extends UnitTestBase
         return node;
     }
 
-    class NoopReplicationGroupListener implements ReplicationGroupListener
+    static class NoopReplicationGroupListener implements ReplicationGroupListener
     {
 
         @Override

--- a/bdbstore/src/test/java/org/apache/qpid/server/virtualhostnode/berkeleydb/BDBHAVirtualHostNodeOperationalLoggingTest.java
+++ b/bdbstore/src/test/java/org/apache/qpid/server/virtualhostnode/berkeleydb/BDBHAVirtualHostNodeOperationalLoggingTest.java
@@ -186,7 +186,8 @@ public class BDBHAVirtualHostNodeOperationalLoggingTest extends UnitTestBase
 
         String expectedMessage = HighAvailabilityMessages.PRIORITY_CHANGED("10").toString();
         verify(_eventLogger).message(argThat(new LogSubjectMatcher(node1.getVirtualHostNodeLogSubject())),
-                argThat(new LogMessageMatcher(expectedMessage, HighAvailabilityMessages.PRIORITY_CHANGED_LOG_HIERARCHY)));
+                argThat(new LogMessageMatcher(expectedMessage,
+                                              HighAvailabilityMessages.PRIORITY_CHANGED_LOG_HIERARCHY)));
     }
 
     @Test
@@ -210,7 +211,8 @@ public class BDBHAVirtualHostNodeOperationalLoggingTest extends UnitTestBase
 
         String expectedMessage = HighAvailabilityMessages.QUORUM_OVERRIDE_CHANGED("1").toString();
         verify(_eventLogger).message(argThat(new LogSubjectMatcher(node1.getVirtualHostNodeLogSubject())),
-                argThat(new LogMessageMatcher(expectedMessage, HighAvailabilityMessages.QUORUM_OVERRIDE_CHANGED_LOG_HIERARCHY)));
+                argThat(new LogMessageMatcher(expectedMessage,
+                                              HighAvailabilityMessages.QUORUM_OVERRIDE_CHANGED_LOG_HIERARCHY)));
     }
 
     @Test
@@ -234,7 +236,8 @@ public class BDBHAVirtualHostNodeOperationalLoggingTest extends UnitTestBase
 
         String expectedMessage = HighAvailabilityMessages.DESIGNATED_PRIMARY_CHANGED("true").toString();
         verify(_eventLogger).message(argThat(new LogSubjectMatcher(node1.getVirtualHostNodeLogSubject())),
-                argThat(new LogMessageMatcher(expectedMessage, HighAvailabilityMessages.DESIGNATED_PRIMARY_CHANGED_LOG_HIERARCHY)));
+                argThat(new LogMessageMatcher(expectedMessage,
+                                              HighAvailabilityMessages.DESIGNATED_PRIMARY_CHANGED_LOG_HIERARCHY)));
     }
 
     @Test
@@ -413,7 +416,7 @@ public class BDBHAVirtualHostNodeOperationalLoggingTest extends UnitTestBase
         return eventLogger;
     }
 
-    class LogMessageMatcher implements ArgumentMatcher<LogMessage>
+    static class LogMessageMatcher implements ArgumentMatcher<LogMessage>
     {
         private String _expectedMessage;
         private String _expectedMessageFailureDescription = null;
@@ -444,7 +447,7 @@ public class BDBHAVirtualHostNodeOperationalLoggingTest extends UnitTestBase
         }
     }
 
-    class LogSubjectMatcher implements ArgumentMatcher<LogSubject>
+    static class LogSubjectMatcher implements ArgumentMatcher<LogSubject>
     {
         private LogSubject _logSubject;
         private String _failureDescription = null;

--- a/bdbstore/systests/src/test/java/org/apache/qpid/server/store/berkeleydb/replication/GroupBrokerAdmin.java
+++ b/bdbstore/systests/src/test/java/org/apache/qpid/server/store/berkeleydb/replication/GroupBrokerAdmin.java
@@ -476,7 +476,7 @@ public class GroupBrokerAdmin
         }
     }
 
-    private class GroupMember
+    private static class GroupMember
     {
         private final Map<String, Object> _nodeAttributes;
         private final SpawnBrokerAdmin _admin;

--- a/broker-core/src/main/java/org/apache/qpid/server/configuration/updater/TaskExecutorImpl.java
+++ b/broker-core/src/main/java/org/apache/qpid/server/configuration/updater/TaskExecutorImpl.java
@@ -224,7 +224,7 @@ public class TaskExecutorImpl implements TaskExecutor
         return contextSubject;
     }
 
-    private class TaskLoggingWrapper<T, E extends Exception> implements Task<T, E>
+    private static class TaskLoggingWrapper<T, E extends Exception> implements Task<T, E>
     {
         private final Task<T,E> _task;
 

--- a/broker-core/src/main/java/org/apache/qpid/server/exchange/DirectExchangeImpl.java
+++ b/broker-core/src/main/java/org/apache/qpid/server/exchange/DirectExchangeImpl.java
@@ -48,7 +48,7 @@ public class DirectExchangeImpl extends AbstractExchange<DirectExchangeImpl> imp
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DirectExchangeImpl.class);
 
-    private final class BindingSet
+    private static final class BindingSet
     {
         private final Map<MessageDestination, String> _unfilteredDestinations;
         private final Map<MessageDestination, FilterManagerReplacementRoutingKeyTuple> _filteredDestinations;
@@ -138,7 +138,8 @@ public class DirectExchangeImpl extends AbstractExchange<DirectExchangeImpl> imp
                 unfilteredDestinations = new HashMap<>(_unfilteredDestinations);
                 Object replacementRoutingKey = arguments == null ? null : arguments.get(BINDING_ARGUMENT_REPLACEMENT_ROUTING_KEY);
                 unfilteredDestinations.put(destination, replacementRoutingKey == null ? null : String.valueOf(replacementRoutingKey));
-                return new BindingSet(Collections.unmodifiableMap(unfilteredDestinations), Collections.unmodifiableMap(filteredDestinations));
+                return new BindingSet(Collections.unmodifiableMap(unfilteredDestinations),
+                                      Collections.unmodifiableMap(filteredDestinations));
             }
         }
 

--- a/broker-core/src/main/java/org/apache/qpid/server/exchange/FanoutExchangeImpl.java
+++ b/broker-core/src/main/java/org/apache/qpid/server/exchange/FanoutExchangeImpl.java
@@ -47,7 +47,7 @@ class FanoutExchangeImpl extends AbstractExchange<FanoutExchangeImpl> implements
 {
     private static final Logger LOGGER = LoggerFactory.getLogger(FanoutExchangeImpl.class);
 
-    private final class BindingSet
+    private static final class BindingSet
     {
         private final Map<MessageDestination, Map<BindingIdentifier, String>> _unfilteredDestinations;
         private final Map<MessageDestination, Map<BindingIdentifier, FilterManagerReplacementRoutingKeyTuple>>

--- a/broker-core/src/main/java/org/apache/qpid/server/protocol/PublishAuthorisationCache.java
+++ b/broker-core/src/main/java/org/apache/qpid/server/protocol/PublishAuthorisationCache.java
@@ -53,7 +53,7 @@ public class PublishAuthorisationCache
         _publishAuthCacheSize = publishAuthCacheSize;
     }
 
-    private final class PublishAuthKey
+    private static final class PublishAuthKey
     {
         private final MessageDestination _messageDestination;
         private final String _routingKey;

--- a/broker-core/src/main/java/org/apache/qpid/server/queue/AbstractQueue.java
+++ b/broker-core/src/main/java/org/apache/qpid/server/queue/AbstractQueue.java
@@ -3646,7 +3646,7 @@ public abstract class AbstractQueue<X extends AbstractQueue<X>>
         return !_referrers.isEmpty();
     }
 
-    private class MessageFinder implements QueueEntryVisitor
+    private static class MessageFinder implements QueueEntryVisitor
     {
         private final long _messageNumber;
         private final boolean _includeHeaders;
@@ -3679,7 +3679,7 @@ public abstract class AbstractQueue<X extends AbstractQueue<X>>
         }
     }
 
-    private class MessageContentFinder implements QueueEntryVisitor
+    private static class MessageContentFinder implements QueueEntryVisitor
     {
         private final long _messageNumber;
         private boolean _found;

--- a/broker-core/src/main/java/org/apache/qpid/server/store/BrokerStoreUpgraderAndRecoverer.java
+++ b/broker-core/src/main/java/org/apache/qpid/server/store/BrokerStoreUpgraderAndRecoverer.java
@@ -216,7 +216,7 @@ public class BrokerStoreUpgraderAndRecoverer extends AbstractConfigurationStoreU
         }
 
     }
-    private class Upgrader_2_0_to_3_0 extends StoreUpgraderPhase
+    private static class Upgrader_2_0_to_3_0 extends StoreUpgraderPhase
     {
         public Upgrader_2_0_to_3_0()
         {
@@ -304,7 +304,7 @@ public class BrokerStoreUpgraderAndRecoverer extends AbstractConfigurationStoreU
         }
 
     }
-    private class Upgrader_3_0_to_6_0 extends StoreUpgraderPhase
+    private static class Upgrader_3_0_to_6_0 extends StoreUpgraderPhase
     {
         private String _defaultVirtualHost;
         private final Set<ConfiguredObjectRecord> _knownBdbHaVirtualHostNode = new HashSet<>();
@@ -443,7 +443,7 @@ public class BrokerStoreUpgraderAndRecoverer extends AbstractConfigurationStoreU
 
     }
 
-    private class Upgrader_6_0_to_6_1 extends StoreUpgraderPhase
+    private static class Upgrader_6_0_to_6_1 extends StoreUpgraderPhase
     {
         private boolean _hasAcl = false;
         private UUID _rootRecordId;
@@ -553,7 +553,7 @@ public class BrokerStoreUpgraderAndRecoverer extends AbstractConfigurationStoreU
 
     }
 
-    private class Upgrader_6_1_to_7_0 extends StoreUpgraderPhase
+    private static class Upgrader_6_1_to_7_0 extends StoreUpgraderPhase
     {
 
         private Map<String,String> BROKER_ATTRIBUTES_MOVED_INTO_CONTEXT = new HashMap<>();
@@ -688,7 +688,7 @@ public class BrokerStoreUpgraderAndRecoverer extends AbstractConfigurationStoreU
         }
     }
 
-    private class Upgrader_7_0_to_7_1 extends StoreUpgraderPhase
+    private static class Upgrader_7_0_to_7_1 extends StoreUpgraderPhase
     {
 
         public Upgrader_7_0_to_7_1()
@@ -712,7 +712,7 @@ public class BrokerStoreUpgraderAndRecoverer extends AbstractConfigurationStoreU
         }
     }
 
-    private class Upgrader_7_1_to_8_0 extends StoreUpgraderPhase
+    private static class Upgrader_7_1_to_8_0 extends StoreUpgraderPhase
     {
 
         public Upgrader_7_1_to_8_0()

--- a/broker-core/src/main/java/org/apache/qpid/server/store/VirtualHostStoreUpgraderAndRecoverer.java
+++ b/broker-core/src/main/java/org/apache/qpid/server/store/VirtualHostStoreUpgraderAndRecoverer.java
@@ -248,7 +248,7 @@ public class VirtualHostStoreUpgraderAndRecoverer extends AbstractConfigurationS
      * Convert the storage of queue attributes to remove the separate "ARGUMENT" attribute, and flatten the
      * attributes into the map using the model attribute names rather than the wire attribute names
      */
-    private class Upgrader_0_2_to_0_3 extends StoreUpgraderPhase
+    private static class Upgrader_0_2_to_0_3 extends StoreUpgraderPhase
     {
         private static final String ARGUMENTS = "arguments";
 
@@ -354,7 +354,7 @@ public class VirtualHostStoreUpgraderAndRecoverer extends AbstractConfigurationS
      * where exclusive was false it will now be "NONE", and where true it will now be "CONTAINER"
      * ensure OWNER is null unless the exclusivity policy is CONTAINER
      */
-    private class Upgrader_0_3_to_0_4 extends StoreUpgraderPhase
+    private static class Upgrader_0_3_to_0_4 extends StoreUpgraderPhase
     {
         private static final String EXCLUSIVE = "exclusive";
 
@@ -537,7 +537,7 @@ public class VirtualHostStoreUpgraderAndRecoverer extends AbstractConfigurationS
 
     }
 
-    private class Upgrader_2_0_to_3_0 extends StoreUpgraderPhase
+    private static class Upgrader_2_0_to_3_0 extends StoreUpgraderPhase
     {
         public Upgrader_2_0_to_3_0()
         {
@@ -560,7 +560,7 @@ public class VirtualHostStoreUpgraderAndRecoverer extends AbstractConfigurationS
         }
 
     }
-    private class Upgrader_3_0_to_6_0 extends StoreUpgraderPhase
+    private static class Upgrader_3_0_to_6_0 extends StoreUpgraderPhase
     {
         public Upgrader_3_0_to_6_0()
         {
@@ -584,7 +584,7 @@ public class VirtualHostStoreUpgraderAndRecoverer extends AbstractConfigurationS
 
     }
 
-    private class Upgrader_6_0_to_6_1 extends StoreUpgraderPhase
+    private static class Upgrader_6_0_to_6_1 extends StoreUpgraderPhase
     {
         public Upgrader_6_0_to_6_1()
         {
@@ -1040,7 +1040,7 @@ public class VirtualHostStoreUpgraderAndRecoverer extends AbstractConfigurationS
     }
 
 
-    private class Upgrader_7_0_to_7_1 extends StoreUpgraderPhase
+    private static class Upgrader_7_0_to_7_1 extends StoreUpgraderPhase
     {
 
         public Upgrader_7_0_to_7_1()
@@ -1064,7 +1064,7 @@ public class VirtualHostStoreUpgraderAndRecoverer extends AbstractConfigurationS
         }
     }
 
-    private class Upgrader_7_1_to_8_0 extends StoreUpgraderPhase
+    private static class Upgrader_7_1_to_8_0 extends StoreUpgraderPhase
     {
 
         public Upgrader_7_1_to_8_0()

--- a/broker-core/src/main/java/org/apache/qpid/server/virtualhost/AbstractVirtualHost.java
+++ b/broker-core/src/main/java/org/apache/qpid/server/virtualhost/AbstractVirtualHost.java
@@ -3322,7 +3322,7 @@ public abstract class AbstractVirtualHost<X extends AbstractVirtualHost<X>> exte
         }
     }
 
-    private class StoreEmptyCheckingHandler
+    private static class StoreEmptyCheckingHandler
             implements MessageHandler, MessageInstanceHandler, DistributedTransactionHandler
     {
         private boolean _empty = true;

--- a/broker-core/src/test/java/org/apache/qpid/server/exchange/HeadersBindingTest.java
+++ b/broker-core/src/test/java/org/apache/qpid/server/exchange/HeadersBindingTest.java
@@ -50,7 +50,7 @@ public class HeadersBindingTest extends UnitTestBase
 {
 
 
-    private class MockHeader implements AMQMessageHeader
+    private static class MockHeader implements AMQMessageHeader
     {
 
         private final Map<String, Object> _headers = new HashMap<String, Object>();

--- a/broker-core/src/test/java/org/apache/qpid/server/model/preferences/UserPreferencesTest.java
+++ b/broker-core/src/test/java/org/apache/qpid/server/model/preferences/UserPreferencesTest.java
@@ -222,7 +222,7 @@ public class UserPreferencesTest extends UnitTestBase
         return queryPreference;
     }
 
-    private class UUIDCollectionMatcher implements ArgumentMatcher<Collection<UUID>>
+    private static class UUIDCollectionMatcher implements ArgumentMatcher<Collection<UUID>>
     {
         private Collection<UUID> _expected;
         private String _failureDescription;
@@ -240,7 +240,7 @@ public class UserPreferencesTest extends UnitTestBase
         }
     }
 
-    private class PreferenceRecordMatcher implements ArgumentMatcher<Collection<PreferenceRecord>>
+    private static class PreferenceRecordMatcher implements ArgumentMatcher<Collection<PreferenceRecord>>
     {
         private final Preference _preference;
 

--- a/broker-core/src/test/java/org/apache/qpid/server/model/testmodels/lifecycle/AbstractConfiguredObjectTest.java
+++ b/broker-core/src/test/java/org/apache/qpid/server/model/testmodels/lifecycle/AbstractConfiguredObjectTest.java
@@ -357,13 +357,21 @@ public class AbstractConfiguredObjectTest extends UnitTestBase
             @Override
             public void attributeSet(ConfiguredObject<?> object, String attributeName, Object oldAttributeValue, Object newAttributeValue)
             {
-                events.add(new ChangeEvent(EventType.ATTRIBUTE_SET, object, attributeName, oldAttributeValue, newAttributeValue));
+                events.add(new ChangeEvent(EventType.ATTRIBUTE_SET,
+                                           object,
+                                           attributeName,
+                                           oldAttributeValue,
+                                           newAttributeValue));
             }
 
             @Override
             public void stateChanged(ConfiguredObject<?> object, State oldState, State newState)
             {
-                events.add(new ChangeEvent(EventType.STATE_CHANGED, object, ConfiguredObject.DESIRED_STATE, oldState, newState));
+                events.add(new ChangeEvent(EventType.STATE_CHANGED,
+                                           object,
+                                           ConfiguredObject.DESIRED_STATE,
+                                           oldState,
+                                           newState));
             }
         });
 
@@ -377,11 +385,19 @@ public class AbstractConfiguredObjectTest extends UnitTestBase
         ChangeEvent event1 = events.get(1);
 
         assertEquals("Unexpected first event: " + event0,
-                            new ChangeEvent(EventType.STATE_CHANGED, configuredObject, Exchange.DESIRED_STATE, State.ACTIVE, State.DELETED),
+                     new ChangeEvent(EventType.STATE_CHANGED,
+                                     configuredObject,
+                                     Exchange.DESIRED_STATE,
+                                     State.ACTIVE,
+                                     State.DELETED),
                             event0);
 
         assertEquals("Unexpected second event: " + event1,
-                            new ChangeEvent(EventType.ATTRIBUTE_SET, configuredObject, Exchange.DESIRED_STATE, State.ACTIVE, State.DELETED),
+                     new ChangeEvent(EventType.ATTRIBUTE_SET,
+                                     configuredObject,
+                                     Exchange.DESIRED_STATE,
+                                     State.ACTIVE,
+                                     State.DELETED),
                             event1);
     }
 
@@ -391,7 +407,7 @@ public class AbstractConfiguredObjectTest extends UnitTestBase
         STATE_CHANGED
     }
 
-    private class ChangeEvent
+    private static class ChangeEvent
     {
         private final ConfiguredObject<?> _source;
         private final String _attributeName;

--- a/broker-core/src/test/java/org/apache/qpid/server/queue/QueueMessageRecoveryTest.java
+++ b/broker-core/src/test/java/org/apache/qpid/server/queue/QueueMessageRecoveryTest.java
@@ -62,7 +62,7 @@ public class QueueMessageRecoveryTest extends UnitTestBase
         // Simple deterministic test to prove that interleaved recovery and new publishing onto a queue is correctly
         // handled
         final List<ServerMessage<?>> messageList = new ArrayList<>();
-        TestQueue queue = new TestQueue(Collections.singletonMap(Queue.NAME, (Object)"test"), _vhost, messageList);
+        TestQueue queue = new TestQueue(Collections.singletonMap(Queue.NAME, (Object) "test"), _vhost, messageList);
 
         queue.open();
 
@@ -118,7 +118,8 @@ public class QueueMessageRecoveryTest extends UnitTestBase
     {
 
         final List<ServerMessage<?>> messageList = new ArrayList<>();
-        final TestQueue queue = new TestQueue(Collections.singletonMap(Queue.NAME, (Object) "test"), _vhost, messageList);
+        final TestQueue queue =
+                new TestQueue(Collections.singletonMap(Queue.NAME, (Object) "test"), _vhost, messageList);
 
         queue.open();
 
@@ -195,7 +196,7 @@ public class QueueMessageRecoveryTest extends UnitTestBase
         return msg;
     }
 
-    private class TestQueue extends AbstractQueue<TestQueue>
+    private static class TestQueue extends AbstractQueue<TestQueue>
     {
 
         private final List<ServerMessage<?>> _messageList;

--- a/broker-core/src/test/java/org/apache/qpid/server/session/AbstractAMQPSessionTest.java
+++ b/broker-core/src/test/java/org/apache/qpid/server/session/AbstractAMQPSessionTest.java
@@ -80,7 +80,7 @@ public class AbstractAMQPSessionTest extends UnitTestBase
         when(_connection.getAddressSpace()).thenReturn((VirtualHost)_virtualHost);
         when(_connection.getContextValue(Long.class, Session.PRODUCER_AUTH_CACHE_TIMEOUT)).thenReturn(Session.PRODUCER_AUTH_CACHE_TIMEOUT_DEFAULT);
         when(_connection.getContextValue(Integer.class, Session.PRODUCER_AUTH_CACHE_SIZE)).thenReturn(Session.PRODUCER_AUTH_CACHE_SIZE_DEFAULT);
-        mockAMQPSession = new MockAMQPSession(_connection,123);
+        mockAMQPSession = new MockAMQPSession(_connection, 123);
 
     }
 
@@ -132,7 +132,7 @@ public class AbstractAMQPSessionTest extends UnitTestBase
         verify(_connection).registerTransactedMessageReceived();
     }
 
-    private class MockAMQPSession extends AbstractAMQPSession{
+    private static class MockAMQPSession extends AbstractAMQPSession{
 
         protected MockAMQPSession(final Connection parent, final int sessionId)
         {

--- a/broker-core/src/test/java/org/apache/qpid/server/store/BrokerStoreUpgraderAndRecovererTest.java
+++ b/broker-core/src/test/java/org/apache/qpid/server/store/BrokerStoreUpgraderAndRecovererTest.java
@@ -742,7 +742,8 @@ public class BrokerStoreUpgraderAndRecovererTest extends UnitTestBase
                                                                             trustStoreAttributes3,
                                                                             parents);
 
-        DurableConfigurationStore dcs = new DurableConfigurationStoreStub(_brokerRecord, trustStore1, trustStore2, trustStore3);
+        DurableConfigurationStore dcs =
+                new DurableConfigurationStoreStub(_brokerRecord, trustStore1, trustStore2, trustStore3);
         BrokerStoreUpgraderAndRecoverer recoverer = new BrokerStoreUpgraderAndRecoverer(_systemConfig);
         List<ConfiguredObjectRecord> records = upgrade(dcs, recoverer);
 
@@ -802,7 +803,8 @@ public class BrokerStoreUpgraderAndRecovererTest extends UnitTestBase
                                                                            jmxPluginAttributes,
                                                                            parents);
 
-        DurableConfigurationStore dcs = new DurableConfigurationStoreStub(_brokerRecord, jmxPort, rmiPort, jmxManagement);
+        DurableConfigurationStore dcs =
+                new DurableConfigurationStoreStub(_brokerRecord, jmxPort, rmiPort, jmxManagement);
 
         BrokerStoreUpgraderAndRecoverer recoverer = new BrokerStoreUpgraderAndRecoverer(_systemConfig);
         List<ConfiguredObjectRecord> records = upgrade(dcs, recoverer);
@@ -1071,7 +1073,7 @@ public class BrokerStoreUpgraderAndRecovererTest extends UnitTestBase
         return results;
     }
 
-    class DurableConfigurationStoreStub implements DurableConfigurationStore
+    static class DurableConfigurationStoreStub implements DurableConfigurationStore
     {
         private ConfiguredObjectRecord[] records;
 
@@ -1140,7 +1142,7 @@ public class BrokerStoreUpgraderAndRecovererTest extends UnitTestBase
         }
     }
 
-    private class RecordRetrievingConfiguredObjectRecordHandler implements ConfiguredObjectRecordHandler
+    private static class RecordRetrievingConfiguredObjectRecordHandler implements ConfiguredObjectRecordHandler
     {
         private List<ConfiguredObjectRecord> _records = new ArrayList<>();
 

--- a/broker-core/src/test/java/org/apache/qpid/server/store/MessageStoreTestCase.java
+++ b/broker-core/src/test/java/org/apache/qpid/server/store/MessageStoreTestCase.java
@@ -139,7 +139,8 @@ public abstract class MessageStoreTestCase extends UnitTestBase
 
         DistributedTransactionHandler handler = mock(DistributedTransactionHandler.class);
         _storeReader.visitDistributedTransactions(handler);
-        verify(handler, times(1)).handle(eq(record), argThat(new RecordMatcher(enqueues)), argThat(new DequeueRecordMatcher(dequeues)));
+        verify(handler, times(1)).handle(eq(record), argThat(new RecordMatcher(enqueues)), argThat(new DequeueRecordMatcher(
+                dequeues)));
 
         transaction = _store.newTransaction();
         transaction.removeXid(record);
@@ -149,7 +150,8 @@ public abstract class MessageStoreTestCase extends UnitTestBase
 
         handler = mock(DistributedTransactionHandler.class);
         _storeReader.visitDistributedTransactions(handler);
-        verify(handler, never()).handle(eq(record), argThat(new RecordMatcher(enqueues)), argThat(new DequeueRecordMatcher(dequeues)));
+        verify(handler, never()).handle(eq(record), argThat(new RecordMatcher(enqueues)), argThat(new DequeueRecordMatcher(
+                dequeues)));
     }
 
     @Test
@@ -589,7 +591,7 @@ public abstract class MessageStoreTestCase extends UnitTestBase
         return enqueueableMessage1;
     }
 
-    private class MessageMetaDataMatcher implements ArgumentMatcher<StoredMessage<?>>
+    private static class MessageMetaDataMatcher implements ArgumentMatcher<StoredMessage<?>>
     {
         private long _messageNumber;
 
@@ -606,7 +608,7 @@ public abstract class MessageStoreTestCase extends UnitTestBase
         }
     }
 
-    private class QueueFilteringMessageInstanceHandler implements MessageInstanceHandler
+    private static class QueueFilteringMessageInstanceHandler implements MessageInstanceHandler
     {
         private final UUID _queueId;
         private final Set<Long> _enqueuedIds = new HashSet<>();
@@ -637,7 +639,7 @@ public abstract class MessageStoreTestCase extends UnitTestBase
         }
     }
 
-    private class EnqueueRecordMatcher implements ArgumentMatcher<MessageEnqueueRecord>
+    private static class EnqueueRecordMatcher implements ArgumentMatcher<MessageEnqueueRecord>
     {
         private final UUID _queueId;
         private final long _messageId;
@@ -656,7 +658,7 @@ public abstract class MessageStoreTestCase extends UnitTestBase
     }
 
 
-    private class RecordMatcher implements ArgumentMatcher<Transaction.EnqueueRecord[]>
+    private static class RecordMatcher implements ArgumentMatcher<Transaction.EnqueueRecord[]>
     {
 
         private final EnqueueRecord[] _expect;
@@ -689,7 +691,7 @@ public abstract class MessageStoreTestCase extends UnitTestBase
         }
     }
 
-    private class DequeueRecordMatcher implements ArgumentMatcher<Transaction.DequeueRecord[]>
+    private static class DequeueRecordMatcher implements ArgumentMatcher<Transaction.DequeueRecord[]>
     {
 
         private final Transaction.DequeueRecord[] _expect;

--- a/broker-core/src/test/java/org/apache/qpid/server/virtualhost/SynchronousMessageStoreRecovererTest.java
+++ b/broker-core/src/test/java/org/apache/qpid/server/virtualhost/SynchronousMessageStoreRecovererTest.java
@@ -185,7 +185,7 @@ public class SynchronousMessageStoreRecovererTest extends UnitTestBase
                 recoverer = new SynchronousMessageStoreRecoverer();
         recoverer.recover(_virtualHost);
 
-        verify(transaction).dequeueMessage(argThat(new MessageEnqueueRecordMatcher(queueId,messageId)));
+        verify(transaction).dequeueMessage(argThat(new MessageEnqueueRecordMatcher(queueId, messageId)));
         verify(transaction, times(1)).commitTranAsync((Void) null);
     }
 
@@ -450,7 +450,7 @@ public class SynchronousMessageStoreRecovererTest extends UnitTestBase
     }
 
 
-    private final class MessageEnqueueRecordMatcher implements ArgumentMatcher<MessageEnqueueRecord>
+    private static final class MessageEnqueueRecordMatcher implements ArgumentMatcher<MessageEnqueueRecord>
     {
         private final long _messageId;
         private final UUID _queueId;
@@ -469,7 +469,7 @@ public class SynchronousMessageStoreRecovererTest extends UnitTestBase
         }
     }
 
-    private class TestMessageEnqueueRecord implements MessageEnqueueRecord
+    private static class TestMessageEnqueueRecord implements MessageEnqueueRecord
     {
         private final UUID _queueId;
         private final long _messageId;

--- a/broker-core/src/test/java/org/apache/qpid/server/virtualhostnode/AbstractStandardVirtualHostNodeTest.java
+++ b/broker-core/src/test/java/org/apache/qpid/server/virtualhostnode/AbstractStandardVirtualHostNodeTest.java
@@ -456,7 +456,7 @@ public class AbstractStandardVirtualHostNodeTest extends UnitTestBase
         Map<String, Object> attributes = Collections.<String, Object>singletonMap(TestVirtualHostNode.NAME, nodeName);
 
         DurableConfigurationStore store = mock(DurableConfigurationStore.class);
-        AbstractVirtualHostNode node = new TestAbstractVirtualHostNode( _broker, attributes, store);
+        AbstractVirtualHostNode node = new TestAbstractVirtualHostNode(_broker, attributes, store);
         node.open();
         assertEquals("Unexpected node state", State.ERRORED, node.getState());
         node.close();
@@ -607,7 +607,7 @@ public class AbstractStandardVirtualHostNodeTest extends UnitTestBase
         };
     }
 
-    private class TestAbstractVirtualHostNode extends AbstractVirtualHostNode
+    private static class TestAbstractVirtualHostNode extends AbstractVirtualHostNode
     {
         private DurableConfigurationStore _store;
 

--- a/broker-plugins/amqp-0-8-protocol/src/main/java/org/apache/qpid/server/protocol/v0_8/ProtocolOutputConverterImpl.java
+++ b/broker-plugins/amqp-0-8-protocol/src/main/java/org/apache/qpid/server/protocol/v0_8/ProtocolOutputConverterImpl.java
@@ -208,7 +208,7 @@ public class ProtocolOutputConverterImpl implements ProtocolOutputConverter
         return GZIP_ENCODING.equals(contentHeaderBody.getProperties().getEncoding());
     }
 
-    private class MessageContentSourceBody implements AMQBody
+    private static class MessageContentSourceBody implements AMQBody
     {
         public static final byte TYPE = 3;
         private final int _length;

--- a/broker-plugins/amqp-0-8-protocol/src/test/java/org/apache/qpid/server/QpidExceptionTest.java
+++ b/broker-plugins/amqp-0-8-protocol/src/test/java/org/apache/qpid/server/QpidExceptionTest.java
@@ -122,7 +122,7 @@ public class QpidExceptionTest extends UnitTestBase
     /**
      * Private class that extends AMQException but does not have a default exception.
      */
-    private class AMQExceptionSubclass extends QpidException
+    private static class AMQExceptionSubclass extends QpidException
     {
 
         public AMQExceptionSubclass(String msg)

--- a/broker-plugins/amqp-1-0-protocol/src/main/java/org/apache/qpid/server/protocol/v1_0/ConsumerTarget_1_0.java
+++ b/broker-plugins/amqp-1-0-protocol/src/main/java/org/apache/qpid/server/protocol/v1_0/ConsumerTarget_1_0.java
@@ -701,7 +701,7 @@ class ConsumerTarget_1_0 extends AbstractConsumerTarget<ConsumerTarget_1_0>
         _unacknowledgedCount.decrementAndGet();
     }
 
-    private class DoNothingAction implements UnsettledAction
+    private static class DoNothingAction implements UnsettledAction
     {
         public DoNothingAction()
         {

--- a/broker-plugins/amqp-1-0-protocol/src/main/java/org/apache/qpid/server/protocol/v1_0/type/messaging/codec/AmqpValueSectionConstructor.java
+++ b/broker-plugins/amqp-1-0-protocol/src/main/java/org/apache/qpid/server/protocol/v1_0/type/messaging/codec/AmqpValueSectionConstructor.java
@@ -64,7 +64,7 @@ public class AmqpValueSectionConstructor implements DescribedTypeConstructor<Amq
     }
 
 
-    private class LazyConstructor extends AbstractLazyConstructor<AmqpValueSection>
+    private static class LazyConstructor extends AbstractLazyConstructor<AmqpValueSection>
     {
         LazyConstructor(final int originalPosition)
         {

--- a/broker-plugins/amqp-1-0-protocol/src/main/java/org/apache/qpid/server/protocol/v1_0/type/messaging/codec/DataSectionConstructor.java
+++ b/broker-plugins/amqp-1-0-protocol/src/main/java/org/apache/qpid/server/protocol/v1_0/type/messaging/codec/DataSectionConstructor.java
@@ -84,7 +84,7 @@ public class DataSectionConstructor implements DescribedTypeConstructor<DataSect
     }
 
 
-    private class LazyConstructor extends AbstractLazyConstructor<DataSection>
+    private static class LazyConstructor extends AbstractLazyConstructor<DataSection>
     {
         private final int _sizeBytes;
 

--- a/broker-plugins/management-http/src/main/java/org/apache/qpid/server/management/plugin/auth/OAuth2InteractiveAuthenticator.java
+++ b/broker-plugins/management-http/src/main/java/org/apache/qpid/server/management/plugin/auth/OAuth2InteractiveAuthenticator.java
@@ -103,7 +103,9 @@ public class OAuth2InteractiveAuthenticator implements HttpRequestInteractiveAut
             }
             catch (IllegalArgumentException e)
             {
-                return new FailedAuthenticationHandler(400, "Some request parameters are included more than once " + request, e);
+                return new FailedAuthenticationHandler(400,
+                                                       "Some request parameters are included more than once " + request,
+                                                       e);
             }
 
             String error = requestParameters.get("error");
@@ -121,7 +123,8 @@ public class OAuth2InteractiveAuthenticator implements HttpRequestInteractiveAut
                 {
                     LOGGER.warn("Authorization endpoint failed, error : '{}', error description '{}'",
                                 error, errorDescription);
-                    return new FailedAuthenticationHandler(responseCode, String.format("Authorization request failed :'%s'", error));
+                    return new FailedAuthenticationHandler(responseCode,
+                                                           String.format("Authorization request failed :'%s'", error));
                 }
             }
 
@@ -145,7 +148,8 @@ public class OAuth2InteractiveAuthenticator implements HttpRequestInteractiveAut
                 if (state == null)
                 {
                     LOGGER.warn("Deny login attempt with wrong state: {}", state);
-                    return new FailedAuthenticationHandler(400, "No state set on request with authorization code grant: "
+                    return new FailedAuthenticationHandler(400,
+                                                           "No state set on request with authorization code grant: "
                                                            + request);
                 }
                 if (!checkState(request, state))
@@ -359,7 +363,7 @@ public class OAuth2InteractiveAuthenticator implements HttpRequestInteractiveAut
         return ERROR_RESPONSES.containsKey(error) ? ERROR_RESPONSES.get(error) : 500;
     }
 
-    class FailedAuthenticationHandler implements AuthenticationHandler
+    static class FailedAuthenticationHandler implements AuthenticationHandler
     {
         private final int _errorCode;
         private final Throwable _throwable;

--- a/broker-plugins/management-http/src/main/java/org/apache/qpid/server/management/plugin/servlet/query/ConfiguredObjectQuery.java
+++ b/broker-plugins/management-http/src/main/java/org/apache/qpid/server/management/plugin/servlet/query/ConfiguredObjectQuery.java
@@ -261,7 +261,7 @@ public final class ConfiguredObjectQuery
     }
 
 
-    class OrderByComparator implements Comparator<Object>
+    static class OrderByComparator implements Comparator<Object>
     {
         private final List<OrderByExpression> _orderByExpressions;
 
@@ -339,7 +339,8 @@ public final class ConfiguredObjectQuery
         List<OrderByExpression> orderByExpressions = parseOrderByClause(orderByClause, headersAndValue);
         List<ConfiguredObject<?>> orderedObjects = new ArrayList<>(unorderedResults.size());
         orderedObjects.addAll(unorderedResults);
-        Comparator<Object> comparator = new OrderByComparator(orderByExpressions, headersAndValue.getValueExpressions());
+        Comparator<Object> comparator =
+                new OrderByComparator(orderByExpressions, headersAndValue.getValueExpressions());
         Collections.sort(orderedObjects, comparator);
         return orderedObjects;
     }

--- a/perftests/src/main/java/org/apache/qpid/disttest/controller/HillClimber.java
+++ b/perftests/src/main/java/org/apache/qpid/disttest/controller/HillClimber.java
@@ -66,7 +66,7 @@ public class HillClimber
         double nextLower();
     }
 
-    private abstract class AbstractStepPolicy implements StepPolicy
+    private abstract static class AbstractStepPolicy implements StepPolicy
     {
         protected double _value;
         protected double _stepSize;

--- a/perftests/src/test/java/org/apache/qpid/disttest/VisitorTest.java
+++ b/perftests/src/test/java/org/apache/qpid/disttest/VisitorTest.java
@@ -85,7 +85,7 @@ public class VisitorTest extends UnitTestBase
         }
     }
 
-    class TestVisitor extends Visitor
+    static class TestVisitor extends Visitor
     {
         String _string = null;
         TestCommand _testCommand = null;
@@ -101,7 +101,7 @@ public class VisitorTest extends UnitTestBase
         }
     }
 
-    class TestCommand extends Command
+    static class TestCommand extends Command
     {
 
         public TestCommand()

--- a/perftests/src/test/java/org/apache/qpid/disttest/client/ParticipantExecutorTest.java
+++ b/perftests/src/test/java/org/apache/qpid/disttest/client/ParticipantExecutorTest.java
@@ -79,7 +79,7 @@ public class ParticipantExecutorTest extends UnitTestBase
     }
 
     /** avoids our unit test needing to use multiple threads */
-    private final class SynchronousExecutor implements Executor
+    private static final class SynchronousExecutor implements Executor
     {
         @Override
         public void execute(Runnable command)

--- a/perftests/visualisation-jfc/src/main/java/org/apache/qpid/disttest/charting/definition/ChartingDefinitionCreator.java
+++ b/perftests/visualisation-jfc/src/main/java/org/apache/qpid/disttest/charting/definition/ChartingDefinitionCreator.java
@@ -139,7 +139,7 @@ public class ChartingDefinitionCreator
         return _seriesDefinitionCreator.createFromProperties(props);
     }
 
-    private final class CHARTDEF_FILE_FILTER implements FileFilter
+    private static final class CHARTDEF_FILE_FILTER implements FileFilter
     {
         @Override
         public boolean accept(File pathname)

--- a/perftests/visualisation-jfc/src/test/java/org/apache/qpid/disttest/charting/chartbuilder/ChartProductionTest.java
+++ b/perftests/visualisation-jfc/src/test/java/org/apache/qpid/disttest/charting/chartbuilder/ChartProductionTest.java
@@ -124,7 +124,8 @@ public class ChartProductionTest extends UnitTestBase
     @Test
     public void testBarChart() throws Exception
     {
-        ChartBuilder builder = ChartBuilderFactory.createChartBuilder(ChartType.BAR, new SampleSeriesBuilder(SIMPLE_SERIES_ROWS));
+        ChartBuilder builder = ChartBuilderFactory.createChartBuilder(ChartType.BAR,
+                                                                      new SampleSeriesBuilder(SIMPLE_SERIES_ROWS));
         assertChartTitlesAndWriteToFile(builder);
     }
 
@@ -236,7 +237,7 @@ public class ChartProductionTest extends UnitTestBase
         _writer.writeChartToFileSystem(chart, _chartingDefinition);
     }
 
-    private class SampleSeriesBuilder implements SeriesBuilder
+    private static class SampleSeriesBuilder implements SeriesBuilder
     {
         private DatasetHolder _datasetHolder;
         private SeriesRow[] _sampleSeriesRows = SIMPLE_SERIES_ROWS;

--- a/systests/protocol-tests-amqp-0-10/src/test/java/org/apache/qpid/tests/protocol/v0_10/extensions/message/MalformedMessageTest.java
+++ b/systests/protocol-tests-amqp-0-10/src/test/java/org/apache/qpid/tests/protocol/v0_10/extensions/message/MalformedMessageTest.java
@@ -111,7 +111,7 @@ public class MalformedMessageTest extends BrokerAdminUsingTestBase
         }
     }
 
-    private class TestMessageTransfer extends Method
+    private static class TestMessageTransfer extends Method
     {
         short packingFlags;
         private String destination;

--- a/systests/protocol-tests-amqp-1-0/src/main/java/org/apache/qpid/tests/protocol/v1_0/extensions/websocket/WebSocketFrameTransport.java
+++ b/systests/protocol-tests-amqp-1-0/src/main/java/org/apache/qpid/tests/protocol/v1_0/extensions/websocket/WebSocketFrameTransport.java
@@ -93,7 +93,7 @@ public class WebSocketFrameTransport extends FrameTransport
         return this;
     }
 
-    private class WebSocketFramingOutputHandler extends ChannelOutboundHandlerAdapter
+    private static class WebSocketFramingOutputHandler extends ChannelOutboundHandlerAdapter
     {
         private boolean _splitFrames;
 
@@ -141,7 +141,7 @@ public class WebSocketFrameTransport extends FrameTransport
         }
     }
 
-    private class WebSocketDeframingInputHandler extends ChannelInboundHandlerAdapter
+    private static class WebSocketDeframingInputHandler extends ChannelInboundHandlerAdapter
     {
         @Override
         public void channelRead(ChannelHandlerContext ctx, Object msg)
@@ -164,7 +164,7 @@ public class WebSocketFrameTransport extends FrameTransport
         }
     }
 
-    public class WebSocketClientHandler extends SimpleChannelInboundHandler<Object>
+    public static class WebSocketClientHandler extends SimpleChannelInboundHandler<Object>
     {
 
         private final WebSocketClientHandshaker _handshaker;

--- a/systests/protocol-tests-core/src/main/java/org/apache/qpid/tests/protocol/OutputHandler.java
+++ b/systests/protocol-tests-core/src/main/java/org/apache/qpid/tests/protocol/OutputHandler.java
@@ -116,7 +116,7 @@ public class OutputHandler extends ChannelOutboundHandlerAdapter
         super.flush(ctx);
     }
 
-    class ByteBufferPromisePair
+    static class ByteBufferPromisePair
     {
         private ByteBuffer byteBuffer;
         private ChannelPromise channelPromise;

--- a/systests/qpid-systests-jms_1.1/src/test/java/org/apache/qpid/systests/jms_1_1/connection/AbruptClientDisconnectTest.java
+++ b/systests/qpid-systests-jms_1.1/src/test/java/org/apache/qpid/systests/jms_1_1/connection/AbruptClientDisconnectTest.java
@@ -285,7 +285,7 @@ public class AbruptClientDisconnectTest extends JmsTestBase
         }
     }
 
-    private class ClientMonitor implements TCPTunneler.TunnelListener
+    private static class ClientMonitor implements TCPTunneler.TunnelListener
     {
         private final CountDownLatch _closeLatch = new CountDownLatch(1);
 

--- a/systests/qpid-systests-jms_1.1/src/test/java/org/apache/qpid/systests/jms_1_1/messagelistener/MessageListenerTest.java
+++ b/systests/qpid-systests-jms_1.1/src/test/java/org/apache/qpid/systests/jms_1_1/messagelistener/MessageListenerTest.java
@@ -114,7 +114,8 @@ public class MessageListenerTest extends JmsTestBase
 
             final MessageConsumer consumer = session.createConsumer(queue);
             final int messageToReceivedBeforeConnectionStop = MSG_COUNT / 2;
-            CountingMessageListener countingMessageListener = new CountingMessageListener(MSG_COUNT, messageToReceivedBeforeConnectionStop);
+            CountingMessageListener countingMessageListener =
+                    new CountingMessageListener(MSG_COUNT, messageToReceivedBeforeConnectionStop);
             consumer.setMessageListener(countingMessageListener);
 
             countingMessageListener.awaitMessages(getReceiveTimeout());
@@ -148,7 +149,8 @@ public class MessageListenerTest extends JmsTestBase
 
             final MessageConsumer consumer = session.createConsumer(queue);
             final int messageToReceivedBeforeConnectionStop = MSG_COUNT / 2;
-            CountingMessageListener countingMessageListener1 = new CountingMessageListener(MSG_COUNT, messageToReceivedBeforeConnectionStop);
+            CountingMessageListener countingMessageListener1 =
+                    new CountingMessageListener(MSG_COUNT, messageToReceivedBeforeConnectionStop);
             consumer.setMessageListener(countingMessageListener1);
 
             countingMessageListener1.awaitMessages(getReceiveTimeout());
@@ -156,7 +158,8 @@ public class MessageListenerTest extends JmsTestBase
             connection.stop();
             assertTrue("Too few messages received after Connection#stop()", countingMessageListener1.getReceivedCount() >= messageToReceivedBeforeConnectionStop);
 
-            CountingMessageListener countingMessageListener2 = new CountingMessageListener(countingMessageListener1.getOutstandingCount());
+            CountingMessageListener countingMessageListener2 =
+                    new CountingMessageListener(countingMessageListener1.getOutstandingCount());
 
             consumer.setMessageListener(countingMessageListener2);
             connection.start();
@@ -184,7 +187,8 @@ public class MessageListenerTest extends JmsTestBase
 
             final MessageConsumer consumer = session.createConsumer(queue);
             final int messageToReceivedBeforeConnectionStop = MSG_COUNT / 2;
-            CountingMessageListener countingMessageListener = new CountingMessageListener(MSG_COUNT, messageToReceivedBeforeConnectionStop);
+            CountingMessageListener countingMessageListener =
+                    new CountingMessageListener(MSG_COUNT, messageToReceivedBeforeConnectionStop);
             consumer.setMessageListener(countingMessageListener);
 
             countingMessageListener.awaitMessages(getReceiveTimeout());
@@ -216,7 +220,8 @@ public class MessageListenerTest extends JmsTestBase
 
             final MessageConsumer consumer = session.createConsumer(queue);
             final int messageToReceivedBeforeConnectionStop = MSG_COUNT / 2;
-            CountingMessageListener countingMessageListener = new CountingMessageListener(MSG_COUNT, messageToReceivedBeforeConnectionStop);
+            CountingMessageListener countingMessageListener =
+                    new CountingMessageListener(MSG_COUNT, messageToReceivedBeforeConnectionStop);
             consumer.setMessageListener(countingMessageListener);
 
             countingMessageListener.awaitMessages(getReceiveTimeout());
@@ -295,7 +300,7 @@ public class MessageListenerTest extends JmsTestBase
         }
     }
 
-    private final class CountingMessageListener implements MessageListener
+    private static final class CountingMessageListener implements MessageListener
     {
         private final AtomicInteger _receivedCount;
         private final AtomicInteger _outstandingMessageCount;

--- a/systests/qpid-systests-spawn-admin/src/main/java/org/apache/qpid/systests/admin/SpawnBrokerAdmin.java
+++ b/systests/qpid-systests-spawn-admin/src/main/java/org/apache/qpid/systests/admin/SpawnBrokerAdmin.java
@@ -904,7 +904,7 @@ public class SpawnBrokerAdmin implements BrokerAdmin, Closeable
         }
     }
 
-    private final class BrokerSystemOutputHandler implements Runnable
+    private static final class BrokerSystemOutputHandler implements Runnable
     {
         private final Logger LOGGER = LoggerFactory.getLogger(BrokerSystemOutputHandler.class);
 

--- a/tools/src/main/java/org/apache/qpid/tools/MemoryConsumptionTestClient.java
+++ b/tools/src/main/java/org/apache/qpid/tools/MemoryConsumptionTestClient.java
@@ -478,7 +478,7 @@ public class MemoryConsumptionTestClient
         return sentBytes;
     }
 
-    private class MemoryStatistic
+    private static class MemoryStatistic
     {
         private long heapUsage;
         private long directMemoryUsage;


### PR DESCRIPTION
This PR addresses issue [QPID-8604](https://issues.apache.org/jira/browse/QPID-8604) marking non-static inner classes having a reference to its outer class, and access to the outer class' fields and methods as static