### PR TITLE
QPID-8623: [Broker-J] AESKeyFile encryption breaks SimpleLDAPAuthenticationManager user search

### DIFF
--- a/broker-core/src/main/java/org/apache/qpid/server/store/GenericRecoverer.java
+++ b/broker-core/src/main/java/org/apache/qpid/server/store/GenericRecoverer.java
@@ -242,6 +242,10 @@ public class GenericRecoverer
                     updatesMade = true;
                     unresolvedIter.remove();
                     ConfiguredObject<?> resolved = unresolvedObject.resolve();
+                    if (!isNew)
+                    {
+                        resolved.decryptSecrets();
+                    }
                     resolvedObjects.put(resolved.getId(), resolved);
                 }
             }


### PR DESCRIPTION
This PR addresses JIRA [QPID-8623](https://issues.apache.org/jira/browse/QPID-8623), fixing issue with the LDAP authentication when an configuration encryption provider is enabled