### PR TITLE
NO-JIRA: update dependencies versions

### DIFF
--- a/apache-qpid-broker-j/src/main/assembly/dependency-verification/DEPENDENCIES_REFERENCE
+++ b/apache-qpid-broker-j/src/main/assembly/dependency-verification/DEPENDENCIES_REFERENCE
@@ -45,12 +45,12 @@ From: 'Apache Software Foundation' (http://db.apache.org/)
     License: Apache 2  (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 From: 'FasterXML' (http://fasterxml.com/)
-  - Jackson-annotations (http://github.com/FasterXML/jackson) com.fasterxml.jackson.core:jackson-annotations:bundle:2.13.4
-    License: The Apache Software License, Version 2.0  (http://www.apache.org/licenses/LICENSE-2.0.txt)
-  - Jackson-core (https://github.com/FasterXML/jackson-core) com.fasterxml.jackson.core:jackson-core:bundle:2.13.4
-    License: The Apache Software License, Version 2.0  (http://www.apache.org/licenses/LICENSE-2.0.txt)
-  - jackson-databind (http://github.com/FasterXML/jackson) com.fasterxml.jackson.core:jackson-databind:bundle:2.13.4.2
-    License: The Apache Software License, Version 2.0  (http://www.apache.org/licenses/LICENSE-2.0.txt)
+  - Jackson-annotations (https://github.com/FasterXML/jackson) com.fasterxml.jackson.core:jackson-annotations:bundle:2.14.1
+    License: The Apache Software License, Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
+  - Jackson-core (https://github.com/FasterXML/jackson-core) com.fasterxml.jackson.core:jackson-core:bundle:2.14.1
+    License: The Apache Software License, Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
+  - jackson-databind (https://github.com/FasterXML/jackson) com.fasterxml.jackson.core:jackson-databind:bundle:2.14.1
+    License: The Apache Software License, Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
 
 From: 'GlassFish Community' (https://glassfish.dev.java.net)
   - Java Servlet API (http://servlet-spec.java.net) javax.servlet:javax.servlet-api:jar:3.1.0
@@ -137,7 +137,7 @@ From: 'The Apache Software Foundation' (https://www.apache.org/)
     License: Apache License, Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
 
 From: 'The CometD Project' (https://cometd.org)
-  - Dojo Toolkit :: Bundles (http://dojotoolkit.org/dojo) org.dojotoolkit:dojo:pom:1.17.2
+  - Dojo Toolkit :: Bundles (http://dojotoolkit.org/dojo) org.dojotoolkit:dojo:pom:1.17.3
     License: Academic Free License v2.1  (https://github.com/dojo/dojo/blob/master/LICENSE)    License: BSD License  (https://github.com/dojo/dojo/blob/master/LICENSE)
 
 From: 'Webtide' (https://webtide.com)

--- a/perftests/src/main/assembly/dependency-verification/DEPENDENCIES_REFERENCE
+++ b/perftests/src/main/assembly/dependency-verification/DEPENDENCIES_REFERENCE
@@ -37,12 +37,12 @@ From: 'Apache Software Foundation' (http://www.apache.org)
     License: The Apache Software License, Version 2.0  (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 From: 'FasterXML' (http://fasterxml.com/)
-  - Jackson-annotations (http://github.com/FasterXML/jackson) com.fasterxml.jackson.core:jackson-annotations:bundle:2.13.4
-    License: The Apache Software License, Version 2.0  (http://www.apache.org/licenses/LICENSE-2.0.txt)
-  - Jackson-core (https://github.com/FasterXML/jackson-core) com.fasterxml.jackson.core:jackson-core:bundle:2.13.4
-    License: The Apache Software License, Version 2.0  (http://www.apache.org/licenses/LICENSE-2.0.txt)
-  - jackson-databind (http://github.com/FasterXML/jackson) com.fasterxml.jackson.core:jackson-databind:bundle:2.13.4.2
-    License: The Apache Software License, Version 2.0  (http://www.apache.org/licenses/LICENSE-2.0.txt)
+  - Jackson-annotations (https://github.com/FasterXML/jackson) com.fasterxml.jackson.core:jackson-annotations:bundle:2.14.1
+    License: The Apache Software License, Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
+  - Jackson-core (https://github.com/FasterXML/jackson-core) com.fasterxml.jackson.core:jackson-core:bundle:2.14.1
+    License: The Apache Software License, Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
+  - jackson-databind (https://github.com/FasterXML/jackson) com.fasterxml.jackson.core:jackson-databind:bundle:2.14.1
+    License: The Apache Software License, Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
 
 From: 'QOS.ch' (http://www.qos.ch)
   - Logback Classic Module (http://logback.qos.ch/logback-classic) ch.qos.logback:logback-classic:jar:1.2.11

--- a/pom.xml
+++ b/pom.xml
@@ -107,8 +107,8 @@
     <logback-version>1.2.11</logback-version>
     <logback-db-version>1.2.11.1</logback-db-version>
     <guava-version>31.1-jre</guava-version>
-    <fasterxml-jackson-version>2.13.4</fasterxml-jackson-version>
-    <fasterxml-jackson-databind-version>2.13.4.2</fasterxml-jackson-databind-version>
+    <fasterxml-jackson-version>2.14.1</fasterxml-jackson-version>
+    <fasterxml-jackson-databind-version>2.14.1</fasterxml-jackson-databind-version>
     <slf4j-version>1.7.36</slf4j-version>
     <jetty-version>9.4.49.v20220914</jetty-version>
 
@@ -124,20 +124,20 @@
     <csvjdbc-version>1.0.35</csvjdbc-version>
     <jfreechart-version>1.0.13</jfreechart-version>
 
-    <dojo-version>1.17.2</dojo-version>
+    <dojo-version>1.17.3</dojo-version>
     <dstore-version>1.1.2</dstore-version>
     <dgrid-version>1.3.3</dgrid-version>
 
     <!-- test dependency version numbers -->
-    <junit-version>5.9.1</junit-version>
-    <mockito-version>4.8.1</mockito-version>
-    <netty-version>4.1.84.Final</netty-version>
+    <junit-version>5.9.2</junit-version>
+    <mockito-version>5.0.0</mockito-version>
+    <netty-version>4.1.87.Final</netty-version>
     <hamcrest-version>2.2</hamcrest-version>
     <maven-resolver-provider-version>3.8.6</maven-resolver-provider-version>
     <maven-resolver-version>1.8.2</maven-resolver-version>
     <httpclient-version>4.5.13</httpclient-version>
     <qpid-jms-client-version>0.61.0</qpid-jms-client-version>
-    <qpid-jms-client-amqp-0-x-version>6.3.4</qpid-jms-client-amqp-0-x-version>
+    <qpid-jms-client-amqp-0-x-version>6.4.0</qpid-jms-client-amqp-0-x-version>
     <jaxb-api-version>2.3.1</jaxb-api-version>
     <nashorn-version>15.4</nashorn-version>
 
@@ -161,8 +161,8 @@
     <h2.version>1.4.200</h2.version>
     <apache-directory-version>2.0.0.AM25</apache-directory-version>
     <kerby-version>2.0.2</kerby-version>
-    <bcprov-version>1.70</bcprov-version>
-    <bcpkix-version>1.70</bcpkix-version>
+    <bcprov-version>1.72</bcprov-version>
+    <bcpkix-version>1.72</bcpkix-version>
     <logback-gelf-version>3.0.0</logback-gelf-version>
     <prometheus-client-version>0.9.0</prometheus-client-version>
 
@@ -924,13 +924,13 @@
 
       <dependency>
         <groupId>org.bouncycastle</groupId>
-        <artifactId>bcprov-jdk15on</artifactId>
+        <artifactId>bcprov-jdk18on</artifactId>
         <version>${bcprov-version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.bouncycastle</groupId>
-        <artifactId>bcpkix-jdk15on</artifactId>
+        <artifactId>bcpkix-jdk18on</artifactId>
         <version>${bcpkix-version}</version>
       </dependency>
 
@@ -1214,7 +1214,6 @@
             <exclude>specs/**</exclude>
             <exclude>**/*.md</exclude>
             <exclude>DEPENDENCIES</exclude>
-            <exclude>.travis.yml</exclude>
             <exclude>appveyor.yml</exclude>
           </excludes>
         </configuration>

--- a/qpid-test-utils/pom.xml
+++ b/qpid-test-utils/pom.xml
@@ -64,12 +64,12 @@
 
     <dependency>
       <groupId>org.bouncycastle</groupId>
-      <artifactId>bcprov-jdk15on</artifactId>
+      <artifactId>bcprov-jdk18on</artifactId>
     </dependency>
 
     <dependency>
       <groupId>org.bouncycastle</groupId>
-      <artifactId>bcpkix-jdk15on</artifactId>
+      <artifactId>bcpkix-jdk18on</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.directory.server</groupId>


### PR DESCRIPTION
This PR updates 
- com.fasterxml.jackson.core:jackson-core to 2.14.1
- com.fasterxml.jackson.core:jackson-databind to 2.14.1 
- org.apache.qpid:qpid-client to 6.4.0
- org.bouncycastle:bcprov-jdk15on to org.bouncycastle:bcprov-jdk18on:1.72
- org.bouncycastle:bcpkix-jdk15on to org.bouncycastle:bcpkix-jdk18on:1.72
- org.dojotoolkit:dojo to 1.17.3
- org.junit.jupiter.* to 5.9.2
- org.mockito:mockito-core to 5.0.0
- io.netty:* to 4.1.87.Final 
