### PR TITLE
QPID-8596: [Broker-J] Replaced Java 1.8 by Java 11 in the documentation

### DIFF
--- a/broker-core/src/main/java/org/apache/qpid/server/model/Broker.java
+++ b/broker-core/src/main/java/org/apache/qpid/server/model/Broker.java
@@ -66,7 +66,7 @@ public interface Broker<X extends Broker<X>> extends ConfiguredObject<X>, EventL
     String BROKER_STATISTICS_REPORING_PERIOD = "broker.statisticsReportingPeriod";
 
     String NETWORK_BUFFER_SIZE = "qpid.broker.networkBufferSize";
-    // network buffer should at least hold a SSL/TLS frame which in jdk1.8 is 33305 bytes
+    // network buffer should at least hold a SSL/TLS frame which in jdk 11 is 33305 bytes
     int MINIMUM_NETWORK_BUFFER_SIZE = 64 * 1024;
     @ManagedContextDefault(name = NETWORK_BUFFER_SIZE)
     int DEFAULT_NETWORK_BUFFER_SIZE = 256 * 1024;

--- a/broker-plugins/query-engine/pom.xml
+++ b/broker-plugins/query-engine/pom.xml
@@ -88,7 +88,7 @@
               <includes>
                 <include>ExpressionParser.jj</include>
               </includes>
-              <jdkVersion>1.8</jdkVersion>
+              <jdkVersion>11</jdkVersion>
             </configuration>
           </execution>
         </executions>

--- a/doc/developer-guide/src/main/markdown/build-instructions.md
+++ b/doc/developer-guide/src/main/markdown/build-instructions.md
@@ -66,8 +66,8 @@ For complete reference and documentation on Maven please visit the following onl
 
 ### Java
 
-The build requires a Java 8 or later. You should set the `JAVA_HOME` environment variable and include its `bin` directory
-in your `PATH`.
+The build requires a Java 11 or later. You should set the `JAVA_HOME` environment variable and include its `bin`
+directory in your `PATH`.
 
 Check java version by executing the following at your command prompt.
 

--- a/doc/developer-guide/src/main/markdown/quick-start.md
+++ b/doc/developer-guide/src/main/markdown/quick-start.md
@@ -5,7 +5,7 @@
 The following tools are needed to build Qpid Broker-J
 
  * Git client
- * JDK 1.8 or above; you should set the `JAVA_HOME` environment variable and include its bin directory in your `PATH`.
+ * JDK 11 or above; you should set the `JAVA_HOME` environment variable and include its bin directory in your `PATH`.
  * Maven 3.0 or above; you should set the `M2_HOME` environment variable and include its bin directory in your `PATH`.
 
 ## Getting sources

--- a/doc/developer-guide/src/main/markdown/release-instructions.md
+++ b/doc/developer-guide/src/main/markdown/release-instructions.md
@@ -41,8 +41,8 @@ would result in failures to publish release artifacts into staging maven repo.
 
 ### Java
 
-JDK 1.8 is required to compile java classes. Install latest 1.8 JDK. At the moment of writing this document JDK version
-1.8.0_192  was the latest one.
+JDK 11 is required to compile java classes. Install latest 11 JDK. At the moment of writing this document JDK version
+11.0.17 was the latest one.
 
 ### Git
 

--- a/doc/java-broker/src/docbkx/Java-Broker-Appendix-Miscellaneous.xml
+++ b/doc/java-broker/src/docbkx/Java-Broker-Appendix-Miscellaneous.xml
@@ -31,14 +31,14 @@
         following at the command prompt: </para>
       <programlisting>echo %JAVA_HOME%</programlisting>
       <para> If JAVA_HOME is set you will see something similar to the following: </para>
-      <screen>c:"\PROGRA~1"\Java\jdk1.8.0_121\
+      <screen>c:"\PROGRA~1"\Java\jdk-11.0.13\
       </screen>
-      <para> Then confirm that a Java installation (1.8 or higher) is available: </para>
+      <para> Then confirm that a Java installation (11 or higher) is available: </para>
       <programlisting>java -version</programlisting>
       <para> If java is available on the path, output similar to the following will be seen: </para>
