### PR TITLE
QPID-8625: [Broker-J] ACL rules require full DN when using LDAP authentication

### DIFF
--- a/broker-core/src/main/java/org/apache/qpid/server/security/auth/manager/SimpleLDAPAuthenticationManager.java
+++ b/broker-core/src/main/java/org/apache/qpid/server/security/auth/manager/SimpleLDAPAuthenticationManager.java
@@ -35,8 +35,8 @@ public interface SimpleLDAPAuthenticationManager<X extends SimpleLDAPAuthenticat
         extends CachingAuthenticationProvider<X>,
                 UsernamePasswordAuthenticationProvider<X>
 {
-    String CLASS_DESCRIPTION = "Authentication provider that delegates authentication decisions to a Directory"
-                               + " supporting the LDAP protocol.";
+    String CLASS_DESCRIPTION = "Authentication provider that delegates authentication decisions to a Directory" +
+            " supporting the LDAP protocol.";
 
     String PROVIDER_TYPE = "SimpleLDAP";
     String PROVIDER_URL = "providerUrl";
@@ -67,6 +67,9 @@ public interface SimpleLDAPAuthenticationManager<X extends SimpleLDAPAuthenticat
 
     @ManagedAttribute( description = "Bind without search")
     boolean isBindWithoutSearch();
+
+    @ManagedAttribute( description = "Use full LDAP name as a principal name", defaultValue = "true")
+    boolean isUseFullLDAPName();
 
     @ManagedContextDefault( name = "ldap.context.factory")
     String DEFAULT_LDAP_CONTEXT_FACTORY = "com.sun.jndi.ldap.LdapCtxFactory";

--- a/broker-core/src/test/resources/users.ldif
+++ b/broker-core/src/test/resources/users.ldif
@@ -43,6 +43,16 @@ sn: ldap-integration-test1
 uid: test1
 userPassword: password1
 
+dn: uid=test2,ou=users,dc=qpid,dc=org
+objectClass: inetOrgPerson
+objectClass: organizationalPerson
+objectClass: person
+objectClass: top
+cn: integration-test2
+sn: ldap-integration-test2
+uid: test2
+userPassword: password2
+
 dn: cn=group1,ou=groups,dc=qpid,dc=org
 cn: Group1
 member: cn=integration-test1,ou=Users,dc=qpid,dc=org

--- a/broker-plugins/management-http/src/main/java/resources/authenticationprovider/simpleldap/add.html
+++ b/broker-plugins/management-http/src/main/java/resources/authenticationprovider/simpleldap/add.html
@@ -160,9 +160,24 @@
                            data-dojo-props=" name: 'bindWithoutSearch' " />
                 </div>
             </div>
+
             <div data-dojo-type="dijit/Tooltip"
                  data-dojo-props="connectId: ['addAuthenticationProvider.simpleldap.bindWithoutSearch'],
                                                   label: 'If selected, the provider will not search the directory'">
+            </div>
+
+            <div class="clear">
+                <div class="formLabel-labelCell tableContainer-labelCell">Use Full LDAP Name:</div>
+                <div class="formLabel-controlCell tableContainer-valueCell">
+                    <input type="text" class="useFullLDAPName" id="addAuthenticationProvider.simpleldap.useFullLDAPName".
+                           data-dojo-type="dijit/form/CheckBox"
+                           data-dojo-props=" name: 'useFullLDAPName' " />
+                </div>
+            </div>
+
+            <div data-dojo-type="dijit/Tooltip"
+                 data-dojo-props="connectId: ['addAuthenticationProvider.simpleldap.useFullLDAPName'],
+                                                  label: 'If selected, full LDAP name will be used as a principal name'">
             </div>
         </fieldset>
     </div>

--- a/broker-plugins/management-http/src/main/java/resources/authenticationprovider/simpleldap/show.html
+++ b/broker-plugins/management-http/src/main/java/resources/authenticationprovider/simpleldap/show.html
@@ -67,6 +67,11 @@
                 <div class="formLabel-labelCell">Bind without search:</div>
                 <div><span class="bindWithoutSearch" ></span></div>
             </div>
+
+            <div class="clear">
+                <div class="formLabel-labelCell">Use full LDAP name:</div>
+                <div><span class="useFullLDAPName" ></span></div>
+            </div>
         </fieldset>
     </div>
     <div class="clear"></div>

--- a/doc/java-broker/src/docbkx/security/Java-Broker-Security-Authentication-Providers-LDAP.xml
+++ b/doc/java-broker/src/docbkx/security/Java-Broker-Security-Authentication-Providers-LDAP.xml
@@ -67,6 +67,11 @@
             </para>
         </listitem>
         <listitem>
+            <para><emphasis>useFullLDAPName</emphasis> is a boolean flag, defining whether user principal name will be
+                obtained from full LDAP DN (default behavior) or from CN only. Set this flag to "false" to be able
+                referencing principal by its CN in broker ACL rules.</para>
+        </listitem>
+        <listitem>
             <para>Additional group information can be obtained from LDAP.
                 There are two common ways of representing group membership in LDAP.
                 <itemizedlist>


### PR DESCRIPTION
This PR affects JIRA [QPID-8625](https://issues.apache.org/jira/browse/QPID-8625), adding possibility to use CN instead of full DN in ACL rules.