### PR TITLE
QPID-8626: [Broker-J] Dependency updates

### DIFF
--- a/apache-qpid-broker-j/src/main/assembly/dependency-verification/DEPENDENCIES_REFERENCE
+++ b/apache-qpid-broker-j/src/main/assembly/dependency-verification/DEPENDENCIES_REFERENCE
@@ -25,162 +25,261 @@ Apache Qpid Broker-J Bundles
 
 
 From: 'an unknown organization'
+
   - Guava InternalFutureFailureAccess and InternalFutures (https://github.com/google/guava/failureaccess) com.google.guava:failureaccess:bundle:1.0.1
     License: The Apache Software License, Version 2.0  (http://www.apache.org/licenses/LICENSE-2.0.txt)
-  - Guava: Google Core Libraries for Java (https://github.com/google/guava) com.google.guava:guava:bundle:31.1-jre
+
+  - Guava: Google Core Libraries for Java (https://github.com/google/guava) com.google.guava:guava:bundle:32.1.2-jre
     License: Apache License, Version 2.0  (http://www.apache.org/licenses/LICENSE-2.0.txt)
-  - J2ObjC Annotations (https://github.com/google/j2objc/) com.google.j2objc:j2objc-annotations:jar:1.3
-    License: The Apache Software License, Version 2.0  (http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+  - J2ObjC Annotations (https://github.com/google/j2objc/) com.google.j2objc:j2objc-annotations:jar:2.8
+    License: Apache License, Version 2.0  (http://www.apache.org/licenses/LICENSE-2.0.txt)
+
   - Prometheus Java Simpleclient (http://github.com/prometheus/client_java/simpleclient) io.prometheus:simpleclient:bundle:0.16.0
     License: The Apache Software License, Version 2.0  (http://www.apache.org/licenses/LICENSE-2.0.txt)
+
   - Prometheus Java Simpleclient Common (http://github.com/prometheus/client_java/simpleclient_common) io.prometheus:simpleclient_common:bundle:0.16.0
     License: The Apache Software License, Version 2.0  (http://www.apache.org/licenses/LICENSE-2.0.txt)
+
   - Prometheus Java Span Context Supplier - Common (http://github.com/prometheus/client_java/simpleclient_tracer/simpleclient_tracer_common) io.prometheus:simpleclient_tracer_common:bundle:0.16.0
     License: The Apache Software License, Version 2.0  (http://www.apache.org/licenses/LICENSE-2.0.txt)
+
   - Prometheus Java Span Context Supplier - OpenTelemetry (http://github.com/prometheus/client_java/simpleclient_tracer/simpleclient_tracer_otel) io.prometheus:simpleclient_tracer_otel:bundle:0.16.0
     License: The Apache Software License, Version 2.0  (http://www.apache.org/licenses/LICENSE-2.0.txt)
+
   - Prometheus Java Span Context Supplier - OpenTelemetry Agent (http://github.com/prometheus/client_java/simpleclient_tracer/simpleclient_tracer_otel_agent) io.prometheus:simpleclient_tracer_otel_agent:bundle:0.16.0
     License: The Apache Software License, Version 2.0  (http://www.apache.org/licenses/LICENSE-2.0.txt)
-  - Bouncy Castle PKIX, CMS, EAC, TSP, PKCS, OCSP, CMP, and CRMF APIs (https://www.bouncycastle.org/java.html) org.bouncycastle:bcpkix-jdk18on:jar:1.72
+
+  - Bouncy Castle PKIX, CMS, EAC, TSP, PKCS, OCSP, CMP, and CRMF APIs (https://www.bouncycastle.org/java.html) org.bouncycastle:bcpkix-jdk18on:jar:1.76
     License: Bouncy Castle Licence  (https://www.bouncycastle.org/licence.html)
-  - Bouncy Castle Provider (https://www.bouncycastle.org/java.html) org.bouncycastle:bcprov-jdk18on:jar:1.72
+
+  - Bouncy Castle Provider (https://www.bouncycastle.org/java.html) org.bouncycastle:bcprov-jdk18on:jar:1.76
     License: Bouncy Castle Licence  (https://www.bouncycastle.org/licence.html)
-  - Bouncy Castle ASN.1 Extension and Utility APIs (https://www.bouncycastle.org/java.html) org.bouncycastle:bcutil-jdk18on:jar:1.72
+
+  - Bouncy Castle ASN.1 Extension and Utility APIs (https://www.bouncycastle.org/java.html) org.bouncycastle:bcutil-jdk18on:jar:1.76
     License: Bouncy Castle Licence  (https://www.bouncycastle.org/licence.html)
+
   - dgrid (https://www.webjars.org) org.webjars.bower:dgrid:jar:1.3.3
     License: BSD 3-Clause  (https://spdx.org/licenses/BSD 3-Clause#licenseText)
+
   - dstore (http://webjars.org) org.webjars.bower:dstore:jar:1.1.2
     License: BSD 3-Clause  (https://spdx.org/licenses/BSD 3-Clause#licenseText)
 
+
 From: 'Apache Software Foundation' (http://db.apache.org/)
+
   - Apache Derby Database Engine and Embedded JDBC Driver (http://db.apache.org/derby/) org.apache.derby:derby:jar:10.14.2.0
     License: Apache 2  (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
+
 From: 'FasterXML' (http://fasterxml.com/)
-  - Jackson-annotations (https://github.com/FasterXML/jackson) com.fasterxml.jackson.core:jackson-annotations:jar:2.15.0
-    License: The Apache Software License, Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
-  - Jackson-core (https://github.com/FasterXML/jackson-core) com.fasterxml.jackson.core:jackson-core:jar:2.15.0
-    License: The Apache Software License, Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
-  - jackson-databind (https://github.com/FasterXML/jackson) com.fasterxml.jackson.core:jackson-databind:jar:2.15.0
+
+  - Jackson-annotations (https://github.com/FasterXML/jackson) com.fasterxml.jackson.core:jackson-annotations:jar:2.15.2
     License: The Apache Software License, Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
 
+  - Jackson-core (https://github.com/FasterXML/jackson-core) com.fasterxml.jackson.core:jackson-core:jar:2.15.2
+    License: The Apache Software License, Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+  - jackson-databind (https://github.com/FasterXML/jackson) com.fasterxml.jackson.core:jackson-databind:jar:2.15.2
+    License: The Apache Software License, Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+
 From: 'JolBox' (http://jolbox.com)
+
   - BoneCP :: Core Library (http://jolbox.com/bonecp) com.jolbox:bonecp:bundle:0.8.0.RELEASE
     License: Apache v2  (http://www.apache.org/licenses/LICENSE-2.0.html)
 
+
 From: 'Mort Bay Consulting' (http://www.mortbay.com)
+
   - Jetty :: Jakarta Servlet API and Schemas for JPMS and OSGi (https://eclipse.org/jetty/jetty-jakarta-servlet-api) org.eclipse.jetty.toolchain:jetty-jakarta-servlet-api:jar:5.0.2
-    License: Apache Software License - Version 2.0  (http://www.apache.org/licenses/LICENSE-2.0)    License: Eclipse Public License - Version 1.0  (http://www.eclipse.org/org/documents/epl-v10.php)
+    License: Apache Software License - Version 2.0  (http://www.apache.org/licenses/LICENSE-2.0)
+    License: Eclipse Public License - Version 1.0  (http://www.eclipse.org/org/documents/epl-v10.php)
+
 
 From: 'Oracle Corporation' (http://www.oracle.com/)
+
   - je  com.sleepycat:je:jar:7.4.5
     License: Apache License, Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
 
+
 From: 'OW2' (http://www.ow2.org/)
+
   - asm (http://asm.ow2.io/) org.ow2.asm:asm:jar:9.5
     License: BSD-3-Clause  (https://asm.ow2.io/license.html)
+
   - asm-tree (http://asm.ow2.io/) org.ow2.asm:asm-tree:jar:9.5
     License: BSD-3-Clause  (https://asm.ow2.io/license.html)
 
+
 From: 'QOS.ch' (http://www.qos.ch)
-  - Logback Classic Module (http://logback.qos.ch/logback-classic) ch.qos.logback:logback-classic:jar:1.4.7
-    License: Eclipse Public License - v 1.0  (http://www.eclipse.org/legal/epl-v10.html)    License: GNU Lesser General Public License  (http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html)
-  - Logback Core Module (http://logback.qos.ch/logback-core) ch.qos.logback:logback-core:jar:1.4.7
-    License: Eclipse Public License - v 1.0  (http://www.eclipse.org/legal/epl-v10.html)    License: GNU Lesser General Public License  (http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html)
+
+  - Logback Classic Module (http://logback.qos.ch/logback-classic) ch.qos.logback:logback-classic:jar:1.4.9
+    License: Eclipse Public License - v 1.0  (http://www.eclipse.org/legal/epl-v10.html)
+    License: GNU Lesser General Public License  (http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html)
+
+  - Logback Core Module (http://logback.qos.ch/logback-core) ch.qos.logback:logback-core:jar:1.4.9
+    License: Eclipse Public License - v 1.0  (http://www.eclipse.org/legal/epl-v10.html)
+    License: GNU Lesser General Public License  (http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html)
+
   - Logback DBAppender Classic Module (http://logback.qos.ch/logback-classic-db) ch.qos.logback.db:logback-classic-db:jar:1.2.11.1
-    License: Eclipse Public License - v 1.0  (http://www.eclipse.org/legal/epl-v10.html)    License: GNU Lesser General Public License  (http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html)
+    License: Eclipse Public License - v 1.0  (http://www.eclipse.org/legal/epl-v10.html)
+    License: GNU Lesser General Public License  (http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html)
+
   - Logback DBAppender Core Module (http://logback.qos.ch/logback-core-db) ch.qos.logback.db:logback-core-db:jar:1.2.11.1
-    License: Eclipse Public License - v 1.0  (http://www.eclipse.org/legal/epl-v10.html)    License: GNU Lesser General Public License  (http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html)
+    License: Eclipse Public License - v 1.0  (http://www.eclipse.org/legal/epl-v10.html)
+    License: GNU Lesser General Public License  (http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html)
+
   - SLF4J API Module (http://www.slf4j.org) org.slf4j:slf4j-api:jar:2.0.7
     License: MIT License  (http://www.opensource.org/licenses/mit-license.php)
 
+
 From: 'The Apache Software Foundation' (https://www.apache.org/)
+
   - Apache Commons CLI (https://commons.apache.org/proper/commons-cli/) commons-cli:commons-cli:jar:1.5.0
     License: Apache License, Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
+
   - Apache Qpid Broker-J BDB Message Store Plug-in (http://qpid.apache.org/components/qpid-bdbstore) org.apache.qpid:qpid-bdbstore:jar
     License: Apache-2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
+
   - Apache Qpid Broker-J (http://qpid.apache.org/components/qpid-broker) org.apache.qpid:qpid-broker:jar
     License: Apache-2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
+
   - Apache Qpid Broker-J Core (http://qpid.apache.org/components/qpid-broker-core) org.apache.qpid:qpid-broker-core:jar
     License: Apache-2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
+
   - Apache Qpid Broker-J Instrumentation (http://qpid.apache.org/components/qpid-broker-instrumentation) org.apache.qpid:qpid-broker-instrumentation:jar
     License: Apache-2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
+
   - Apache Qpid Broker-J Access Control Plug-in (http://qpid.apache.org/components/broker-plugins/qpid-broker-plugins-access-control) org.apache.qpid:qpid-broker-plugins-access-control:jar
     License: Apache-2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
+
   - Apache Qpid Broker-J AMQP 0-10 Protocol Plug-in (http://qpid.apache.org/components/broker-plugins/qpid-broker-plugins-amqp-0-10-protocol) org.apache.qpid:qpid-broker-plugins-amqp-0-10-protocol:jar
     License: Apache-2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
+
   - Apache Qpid Broker-J AMQP 0-8 Protocol Plug-in (http://qpid.apache.org/components/broker-plugins/qpid-broker-plugins-amqp-0-8-protocol) org.apache.qpid:qpid-broker-plugins-amqp-0-8-protocol:jar
     License: Apache-2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
+
   - Apache Qpid Broker-J AMQP 1-0 Protocol Plug-in (http://qpid.apache.org/components/broker-plugins/qpid-broker-plugins-amqp-1-0-protocol) org.apache.qpid:qpid-broker-plugins-amqp-1-0-protocol:jar
     License: Apache-2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
+
   - Apache Qpid AMQP 1.0 BDB Link Store Plug-in (http://qpid.apache.org/components/broker-plugins/qpid-broker-plugins-amqp-1-0-protocol-bdb-link-store) org.apache.qpid:qpid-broker-plugins-amqp-1-0-protocol-bdb-link-store:jar
     License: Apache-2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
+
   - Apache Qpid AMQP 1.0 JDBC Link Store Plug-in (http://qpid.apache.org/components/broker-plugins/qpid-broker-plugins-amqp-1-0-protocol-jdbc-link-store) org.apache.qpid:qpid-broker-plugins-amqp-1-0-protocol-jdbc-link-store:jar
     License: Apache-2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
+
   - Apache Qpid Broker-J AMQP 0-10 to 1-0 Message Conversion Plug-in (http://qpid.apache.org/components/broker-plugins/qpid-broker-plugins-amqp-msg-conv-0-10-to-1-0) org.apache.qpid:qpid-broker-plugins-amqp-msg-conv-0-10-to-1-0:jar
     License: Apache-2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
+
   - Apache Qpid Broker-J AMQP 0-8 to 0-10 Message Conversion Plug-in (http://qpid.apache.org/components/broker-plugins/qpid-broker-plugins-amqp-msg-conv-0-8-to-0-10) org.apache.qpid:qpid-broker-plugins-amqp-msg-conv-0-8-to-0-10:jar
     License: Apache-2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
+
   - Apache Qpid Broker-J AMQP 0-8 to 1-0 Message Conversion Plug-in (http://qpid.apache.org/components/broker-plugins/qpid-broker-plugins-amqp-msg-conv-0-8-to-1-0) org.apache.qpid:qpid-broker-plugins-amqp-msg-conv-0-8-to-1-0:jar
     License: Apache-2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
+
   - Apache Qpid Broker-J Connection Limit Plug-in (http://qpid.apache.org/components/broker-plugins/qpid-broker-plugins-connection-limits) org.apache.qpid:qpid-broker-plugins-connection-limits:jar
     License: Apache-2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
+
   - Apache Qpid Broker-J Derby Message Store Plug-in (http://qpid.apache.org/components/broker-plugins/qpid-broker-plugins-derby-store) org.apache.qpid:qpid-broker-plugins-derby-store:jar
     License: Apache-2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
+
   - Apache Qpid Broker-J LogBack JDBC Logging Plug-in (http://qpid.apache.org/components/broker-plugins/qpid-broker-plugins-jdbc-logging-logback) org.apache.qpid:qpid-broker-plugins-jdbc-logging-logback:jar
     License: Apache-2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
+
   - Apache Qpid Broker-J JDBC Message Store Connection Pooling Plug-in (http://qpid.apache.org/components/broker-plugins/qpid-broker-plugins-jdbc-provider-bone) org.apache.qpid:qpid-broker-plugins-jdbc-provider-bone:jar
     License: Apache-2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
+
   - Apache Qpid Broker-J JDBC Message Store Plug-in (http://qpid.apache.org/components/broker-plugins/qpid-broker-plugins-jdbc-store) org.apache.qpid:qpid-broker-plugins-jdbc-store:jar
     License: Apache-2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
+
   - Apache Qpid Broker-J LogBack Logging Plug-in (http://qpid.apache.org/components/broker-plugins/qpid-broker-plugins-logging-logback) org.apache.qpid:qpid-broker-plugins-logging-logback:jar
     License: Apache-2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
+
   - Apache Qpid Broker-J AMQP Management Protocol Plug-in (http://qpid.apache.org/components/broker-plugins/qpid-broker-plugins-management-amqp) org.apache.qpid:qpid-broker-plugins-management-amqp:jar
     License: Apache-2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
+
   - Apache Qpid Broker-J HTTP Management Plug-in (http://qpid.apache.org/components/broker-plugins/qpid-broker-plugins-management-http) org.apache.qpid:qpid-broker-plugins-management-http:jar
     License: Apache-2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
+
   - Apache Qpid Broker-J Memory Message Store Plug-in (http://qpid.apache.org/components/broker-plugins/qpid-broker-plugins-memory-store) org.apache.qpid:qpid-broker-plugins-memory-store:jar
     License: Apache-2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
+
   - qpid-broker-plugins-prometheus-exporter (http://qpid.apache.org/components/broker-plugins/qpid-broker-plugins-prometheus-exporter) org.apache.qpid:qpid-broker-plugins-prometheus-exporter:jar
     License: Apache-2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
+
   - Apache Qpid Broker-J Query Engine Plug-In (http://qpid.apache.org/components/broker-plugins/qpid-broker-plugins-query-engine) org.apache.qpid:qpid-broker-plugins-query-engine:jar
     License: Apache-2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
+
   - Apache Qpid Broker-J WebSocket Plug-in (http://qpid.apache.org/components/broker-plugins/qpid-broker-plugins-websocket) org.apache.qpid:qpid-broker-plugins-websocket:jar
     License: Apache-2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
 
+
 From: 'The CometD Project' (https://cometd.org)
+
   - Dojo Toolkit :: Bundles (http://dojotoolkit.org/dojo) org.dojotoolkit:dojo:pom:1.17.3
-    License: Academic Free License v2.1  (https://github.com/dojo/dojo/blob/master/LICENSE)    License: BSD License  (https://github.com/dojo/dojo/blob/master/LICENSE)
+    License: Academic Free License v2.1  (https://github.com/dojo/dojo/blob/master/LICENSE)
+    License: BSD License  (https://github.com/dojo/dojo/blob/master/LICENSE)
+
 
 From: 'Webtide' (https://webtide.com)
+
   - Jetty :: Http Utility (https://eclipse.org/jetty/jetty-http) org.eclipse.jetty:jetty-http:jar:11.0.15
-    License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0)    License: Apache Software License - Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0)
+    License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0)
+    License: Apache Software License - Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0)
+
   - Jetty :: IO Utility (https://eclipse.org/jetty/jetty-io) org.eclipse.jetty:jetty-io:jar:11.0.15
-    License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0)    License: Apache Software License - Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0)
+    License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0)
+    License: Apache Software License - Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0)
+
   - Jetty :: Rewrite Handler (https://eclipse.org/jetty/jetty-rewrite) org.eclipse.jetty:jetty-rewrite:jar:11.0.15
-    License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0)    License: Apache Software License - Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0)
+    License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0)
+    License: Apache Software License - Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0)
+
   - Jetty :: Security (https://eclipse.org/jetty/jetty-security) org.eclipse.jetty:jetty-security:jar:11.0.15
-    License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0)    License: Apache Software License - Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0)
+    License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0)
+    License: Apache Software License - Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0)
+
   - Jetty :: Server Core (https://eclipse.org/jetty/jetty-server) org.eclipse.jetty:jetty-server:jar:11.0.15
-    License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0)    License: Apache Software License - Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0)
+    License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0)
+    License: Apache Software License - Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0)
+
   - Jetty :: Servlet Handling (https://eclipse.org/jetty/jetty-servlet) org.eclipse.jetty:jetty-servlet:jar:11.0.15
-    License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0)    License: Apache Software License - Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0)
+    License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0)
+    License: Apache Software License - Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0)
+
   - Jetty :: Utility Servlets and Filters (https://eclipse.org/jetty/jetty-servlets) org.eclipse.jetty:jetty-servlets:jar:11.0.15
-    License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0)    License: Apache Software License - Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0)
+    License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0)
+    License: Apache Software License - Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0)
+
   - Jetty :: Utilities (https://eclipse.org/jetty/jetty-util) org.eclipse.jetty:jetty-util:jar:11.0.15
-    License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0)    License: Apache Software License - Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0)
+    License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0)
+    License: Apache Software License - Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0)
+
   - Jetty :: Websocket :: Core :: Common (https://eclipse.org/jetty/websocket-parent/websocket-core-common) org.eclipse.jetty.websocket:websocket-core-common:jar:11.0.15
-    License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0)    License: Apache Software License - Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0)
+    License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0)
+    License: Apache Software License - Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0)
+
   - Jetty :: Websocket :: Core :: Server (https://eclipse.org/jetty/websocket-parent/websocket-core-server) org.eclipse.jetty.websocket:websocket-core-server:jar:11.0.15
-    License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0)    License: Apache Software License - Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0)
+    License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0)
+    License: Apache Software License - Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0)
+
   - Jetty :: Websocket :: org.eclipse.jetty.websocket :: API (https://eclipse.org/jetty/websocket-parent/websocket-jetty-api) org.eclipse.jetty.websocket:websocket-jetty-api:jar:11.0.15
-    License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0)    License: Apache Software License - Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0)
+    License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0)
+    License: Apache Software License - Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0)
+
   - Jetty :: Websocket :: org.eclipse.jetty.websocket :: Common (https://eclipse.org/jetty/websocket-parent/websocket-jetty-common) org.eclipse.jetty.websocket:websocket-jetty-common:jar:11.0.15
-    License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0)    License: Apache Software License - Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0)
+    License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0)
+    License: Apache Software License - Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0)
+
   - Jetty :: Websocket :: org.eclipse.jetty.websocket :: Server (https://eclipse.org/jetty/websocket-parent/websocket-jetty-server) org.eclipse.jetty.websocket:websocket-jetty-server:jar:11.0.15
-    License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0)    License: Apache Software License - Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0)
+    License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0)
+    License: Apache Software License - Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0)
+
   - Jetty :: Websocket :: Servlet (https://eclipse.org/jetty/websocket-parent/websocket-servlet) org.eclipse.jetty.websocket:websocket-servlet:jar:11.0.15
-    License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0)    License: Apache Software License - Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0)
+    License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0)
+    License: Apache Software License - Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0)
+
 
 
 

--- a/apache-qpid-broker-j/src/main/assembly/dependency-verification/DEPENDENCIES_REFERENCE
+++ b/apache-qpid-broker-j/src/main/assembly/dependency-verification/DEPENDENCIES_REFERENCE
@@ -57,11 +57,11 @@ From: 'Apache Software Foundation' (http://db.apache.org/)
     License: Apache 2  (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 From: 'FasterXML' (http://fasterxml.com/)
-  - Jackson-annotations (https://github.com/FasterXML/jackson) com.fasterxml.jackson.core:jackson-annotations:bundle:2.14.2
+  - Jackson-annotations (https://github.com/FasterXML/jackson) com.fasterxml.jackson.core:jackson-annotations:jar:2.15.0
     License: The Apache Software License, Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
-  - Jackson-core (https://github.com/FasterXML/jackson-core) com.fasterxml.jackson.core:jackson-core:bundle:2.14.2
+  - Jackson-core (https://github.com/FasterXML/jackson-core) com.fasterxml.jackson.core:jackson-core:jar:2.15.0
     License: The Apache Software License, Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
-  - jackson-databind (https://github.com/FasterXML/jackson) com.fasterxml.jackson.core:jackson-databind:bundle:2.14.2
+  - jackson-databind (https://github.com/FasterXML/jackson) com.fasterxml.jackson.core:jackson-databind:jar:2.15.0
     License: The Apache Software License, Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
 
 From: 'JolBox' (http://jolbox.com)
@@ -77,15 +77,15 @@ From: 'Oracle Corporation' (http://www.oracle.com/)
     License: Apache License, Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
 
 From: 'OW2' (http://www.ow2.org/)
-  - asm (http://asm.ow2.io/) org.ow2.asm:asm:jar:9.4
+  - asm (http://asm.ow2.io/) org.ow2.asm:asm:jar:9.5
     License: BSD-3-Clause  (https://asm.ow2.io/license.html)
-  - asm-tree (http://asm.ow2.io/) org.ow2.asm:asm-tree:jar:9.4
+  - asm-tree (http://asm.ow2.io/) org.ow2.asm:asm-tree:jar:9.5
     License: BSD-3-Clause  (https://asm.ow2.io/license.html)
 
 From: 'QOS.ch' (http://www.qos.ch)
-  - Logback Classic Module (http://logback.qos.ch/logback-classic) ch.qos.logback:logback-classic:jar:1.4.6
+  - Logback Classic Module (http://logback.qos.ch/logback-classic) ch.qos.logback:logback-classic:jar:1.4.7
     License: Eclipse Public License - v 1.0  (http://www.eclipse.org/legal/epl-v10.html)    License: GNU Lesser General Public License  (http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html)
-  - Logback Core Module (http://logback.qos.ch/logback-core) ch.qos.logback:logback-core:jar:1.4.6
+  - Logback Core Module (http://logback.qos.ch/logback-core) ch.qos.logback:logback-core:jar:1.4.7
     License: Eclipse Public License - v 1.0  (http://www.eclipse.org/legal/epl-v10.html)    License: GNU Lesser General Public License  (http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html)
   - Logback DBAppender Classic Module (http://logback.qos.ch/logback-classic-db) ch.qos.logback.db:logback-classic-db:jar:1.2.11.1
     License: Eclipse Public License - v 1.0  (http://www.eclipse.org/legal/epl-v10.html)    License: GNU Lesser General Public License  (http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html)
@@ -153,33 +153,33 @@ From: 'The CometD Project' (https://cometd.org)
     License: Academic Free License v2.1  (https://github.com/dojo/dojo/blob/master/LICENSE)    License: BSD License  (https://github.com/dojo/dojo/blob/master/LICENSE)
 
 From: 'Webtide' (https://webtide.com)
-  - Jetty :: Http Utility (https://eclipse.org/jetty/jetty-http) org.eclipse.jetty:jetty-http:jar:11.0.14
+  - Jetty :: Http Utility (https://eclipse.org/jetty/jetty-http) org.eclipse.jetty:jetty-http:jar:11.0.15
     License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0)    License: Apache Software License - Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0)
-  - Jetty :: IO Utility (https://eclipse.org/jetty/jetty-io) org.eclipse.jetty:jetty-io:jar:11.0.14
+  - Jetty :: IO Utility (https://eclipse.org/jetty/jetty-io) org.eclipse.jetty:jetty-io:jar:11.0.15
     License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0)    License: Apache Software License - Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0)
-  - Jetty :: Rewrite Handler (https://eclipse.org/jetty/jetty-rewrite) org.eclipse.jetty:jetty-rewrite:jar:11.0.14
+  - Jetty :: Rewrite Handler (https://eclipse.org/jetty/jetty-rewrite) org.eclipse.jetty:jetty-rewrite:jar:11.0.15
     License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0)    License: Apache Software License - Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0)
-  - Jetty :: Security (https://eclipse.org/jetty/jetty-security) org.eclipse.jetty:jetty-security:jar:11.0.14
+  - Jetty :: Security (https://eclipse.org/jetty/jetty-security) org.eclipse.jetty:jetty-security:jar:11.0.15
     License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0)    License: Apache Software License - Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0)
-  - Jetty :: Server Core (https://eclipse.org/jetty/jetty-server) org.eclipse.jetty:jetty-server:jar:11.0.14
+  - Jetty :: Server Core (https://eclipse.org/jetty/jetty-server) org.eclipse.jetty:jetty-server:jar:11.0.15
     License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0)    License: Apache Software License - Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0)
-  - Jetty :: Servlet Handling (https://eclipse.org/jetty/jetty-servlet) org.eclipse.jetty:jetty-servlet:jar:11.0.14
+  - Jetty :: Servlet Handling (https://eclipse.org/jetty/jetty-servlet) org.eclipse.jetty:jetty-servlet:jar:11.0.15
     License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0)    License: Apache Software License - Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0)
-  - Jetty :: Utility Servlets and Filters (https://eclipse.org/jetty/jetty-servlets) org.eclipse.jetty:jetty-servlets:jar:11.0.14
+  - Jetty :: Utility Servlets and Filters (https://eclipse.org/jetty/jetty-servlets) org.eclipse.jetty:jetty-servlets:jar:11.0.15
     License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0)    License: Apache Software License - Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0)
-  - Jetty :: Utilities (https://eclipse.org/jetty/jetty-util) org.eclipse.jetty:jetty-util:jar:11.0.14
+  - Jetty :: Utilities (https://eclipse.org/jetty/jetty-util) org.eclipse.jetty:jetty-util:jar:11.0.15
     License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0)    License: Apache Software License - Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0)
-  - Jetty :: Websocket :: Core :: Common (https://eclipse.org/jetty/websocket-parent/websocket-core-common) org.eclipse.jetty.websocket:websocket-core-common:jar:11.0.14
+  - Jetty :: Websocket :: Core :: Common (https://eclipse.org/jetty/websocket-parent/websocket-core-common) org.eclipse.jetty.websocket:websocket-core-common:jar:11.0.15
     License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0)    License: Apache Software License - Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0)
-  - Jetty :: Websocket :: Core :: Server (https://eclipse.org/jetty/websocket-parent/websocket-core-server) org.eclipse.jetty.websocket:websocket-core-server:jar:11.0.14
+  - Jetty :: Websocket :: Core :: Server (https://eclipse.org/jetty/websocket-parent/websocket-core-server) org.eclipse.jetty.websocket:websocket-core-server:jar:11.0.15
     License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0)    License: Apache Software License - Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0)
-  - Jetty :: Websocket :: org.eclipse.jetty.websocket :: API (https://eclipse.org/jetty/websocket-parent/websocket-jetty-api) org.eclipse.jetty.websocket:websocket-jetty-api:jar:11.0.14
+  - Jetty :: Websocket :: org.eclipse.jetty.websocket :: API (https://eclipse.org/jetty/websocket-parent/websocket-jetty-api) org.eclipse.jetty.websocket:websocket-jetty-api:jar:11.0.15
     License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0)    License: Apache Software License - Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0)
-  - Jetty :: Websocket :: org.eclipse.jetty.websocket :: Common (https://eclipse.org/jetty/websocket-parent/websocket-jetty-common) org.eclipse.jetty.websocket:websocket-jetty-common:jar:11.0.14
+  - Jetty :: Websocket :: org.eclipse.jetty.websocket :: Common (https://eclipse.org/jetty/websocket-parent/websocket-jetty-common) org.eclipse.jetty.websocket:websocket-jetty-common:jar:11.0.15
     License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0)    License: Apache Software License - Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0)
-  - Jetty :: Websocket :: org.eclipse.jetty.websocket :: Server (https://eclipse.org/jetty/websocket-parent/websocket-jetty-server) org.eclipse.jetty.websocket:websocket-jetty-server:jar:11.0.14
+  - Jetty :: Websocket :: org.eclipse.jetty.websocket :: Server (https://eclipse.org/jetty/websocket-parent/websocket-jetty-server) org.eclipse.jetty.websocket:websocket-jetty-server:jar:11.0.15
     License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0)    License: Apache Software License - Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0)
-  - Jetty :: Websocket :: Servlet (https://eclipse.org/jetty/websocket-parent/websocket-servlet) org.eclipse.jetty.websocket:websocket-servlet:jar:11.0.14
+  - Jetty :: Websocket :: Servlet (https://eclipse.org/jetty/websocket-parent/websocket-servlet) org.eclipse.jetty.websocket:websocket-servlet:jar:11.0.15
     License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0)    License: Apache Software License - Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0)
 
 

--- a/broker-plugins/logging-logback/src/main/java/org/apache/qpid/server/logging/logback/NoopConfigurator.java
+++ b/broker-plugins/logging-logback/src/main/java/org/apache/qpid/server/logging/logback/NoopConfigurator.java
@@ -20,14 +20,14 @@
  */
 package org.apache.qpid.server.logging.logback;
 
-import ch.qos.logback.classic.LoggerContext;
-import ch.qos.logback.classic.spi.Configurator;
+import ch.qos.logback.core.Context;
+import ch.qos.logback.core.spi.Configurator;
 import ch.qos.logback.core.spi.ContextAwareBase;
 
 public class NoopConfigurator extends ContextAwareBase implements Configurator
 {
     @Override
-    public ExecutionStatus configure(LoggerContext loggerContext)
+    public ExecutionStatus configure(Context loggerContext)
     {
         // no-op
         return ExecutionStatus.NEUTRAL;

--- a/perftests/src/main/assembly/dependency-verification/DEPENDENCIES_REFERENCE
+++ b/perftests/src/main/assembly/dependency-verification/DEPENDENCIES_REFERENCE
@@ -25,44 +25,66 @@ Apache Qpid Broker-J Performance Tests
 
 
 From: 'an unknown organization'
+
   - Guava InternalFutureFailureAccess and InternalFutures (https://github.com/google/guava/failureaccess) com.google.guava:failureaccess:bundle:1.0.1
     License: The Apache Software License, Version 2.0  (http://www.apache.org/licenses/LICENSE-2.0.txt)
-  - Guava: Google Core Libraries for Java (https://github.com/google/guava) com.google.guava:guava:bundle:31.1-jre
+
+  - Guava: Google Core Libraries for Java (https://github.com/google/guava) com.google.guava:guava:bundle:32.1.2-jre
     License: Apache License, Version 2.0  (http://www.apache.org/licenses/LICENSE-2.0.txt)
-  - J2ObjC Annotations (https://github.com/google/j2objc/) com.google.j2objc:j2objc-annotations:jar:1.3
-    License: The Apache Software License, Version 2.0  (http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+  - J2ObjC Annotations (https://github.com/google/j2objc/) com.google.j2objc:j2objc-annotations:jar:2.8
+    License: Apache License, Version 2.0  (http://www.apache.org/licenses/LICENSE-2.0.txt)
+
 
 From: 'Apache Software Foundation' (http://www.apache.org)
+
   - JMS 1.1 (http://geronimo.apache.org/specs/geronimo-jms_1.1_spec) org.apache.geronimo.specs:geronimo-jms_1.1_spec:jar:1.1.1
     License: The Apache Software License, Version 2.0  (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
+
 From: 'FasterXML' (http://fasterxml.com/)
-  - Jackson-annotations (https://github.com/FasterXML/jackson) com.fasterxml.jackson.core:jackson-annotations:jar:2.15.0
-    License: The Apache Software License, Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
-  - Jackson-core (https://github.com/FasterXML/jackson-core) com.fasterxml.jackson.core:jackson-core:jar:2.15.0
-    License: The Apache Software License, Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
-  - jackson-databind (https://github.com/FasterXML/jackson) com.fasterxml.jackson.core:jackson-databind:jar:2.15.0
+
+  - Jackson-annotations (https://github.com/FasterXML/jackson) com.fasterxml.jackson.core:jackson-annotations:jar:2.15.2
     License: The Apache Software License, Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
 
+  - Jackson-core (https://github.com/FasterXML/jackson-core) com.fasterxml.jackson.core:jackson-core:jar:2.15.2
+    License: The Apache Software License, Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+  - jackson-databind (https://github.com/FasterXML/jackson) com.fasterxml.jackson.core:jackson-databind:jar:2.15.2
+    License: The Apache Software License, Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+
 From: 'QOS.ch' (http://www.qos.ch)
-  - Logback Classic Module (http://logback.qos.ch/logback-classic) ch.qos.logback:logback-classic:jar:1.4.7
-    License: Eclipse Public License - v 1.0  (http://www.eclipse.org/legal/epl-v10.html)    License: GNU Lesser General Public License  (http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html)
-  - Logback Core Module (http://logback.qos.ch/logback-core) ch.qos.logback:logback-core:jar:1.4.7
-    License: Eclipse Public License - v 1.0  (http://www.eclipse.org/legal/epl-v10.html)    License: GNU Lesser General Public License  (http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html)
+
+  - Logback Classic Module (http://logback.qos.ch/logback-classic) ch.qos.logback:logback-classic:jar:1.4.9
+    License: Eclipse Public License - v 1.0  (http://www.eclipse.org/legal/epl-v10.html)
+    License: GNU Lesser General Public License  (http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html)
+
+  - Logback Core Module (http://logback.qos.ch/logback-core) ch.qos.logback:logback-core:jar:1.4.9
+    License: Eclipse Public License - v 1.0  (http://www.eclipse.org/legal/epl-v10.html)
+    License: GNU Lesser General Public License  (http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html)
+
   - SLF4J API Module (http://www.slf4j.org) org.slf4j:slf4j-api:jar:2.0.7
     License: MIT License  (http://www.opensource.org/licenses/mit-license.php)
 
+
 From: 'The Apache Software Foundation' (http://www.apache.org/)
+
   - Apache Commons Logging (http://commons.apache.org/proper/commons-logging/) commons-logging:commons-logging:jar:1.2
     License: The Apache Software License, Version 2.0  (http://www.apache.org/licenses/LICENSE-2.0.txt)
+
   - Apache HttpClient (http://hc.apache.org/httpcomponents-client) org.apache.httpcomponents:httpclient:jar:4.5.13
     License: Apache License, Version 2.0  (http://www.apache.org/licenses/LICENSE-2.0.txt)
+
   - Apache HttpCore (http://hc.apache.org/httpcomponents-core-ga) org.apache.httpcomponents:httpcore:jar:4.4.13
     License: Apache License, Version 2.0  (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
+
 From: 'The Apache Software Foundation' (https://www.apache.org/)
+
   - Apache Commons Codec (http://commons.apache.org/proper/commons-codec/) commons-codec:commons-codec:jar:1.11
     License: Apache License, Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
+
 
 
 

--- a/perftests/src/main/assembly/dependency-verification/DEPENDENCIES_REFERENCE
+++ b/perftests/src/main/assembly/dependency-verification/DEPENDENCIES_REFERENCE
@@ -37,17 +37,17 @@ From: 'Apache Software Foundation' (http://www.apache.org)
     License: The Apache Software License, Version 2.0  (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 From: 'FasterXML' (http://fasterxml.com/)
-  - Jackson-annotations (https://github.com/FasterXML/jackson) com.fasterxml.jackson.core:jackson-annotations:bundle:2.14.2
+  - Jackson-annotations (https://github.com/FasterXML/jackson) com.fasterxml.jackson.core:jackson-annotations:jar:2.15.0
     License: The Apache Software License, Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
-  - Jackson-core (https://github.com/FasterXML/jackson-core) com.fasterxml.jackson.core:jackson-core:bundle:2.14.2
+  - Jackson-core (https://github.com/FasterXML/jackson-core) com.fasterxml.jackson.core:jackson-core:jar:2.15.0
     License: The Apache Software License, Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
-  - jackson-databind (https://github.com/FasterXML/jackson) com.fasterxml.jackson.core:jackson-databind:bundle:2.14.2
+  - jackson-databind (https://github.com/FasterXML/jackson) com.fasterxml.jackson.core:jackson-databind:jar:2.15.0
     License: The Apache Software License, Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
 
 From: 'QOS.ch' (http://www.qos.ch)
-  - Logback Classic Module (http://logback.qos.ch/logback-classic) ch.qos.logback:logback-classic:jar:1.4.6
+  - Logback Classic Module (http://logback.qos.ch/logback-classic) ch.qos.logback:logback-classic:jar:1.4.7
     License: Eclipse Public License - v 1.0  (http://www.eclipse.org/legal/epl-v10.html)    License: GNU Lesser General Public License  (http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html)
-  - Logback Core Module (http://logback.qos.ch/logback-core) ch.qos.logback:logback-core:jar:1.4.6
+  - Logback Core Module (http://logback.qos.ch/logback-core) ch.qos.logback:logback-core:jar:1.4.7
     License: Eclipse Public License - v 1.0  (http://www.eclipse.org/legal/epl-v10.html)    License: GNU Lesser General Public License  (http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html)
   - SLF4J API Module (http://www.slf4j.org) org.slf4j:slf4j-api:jar:2.0.7
     License: MIT License  (http://www.opensource.org/licenses/mit-license.php)

--- a/pom.xml
+++ b/pom.xml
@@ -104,13 +104,13 @@
 
     <bdb-version>7.4.5</bdb-version>
     <derby-version>10.14.2.0</derby-version>
-    <logback-version>1.4.6</logback-version>
+    <logback-version>1.4.7</logback-version>
     <logback-db-version>1.2.11.1</logback-db-version>
     <guava-version>31.1-jre</guava-version>
-    <fasterxml-jackson-version>2.14.2</fasterxml-jackson-version>
-    <fasterxml-jackson-databind-version>2.14.2</fasterxml-jackson-databind-version>
+    <fasterxml-jackson-version>2.15.0</fasterxml-jackson-version>
+    <fasterxml-jackson-databind-version>2.15.0</fasterxml-jackson-databind-version>
     <slf4j-version>2.0.7</slf4j-version>
-    <jetty-version>11.0.14</jetty-version>
+    <jetty-version>11.0.15</jetty-version>
 
     <!-- dependency version numbers -->
     <bonecp-version>0.8.0.RELEASE</bonecp-version>
@@ -118,7 +118,7 @@
 
     <geronimo-jms-1-1-version>1.1.1</geronimo-jms-1-1-version>
     <geronimo-jms-2-0-version>1.0-alpha-2</geronimo-jms-2-0-version>
-    <asm-version>9.4</asm-version>
+    <asm-version>9.5</asm-version>
 
     <velocity-version>1.4</velocity-version>
     <csvjdbc-version>1.0.35</csvjdbc-version>
@@ -129,9 +129,9 @@
     <dgrid-version>1.3.3</dgrid-version>
 
     <!-- test dependency version numbers -->
-    <junit-version>5.9.2</junit-version>
-    <mockito-version>5.2.0</mockito-version>
-    <netty-version>4.1.90.Final</netty-version>
+    <junit-version>5.9.3</junit-version>
+    <mockito-version>5.3.1</mockito-version>
+    <netty-version>4.1.92.Final</netty-version>
     <hamcrest-version>2.2</hamcrest-version>
     <maven-resolver-provider-version>3.8.6</maven-resolver-provider-version>
     <maven-resolver-version>1.8.2</maven-resolver-version>
@@ -144,25 +144,25 @@
     <exec-maven-plugin-version>3.1.0</exec-maven-plugin-version>
     <javacc-maven-plugin-version>2.6</javacc-maven-plugin-version>
     <ph-javacc-maven-plugin-version>4.1.5</ph-javacc-maven-plugin-version>
-    <maven-enforcer-plugin-version>3.2.1</maven-enforcer-plugin-version>
+    <maven-enforcer-plugin-version>3.3.0</maven-enforcer-plugin-version>
     <maven-rar-plugin-version>2.4</maven-rar-plugin-version>
     <license-maven-plugin-version>2.0.0</license-maven-plugin-version>
-    <maven-jxr-plugin-version>3.0.0</maven-jxr-plugin-version>
+    <maven-jxr-plugin-version>3.3.0</maven-jxr-plugin-version>
     <findbugs-maven-plugin-version>3.0.5</findbugs-maven-plugin-version>
-    <jacoco-plugin-version>0.8.8</jacoco-plugin-version>
+    <jacoco-plugin-version>0.8.9</jacoco-plugin-version>
     <apache-rat-plugin-version>0.15</apache-rat-plugin-version>
     <maven-docbx-plugin-version>2.0.15</maven-docbx-plugin-version>
     <maven-docbook-xml-plugin-version>5.0-all</maven-docbook-xml-plugin-version>
     <buildnumber-maven-plugin-version>1.4</buildnumber-maven-plugin-version>
-    <maven-compiler-plugin-version>3.10.1</maven-compiler-plugin-version>
+    <maven-compiler-plugin-version>3.11.0</maven-compiler-plugin-version>
     <maven-jar-plugin-version>3.3.0</maven-jar-plugin-version>
     <maven-surefire-plugin-version>3.0.0</maven-surefire-plugin-version>
     <maven-surefire-report-plugin-version>3.0.0</maven-surefire-report-plugin-version>
     <h2.version>2.1.214</h2.version>
     <apache-directory-version>2.0.0.AM25</apache-directory-version>
     <kerby-version>2.0.3</kerby-version>
-    <bcprov-version>1.72</bcprov-version>
-    <bcpkix-version>1.72</bcpkix-version>
+    <bcprov-version>1.73</bcprov-version>
+    <bcpkix-version>1.73</bcpkix-version>
     <logback-gelf-version>3.0.0</logback-gelf-version>
     <prometheus-client-version>0.16.0</prometheus-client-version>
 
@@ -536,6 +536,16 @@
         <groupId>org.apache.qpid</groupId>
         <artifactId>qpid-jms-client</artifactId>
         <version>${qpid-jms-client-version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-transport-native-epoll</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-transport-native-kqueue</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>com.sleepycat</groupId>
@@ -780,6 +790,14 @@
         <groupId>io.netty</groupId>
         <artifactId>netty-codec-http</artifactId>
         <version>${netty-version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-transport-native-epoll</artifactId>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-transport-native-kqueue</artifactId>
       </dependency>
       <dependency>
         <groupId>org.hamcrest</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache</groupId>
     <artifactId>apache</artifactId>
-    <version>29</version>
+    <version>30</version>
   </parent>
 
   <groupId>org.apache.qpid</groupId>
@@ -104,11 +104,11 @@
 
     <bdb-version>7.4.5</bdb-version>
     <derby-version>10.14.2.0</derby-version>
-    <logback-version>1.4.7</logback-version>
+    <logback-version>1.4.9</logback-version>
     <logback-db-version>1.2.11.1</logback-db-version>
-    <guava-version>31.1-jre</guava-version>
-    <fasterxml-jackson-version>2.15.0</fasterxml-jackson-version>
-    <fasterxml-jackson-databind-version>2.15.0</fasterxml-jackson-databind-version>
+    <guava-version>32.1.2-jre</guava-version>
+    <fasterxml-jackson-version>2.15.2</fasterxml-jackson-version>
+    <fasterxml-jackson-databind-version>2.15.2</fasterxml-jackson-databind-version>
     <slf4j-version>2.0.7</slf4j-version>
     <jetty-version>11.0.15</jetty-version>
 
@@ -129,9 +129,9 @@
     <dgrid-version>1.3.3</dgrid-version>
 
     <!-- test dependency version numbers -->
-    <junit-version>5.9.3</junit-version>
-    <mockito-version>5.3.1</mockito-version>
-    <netty-version>4.1.92.Final</netty-version>
+    <junit-version>5.10.0</junit-version>
+    <mockito-version>5.4.0</mockito-version>
+    <netty-version>4.1.96.Final</netty-version>
     <hamcrest-version>2.2</hamcrest-version>
     <maven-resolver-provider-version>3.8.6</maven-resolver-provider-version>
     <maven-resolver-version>1.8.2</maven-resolver-version>
@@ -149,20 +149,20 @@
     <license-maven-plugin-version>2.0.0</license-maven-plugin-version>
     <maven-jxr-plugin-version>3.3.0</maven-jxr-plugin-version>
     <findbugs-maven-plugin-version>3.0.5</findbugs-maven-plugin-version>
-    <jacoco-plugin-version>0.8.9</jacoco-plugin-version>
+    <jacoco-plugin-version>0.8.10</jacoco-plugin-version>
     <apache-rat-plugin-version>0.15</apache-rat-plugin-version>
     <maven-docbx-plugin-version>2.0.15</maven-docbx-plugin-version>
     <maven-docbook-xml-plugin-version>5.0-all</maven-docbook-xml-plugin-version>
     <buildnumber-maven-plugin-version>1.4</buildnumber-maven-plugin-version>
     <maven-compiler-plugin-version>3.11.0</maven-compiler-plugin-version>
     <maven-jar-plugin-version>3.3.0</maven-jar-plugin-version>
-    <maven-surefire-plugin-version>3.0.0</maven-surefire-plugin-version>
-    <maven-surefire-report-plugin-version>3.0.0</maven-surefire-report-plugin-version>
-    <h2.version>2.1.214</h2.version>
+    <maven-surefire-plugin-version>3.1.2</maven-surefire-plugin-version>
+    <maven-surefire-report-plugin-version>3.1.2</maven-surefire-report-plugin-version>
+    <h2.version>2.2.220</h2.version>
     <apache-directory-version>2.0.0.AM25</apache-directory-version>
     <kerby-version>2.0.3</kerby-version>
-    <bcprov-version>1.73</bcprov-version>
-    <bcpkix-version>1.73</bcpkix-version>
+    <bcprov-version>1.76</bcprov-version>
+    <bcpkix-version>1.76</bcpkix-version>
     <logback-gelf-version>3.0.0</logback-gelf-version>
     <prometheus-client-version>0.16.0</prometheus-client-version>
 


### PR DESCRIPTION
This PR addresses [QPID-8626](https://issues.apache.org/jira/browse/QPID-8626), updating broker dependencies.

Following dependencies are updated:

**runtime dependencies**

ch.qos.logback:logback-classic 1.4.6 => 1.4.9
com.fasterxml.jackson.core:jackson-core 2.14.2 => 2.15.2
com.fasterxml.jackson.core:jackson-databind 2.14.2 => 2.15.2
com.google.guava:guava 31.1-jre => 32.1.2-jre
com.h2database:h2 2.1.214 => 2.2.220
org.bouncycastle:bcprov-jdk18on 1.72 => 1.76
org.bouncycastle:bcpkix-jdk18on 1.72 => 1.76
org.ow2.asm:asm 9.4 => 9.5
org.ow2.asm:asm-tree 9.4 => 9.5
org.eclipse.jetty:jetty-server 11.0.14 => 11.0.15
org.eclipse.jetty:jetty-servlet 11.0.14 => 11.0.15
org.eclipse.jetty:jetty-servlets 11.0.14 => 11.0.15
org.eclipse.jetty:jetty-rewrite 11.0.14 => 11.0.15
org.eclipse.jetty.websocket:websocket-jetty-server 11.0.14 => 11.0.15

**test dependencies**

io.netty:netty-buffer 4.1.90.Final => 4.1.96.Final
io.netty:netty-common 4.1.90.Final => 4.1.96.Final
io.netty:netty-handler 4.1.90.Final => 4.1.96.Final
io.netty:netty-transport 4.1.90.Final => 4.1.96.Final
io.netty:netty-codec-http 4.1.90.Final => 4.1.96.Final
org.junit.jupiter:junit-jupiter-api 5.9.2 => 5.10.0
org.junit.jupiter:junit-jupiter-engine 5.9.2 => 5.10.0
org.junit.jupiter:junit-jupiter-params 5.9.2 => 5.10.0
org.mockito:mockito-core 5.2.0 => 5.4.0

**maven plugins**
org.apache.maven.plugins:maven-complier-plugin 3.10.1 => 3.11.0
org.apache.maven.plugins:maven-enforcer-plugin 3.2.1 => 3.3.0
org.apache.maven.plugins:maven-jxr-plugin 3.0.0 => 3.3.0
org.jacoco:jacoco-maven-plugin 0.8.8 => 0.8.10