-      <screen>java version "1.8.0_121-b13"
-Java(TM) SE Runtime Environment (build 1.8.0_121-b13)
-Java HotSpot(TM) 64-Bit Server VM (build 25.121-b13, mixed mode)</screen>
+      <screen>java version "11.0.13" 2021-10-19 LTS
+        Java(TM) SE Runtime Environment 18.9 (build 11.0.13+10-LTS-370)
+        Java HotSpot(TM) 64-Bit Server VM 18.9 (build 11.0.13+10-LTS-370, mixed mode</screen>
     </section>
 
     <section role="h2" xml:id="Java-Broker-Miscellaneous-JVM-Verification-Unix">
@@ -47,14 +47,14 @@ Java HotSpot(TM) 64-Bit Server VM (build 25.121-b13, mixed mode)</screen>
         following at the command prompt: </para>
       <programlisting>echo $JAVA_HOME</programlisting>
       <para> If JAVA_HOME is set you will see something similar to the following: </para>
-      <screen>/usr/java/jdk1.8.0_121
+      <screen>/usr/java/jdk-11.0.13
       </screen>
-      <para> Then confirm that a Java installation (1.8 or higher) is available: </para>
+      <para> Then confirm that a Java installation (11 or higher) is available: </para>
       <programlisting>java -version</programlisting>
       <para> If java is available on the path, output similar to the following will be seen: </para>
-      <screen>java version "1.8.0_121-b13"
-        Java(TM) SE Runtime Environment (build 1.8.0_121-b13)
-        Java HotSpot(TM) 64-Bit Server VM (build 25.121-b13, mixed mode)</screen>
+      <screen>java version "11.0.13" 2021-10-19 LTS
+        Java(TM) SE Runtime Environment 18.9 (build 11.0.13+10-LTS-370)
+        Java HotSpot(TM) 64-Bit Server VM 18.9 (build 11.0.13+10-LTS-370, mixed mode</screen>
     </section>
   </section>
   <section role="h2" xml:id="Java-Broker-Miscellaneous-Installing-External-JDBC-Driver">

--- a/doc/java-broker/src/docbkx/Java-Broker-Getting-Started.xml
+++ b/doc/java-broker/src/docbkx/Java-Broker-Getting-Started.xml
@@ -44,7 +44,7 @@
     <para>Output similar to the following will be seen:</para>
     <screen>[Broker] BRK-1006 : Using configuration : C:\qpidwork\config.json
 [Broker] BRK-1001 : Startup : Version: ${project.version} Build: 1478262
-[Broker] BRK-1010 : Platform : JVM : Oracle Corporation version: 1.8.0_144-b01 OS : Windows 7 version: 6.1 arch: x86 cores: 4
+[Broker] BRK-1010 : Platform : JVM : Oracle Corporation version: 11.0.13+10-LTS-370 OS : Windows 7 version: 6.1 arch: x86 cores: 4
 [Broker] BRK-1011 : Maximum Memory : Heap : 518,979,584 bytes Direct : 1,610,612,736 bytes
 [Broker] BRK-1002 : Starting : Listening on TCP port 5672
 [Broker] MNG-1001 : Web Management Startup
@@ -66,7 +66,7 @@
     <para>Output similar to the following will be seen:</para>
     <screen>[Broker] BRK-1006 : Using configuration : /var/qpidwork/config.json
 [Broker] BRK-1001 : Startup : Version: ${project.version} Build: exported
-[Broker] BRK-1010 : Platform : JVM : Oracle Corporation version: 1.8.0_144-b01 OS : Mac OS X version: 10.12.6 arch: x86_64 cores: 8
+[Broker] BRK-1010 : Platform : JVM : Oracle Corporation version: 11.0.13+10-LTS-370 OS : Mac OS X version: 10.12.6 arch: x86_64 cores: 8
 [Broker] BRK-1011 : Maximum Memory : Heap : 518,979,584 bytes Direct : 1,610,612,736 bytes
 [Broker] BRK-1002 : Starting : Listening on TCP port 5672
 [Broker] MNG-1001 : Web Management Startup

--- a/doc/java-broker/src/docbkx/Java-Broker-Installation.xml
+++ b/doc/java-broker/src/docbkx/Java-Broker-Installation.xml
@@ -32,7 +32,7 @@
     <section role="h3" xml:id="Java-Broker-Installation-Prerequistes-Java">
       <title>Java Platform</title>
       <para> The Apache Qpid Broker-J is an 100% Java implementation and as such it can be used on any
-        operating system supporting Java 1.8 or higher<footnote><para>Java Cryptography Extension (JCE)
+        operating system supporting Java 11 or higher<footnote><para>Java Cryptography Extension (JCE)
         Unlimited Strength extension must be installed or enabled for some features.</para></footnote>. This includes Linux,
         Solaris, Mac OS X, and Windows 7/8/10 etc.</para>
       <para> The broker has been tested with Java implementations from both Oracle and IBM. Whatever

--- a/doc/java-broker/src/docbkx/Java-Broker-Introduction.xml
+++ b/doc/java-broker/src/docbkx/Java-Broker-Introduction.xml
@@ -31,7 +31,7 @@
   <para><emphasis>Headline features</emphasis></para>
   <itemizedlist mark="circle">
     <listitem>
-      <para>100% Java implementation - runs on any platform supporting Java 1.8 or higher</para>
+      <para>100% Java implementation - runs on any platform supporting Java 11 or higher</para>
     </listitem>
     <listitem>
       <para>Messaging clients support in Java (JMS 1.1 and 2.0 compliance), C++, Python and more.</para>

--- a/doc/java-broker/src/docbkx/runtime/Java-Broker-Runtime-Memory.xml
+++ b/doc/java-broker/src/docbkx/runtime/Java-Broker-Runtime-Memory.xml
@@ -189,7 +189,7 @@
     <section>
       <title>Java Tuning</title>
       <para>
-        Most of these options are implementation specific. It is assumed you are using Oracle Java 1.8.
+        Most of these options are implementation specific. It is assumed you are using Oracle Java 11.
         <itemizedlist>
           <listitem>
             Heap and direct memory can be configured through the <link linkend="Java-Broker-Appendix-Environment-Variables-Qpid-Java-Mem"><literal>QPID_JAVA_MEM</literal> environment variable</link>.


### PR DESCRIPTION
The minimum Java version has been increased to Java 11 in the documentation.