### PR TITLE
Revert "NO-JIRA: Replaced gnu by posix in tar long file mode (assembly-plugin)"

### DIFF
--- a/apache-qpid-broker-j/pom.xml
+++ b/apache-qpid-broker-j/pom.xml
@@ -54,7 +54,7 @@
               <descriptors>
                 <descriptor>src/main/assembly/bin.xml</descriptor>
               </descriptors>
-              <tarLongFileMode>posix</tarLongFileMode>
+              <tarLongFileMode>gnu</tarLongFileMode>
             </configuration>
           </execution>
         </executions>
@@ -80,7 +80,7 @@
                   <descriptors>
                     <descriptor>src/main/assembly/src.xml</descriptor>
                   </descriptors>
-                  <tarLongFileMode>posix</tarLongFileMode>
+                  <tarLongFileMode>gnu</tarLongFileMode>
                 </configuration>
               </execution>
             </executions>

--- a/apache-qpid-broker-j/pom.xml
+++ b/apache-qpid-broker-j/pom.xml
@@ -54,6 +54,10 @@
               <descriptors>
                 <descriptor>src/main/assembly/bin.xml</descriptor>
               </descriptors>
+              <!-- 7-zip/mc truncates path to 100 characters in 'posix' mode
+                        - https://sourceforge.net/p/sevenzip/bugs/2228/
+                        - https://github.com/apache/qpid-broker-j/pull/161
+                   'gnu' value causes a packaging issue on OSes where the user ID is greater than 2097151. -->
               <tarLongFileMode>gnu</tarLongFileMode>
             </configuration>
           </execution>
@@ -80,6 +84,10 @@
                   <descriptors>
                     <descriptor>src/main/assembly/src.xml</descriptor>
                   </descriptors>
+                  <!-- 7-zip/mc truncates path to 100 characters in 'posix' mode
+                           - https://sourceforge.net/p/sevenzip/bugs/2228/
+                           - https://github.com/apache/qpid-broker-j/pull/161
+                       'gnu' value causes a packaging issue on OSes where the user ID is greater than 2097151. -->
                   <tarLongFileMode>gnu</tarLongFileMode>
                 </configuration>
               </execution>

--- a/doc/pom.xml
+++ b/doc/pom.xml
@@ -176,6 +176,10 @@
                         <descriptors>
                             <descriptor>${project.basedir}/../src/main/assembly/html.xml</descriptor>
                         </descriptors>
+                        <!-- 7-zip/mc truncates path to 100 characters in 'posix' mode
+                                 - https://sourceforge.net/p/sevenzip/bugs/2228/
+                                 - https://github.com/apache/qpid-broker-j/pull/161
+                             'gnu' value causes a packaging issue on OSes where the user ID is greater than 2097151. -->
                         <tarLongFileMode>gnu</tarLongFileMode>
                         <appendAssemblyId>false</appendAssemblyId>
                     </configuration>

--- a/doc/pom.xml
+++ b/doc/pom.xml
@@ -176,7 +176,7 @@
                         <descriptors>
                             <descriptor>${project.basedir}/../src/main/assembly/html.xml</descriptor>
                         </descriptors>
-                        <tarLongFileMode>posix</tarLongFileMode>
+                        <tarLongFileMode>gnu</tarLongFileMode>
                         <appendAssemblyId>false</appendAssemblyId>
                     </configuration>
                     <executions>


### PR DESCRIPTION
Reverts apache/qpid-broker-j#159

There is an issue with 7-zip on Windows (Midnight Commander in Ubuntu 22.04 has the same issues), which truncates path to 100 characters in `posix` tar long file mode of maven-assembly-plugin. Unpacking by `tar -xvf` works without any issues.

Reverting change for wider compatibility. Downside is that build/release will fail on OSes where user id is larger than 2097151.

Details:
https://www.gnu.org/software/tar/manual/html_chapter/Formats.html
https://sourceforge.net/p/sevenzip/bugs/2228/
https://issues.onehippo.com/browse/ARCHE-565?attachmentViewMode=list
