### PR TITLE
QPID-8612: [Broker-J] Changed default Garbage Collector from CMS to G1

### DIFF
--- a/broker/bin/qpid-server
+++ b/broker/bin/qpid-server
@@ -40,7 +40,7 @@ QPID_LIBS="${QPID_HOME}/lib/*:${QPID_HOME}/lib/plugins/*:${QPID_HOME}/lib/opt/*"
 export JAVA=java \
        JAVA_VM=-server \
        JAVA_MEM="-Xmx512m -XX:MaxDirectMemorySize=1536m" \
-       JAVA_GC="-XX:+UseConcMarkSweepGC -XX:+HeapDumpOnOutOfMemoryError" \
+       JAVA_GC="-XX:+UseG1GC -XX:+HeapDumpOnOutOfMemoryError" \
        QPID_CLASSPATH="${QPID_LIBS}" \
        QPID_RUN_LOG=2 
 

--- a/broker/bin/qpid-server.bat
+++ b/broker/bin/qpid-server.bat
@@ -165,7 +165,7 @@ REM end parsing -run arguments
 
 set JAVA_VM=-server
 set JAVA_MEM=-Xmx512m -XX:MaxDirectMemorySize=1536m
-set JAVA_GC=-XX:+UseConcMarkSweepGC -XX:+HeapDumpOnOutOfMemoryError
+set JAVA_GC=-XX:+UseG1GC -XX:+HeapDumpOnOutOfMemoryError
 
 REM Use QPID_JAVA_GC if set
 if "%QPID_JAVA_GC%" == "" goto noQpidJavaGC

--- a/doc/java-broker/src/docbkx/Java-Broker-Appendix-Environment-Variables.xml
+++ b/doc/java-broker/src/docbkx/Java-Broker-Appendix-Environment-Variables.xml
@@ -85,7 +85,7 @@
         <row xml:id="Java-Broker-Appendix-Environment-Variables-Qpid-Java-Gc">
           <entry>QPID_JAVA_GC</entry>
           <entry>
-            <literal>-XX:+HeapDumpOnOutOfMemoryError -XX:+UseConcMarkSweepGC</literal>
+            <literal>-XX:+HeapDumpOnOutOfMemoryError -XX:+UseG1GC</literal>
           </entry>
           <entry>
             <para>This is the preferred mechanism for customising garbage collection behaviour. The

--- a/tools/src/main/java/org/apache/qpid/tools/MemoryConsumptionTestClient.java
+++ b/tools/src/main/java/org/apache/qpid/tools/MemoryConsumptionTestClient.java
@@ -122,7 +122,7 @@ public class MemoryConsumptionTestClient
         options.put(JMX_PORT_ARG, JMX_PORT_DEFAULT);
         options.put(JMX_USER_ARG, "");
         options.put(JMX_USER_PASSWORD_ARG, "");
-        options.put(JMX_GARBAGE_COLLECTOR_MBEAN, "java.lang:type=GarbageCollector,name=ConcurrentMarkSweep");
+        options.put(JMX_GARBAGE_COLLECTOR_MBEAN, "java.lang:type=GarbageCollector,name=G1 Old Generation");
 
         if(args.length == 1 &&
                 (args[0].equals("-h") || args[0].equals("--help") || args[0].equals("help")))


### PR DESCRIPTION
Concurrent Mark Sweep (CMS) garbage collector was [deprecated in Java 9](https://openjdk.org/jeps/291) and is no longer supported in Java 17.

G1GC looks like good replacement for CMS GC (G1GC was also recommended in related [JEP 291](https://openjdk.org/jeps/291)).