### PR TITLE
NO-JIRA: Replaced gnu by posix in tar long file mode (assembly-plugin)

### DIFF
--- a/apache-qpid-broker-j/pom.xml
+++ b/apache-qpid-broker-j/pom.xml
@@ -54,7 +54,7 @@
               <descriptors>
                 <descriptor>src/main/assembly/bin.xml</descriptor>
               </descriptors>
-              <tarLongFileMode>gnu</tarLongFileMode>
+              <tarLongFileMode>posix</tarLongFileMode>
             </configuration>
           </execution>
         </executions>
@@ -80,7 +80,7 @@
                   <descriptors>
                     <descriptor>src/main/assembly/src.xml</descriptor>
                   </descriptors>
-                  <tarLongFileMode>gnu</tarLongFileMode>
+                  <tarLongFileMode>posix</tarLongFileMode>
                 </configuration>
               </execution>
             </executions>

--- a/doc/pom.xml
+++ b/doc/pom.xml
@@ -176,7 +176,7 @@
                         <descriptors>
                             <descriptor>${project.basedir}/../src/main/assembly/html.xml</descriptor>
                         </descriptors>
-                        <tarLongFileMode>gnu</tarLongFileMode>
+                        <tarLongFileMode>posix</tarLongFileMode>
                         <appendAssemblyId>false</appendAssemblyId>
                     </configuration>
                     <executions>


### PR DESCRIPTION
There is an issue with GNU tar long file mode in some OSes. 

`group id '1377585961' is too big ( > 2097151 ). Use STAR or POSIX extensions to overcome this limit`

Changing the mode to 'posix' fixes the issue.