### PR TITLE
QPID-8601: [Broker-J] Renamed module and updated documentation

### DIFF
--- a/broker-instrumentation/README.md
+++ b/broker-instrumentation/README.md
@@ -10,21 +10,21 @@ To use instrumentation agent following JVM argument should be added to the broke
 parameters:
 
 ```
--javaagent:$BROKER_DIR/lib/broker-instrumentation-9.0.0-SNAPSHOT.jar
+-javaagent:$BROKER_DIR/lib/qpid-broker-instrumentation-${broker-version}.jar
 ```
 
 List of classes to instrument can be supplied as a comma separated list:
 
 ```
--javaagent:$BROKER_DIR/lib/broker-instrumentation-9.0.0-SNAPSHOT.jar=ConfiguredObjectMethodAttributeOrStatistic
+-javaagent:$BROKER_DIR/lib/qpid-broker-instrumentation-${broker-version}.jar=ConfiguredObjectMethodAttributeOrStatistic
 ```
 
 ```
--javaagent:$BROKER_DIR/lib/broker-instrumentation-9.0.0-SNAPSHOT.jar=ConfiguredObjectMethodAttributeOrStatistic,ConfiguredObjectMethodOperation
+-javaagent:$BROKER_DIR/lib/qpid-broker-instrumentation-${broker-version}.jar=ConfiguredObjectMethodAttributeOrStatistic,ConfiguredObjectMethodOperation
 ```
 
 ```
--javaagent:$BROKER_DIR/lib/broker-instrumentation-9.0.0-SNAPSHOT.jar=ConfiguredObjectMethodAttributeOrStatistic,ConfiguredObjectMethodOperation,AutomatedField
+-javaagent:$BROKER_DIR/lib/qpid-broker-instrumentation-${broker-version}.jar=ConfiguredObjectMethodAttributeOrStatistic,ConfiguredObjectMethodOperation,AutomatedField
 ```
 
 When no arguments supplied, all classes will be instrumented.

--- a/broker-instrumentation/pom.xml
+++ b/broker-instrumentation/pom.xml
@@ -25,9 +25,9 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>broker-instrumentation</artifactId>
+    <artifactId>qpid-broker-instrumentation</artifactId>
     <name>Apache Qpid Broker-J Instrumentation</name>
-    <description>Broker instrumentation</description>
+    <description>Broker static instrumentation agent</description>
 
     <dependencies>
         <dependency>

--- a/broker/pom.xml
+++ b/broker/pom.xml
@@ -51,7 +51,7 @@
 
     <dependency>
       <groupId>org.apache.qpid</groupId>
-      <artifactId>broker-instrumentation</artifactId>
+      <artifactId>qpid-broker-instrumentation</artifactId>
       <scope>runtime</scope>
     </dependency>
 

--- a/doc/java-broker/src/docbkx/runtime/Java-Broker-Runtime-Instrumentation.xml
+++ b/doc/java-broker/src/docbkx/runtime/Java-Broker-Runtime-Instrumentation.xml
@@ -23,9 +23,14 @@
 <section xmlns="http://docbook.org/ns/docbook" version="5.0" xml:id="Java-Broker-Runtime-Instrumentation">
     <title>Broker Instrumentation</title>
     <para>The Apache Qpid Broker-J heavy relies on java reflection mechanism. A static instrumentation agent
-        can be used to replace method.invoke() reflection calls with static final MethodHandle.invokeExact().</para>
-    <para>To use instrumentation agent following JVM argument should be added to the broker start
-        parameters:</para>
-    <para>-javaagent:$BROKER_DIR/lib/broker-instrumentation.jar</para>
+        can be used to replace <literal>method.invoke()</literal> reflection calls with static final
+        <literal>MethodHandle.invokeExact()</literal>.</para>
+    <para>To use instrumentation agent following JVM argument should be added to the broker start parameters:</para>
+    <screen>-javaagent:$BROKER_DIR/lib/qpid-broker-instrumentation-${broker-version}.jar</screen>
+    <para>List of classes to instrument can be supplied as a comma separated list:</para>
+    <screen>-javaagent:$BROKER_DIR/lib/qpid-broker-instrumentation-${broker-version}.jar=ConfiguredObjectMethodAttributeOrStatistic</screen>
+    <screen>-javaagent:$BROKER_DIR/lib/qpid-broker-instrumentation-${broker-version}.jar=ConfiguredObjectMethodAttributeOrStatistic,ConfiguredObjectMethodOperation</screen>
+    <screen>-javaagent:$BROKER_DIR/lib/qpid-broker-instrumentation-${broker-version}.jar=ConfiguredObjectMethodAttributeOrStatistic,ConfiguredObjectMethodOperation,AutomatedField</screen>
+    <para>When no arguments supplied, all classes will be instrumented.</para>
 
 </section>

--- a/pom.xml
+++ b/pom.xml
@@ -292,7 +292,7 @@
 
       <dependency>
         <groupId>org.apache.qpid</groupId>
-        <artifactId>broker-instrumentation</artifactId>
+        <artifactId>qpid-broker-instrumentation</artifactId>
         <version>${project.version}</version>
       </dependency>
 


### PR DESCRIPTION
The broker instrumentation module has been renamed to match the other modules naming.

```
broker-instrumentation -> qpid-broker-instrumentation
```

Added examples with list of classes to instrument to Java Broker book.