### PR TITLE
QPID-8653: [Broker-J] Code cleanup: prometheus / query-engine / websocket - collection type arguments, collection factory methods, lambdas 

### DIFF
--- a/broker-plugins/prometheus-exporter/src/main/java/org/apache/qpid/server/prometheus/PrometheusContentFactory.java
+++ b/broker-plugins/prometheus-exporter/src/main/java/org/apache/qpid/server/prometheus/PrometheusContentFactory.java
@@ -24,10 +24,10 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 import io.prometheus.client.exporter.common.TextFormat;
 
@@ -63,7 +63,7 @@ public class PrometheusContentFactory implements ContentFactory
         final IncludeMetricPredicate metricIncludeFilter =
                 new IncludeMetricPredicate(includedMetricNames == null || includedMetricNames.length == 0
                                                    ? Collections.emptySet()
-                                                   : new HashSet<>(Arrays.asList(includedMetricNames)));
+                                                   : new HashSet<>(Set.of(includedMetricNames)));
         final QpidCollector qpidCollector = new QpidCollector(object,
                                                               new IncludeDisabledStatisticPredicate(includeDisabled),
                                                               metricIncludeFilter);

--- a/broker-plugins/prometheus-exporter/src/main/java/org/apache/qpid/server/prometheus/QpidCollector.java
+++ b/broker-plugins/prometheus-exporter/src/main/java/org/apache/qpid/server/prometheus/QpidCollector.java
@@ -21,7 +21,6 @@ package org.apache.qpid.server.prometheus;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -61,8 +60,8 @@ public class QpidCollector extends Collector
     public List<MetricFamilySamples> collect()
     {
         final List<MetricFamilySamples> metricFamilySamples = new ArrayList<>();
-        addObjectMetrics(_root, Collections.emptyList(), new HashMap<>(), metricFamilySamples);
-        addChildrenMetrics(metricFamilySamples, _root, Collections.singletonList("name"));
+        addObjectMetrics(_root, List.of(), new HashMap<>(), metricFamilySamples);
+        addChildrenMetrics(metricFamilySamples, _root, List.of("name"));
         return metricFamilySamples;
     }
 

--- a/broker-plugins/prometheus-exporter/src/test/java/org/apache/qpid/server/prometheus/PrometheusContentFactoryTest.java
+++ b/broker-plugins/prometheus-exporter/src/test/java/org/apache/qpid/server/prometheus/PrometheusContentFactoryTest.java
@@ -36,7 +36,6 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -77,7 +76,7 @@ public class PrometheusContentFactoryTest
     @Test
     public void testCreateContent() throws Exception
     {
-        final Content content = _prometheusContentFactory.createContent(_root, Collections.emptyMap());
+        final Content content = _prometheusContentFactory.createContent(_root, Map.of());
         assertThat(content, is(notNullValue()));
         Collection<String> metrics;
         try (final ByteArrayOutputStream output = new ByteArrayOutputStream())
@@ -95,7 +94,7 @@ public class PrometheusContentFactoryTest
     @Test
     public void testCreateContentIncludeDisabled() throws Exception
     {
-        final Content content = _prometheusContentFactory.createContent(_root, Collections.singletonMap(INCLUDE_DISABLED, new String[]{"true"}));
+        final Content content = _prometheusContentFactory.createContent(_root, Map.of(INCLUDE_DISABLED, new String[]{"true"}));
         assertThat(content, is(notNullValue()));
         Collection<String> metrics;
         try (final ByteArrayOutputStream output = new ByteArrayOutputStream())
@@ -115,7 +114,7 @@ public class PrometheusContentFactoryTest
     public void testCreateContentIncludeDisabledUsingContextVariable() throws Exception
     {
         _root.setContextVariable(INCLUDE_DISABLED_CONTEXT_VARIABLE, "true");
-        final Content content = _prometheusContentFactory.createContent(_root, Collections.emptyMap());
+        final Content content = _prometheusContentFactory.createContent(_root, Map.of());
         assertThat(content, is(notNullValue()));
         Collection<String> metrics;
         try (final ByteArrayOutputStream output = new ByteArrayOutputStream())

--- a/broker-plugins/prometheus-exporter/src/test/java/org/apache/qpid/server/prometheus/QpidCollectorTest.java
+++ b/broker-plugins/prometheus-exporter/src/test/java/org/apache/qpid/server/prometheus/QpidCollectorTest.java
@@ -29,11 +29,10 @@ import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import io.prometheus.client.Collector;
@@ -120,8 +119,8 @@ public class QpidCollectorTest extends UnitTestBase
                 QPID_TEST_ENGINE_TEMPERATURE_TOTAL);
         assertMetricFamilySamplesSize(engineMetricFamilySamples, 1);
         final Collector.MetricFamilySamples.Sample engineSample = engineMetricFamilySamples.samples.get(0);
-        assertThat(engineSample.labelNames, is(equalTo(Collections.singletonList("name"))));
-        assertThat(engineSample.labelValues, is(equalTo(Collections.singletonList(ELECTRIC_ENGINE_NAME))));
+        assertThat(engineSample.labelNames, is(equalTo(List.of("name"))));
+        assertThat(engineSample.labelValues, is(equalTo(List.of(ELECTRIC_ENGINE_NAME))));
         assertThat(engineSample.value, Matchers.closeTo(TestAbstractEngineImpl.TEST_TEMPERATURE, 0.01));
     }
 
@@ -149,8 +148,8 @@ public class QpidCollectorTest extends UnitTestBase
                 metricsMap.get(QPID_TEST_SENSOR_ALERT_COUNT);
         assertMetricFamilySamplesSize(sensorlMetricFamilySamples, 1);
         final Collector.MetricFamilySamples.Sample sensorSample = sensorlMetricFamilySamples.samples.get(0);
-        assertThat(sensorSample.labelNames, is(equalTo(Arrays.asList("name", "test_instrument_panel_name"))));
-        assertThat(sensorSample.labelValues, is(equalTo(Arrays.asList(SENSOR, INSTRUMENT_PANEL_NAME))));
+        assertThat(sensorSample.labelNames, is(equalTo(List.of("name", "test_instrument_panel_name"))));
+        assertThat(sensorSample.labelValues, is(equalTo(List.of(SENSOR, INSTRUMENT_PANEL_NAME))));
     }
 
     @Test
@@ -179,8 +178,8 @@ public class QpidCollectorTest extends UnitTestBase
         {
             final Collector.MetricFamilySamples.Sample sample =
                     findSampleByLabelValue(engineMetricFamilySamples, engineName);
-            assertThat(sample.labelNames, is(equalTo(Collections.singletonList("name"))));
-            assertThat(sample.labelValues, is(equalTo(Collections.singletonList(engineName))));
+            assertThat(sample.labelNames, is(equalTo(List.of("name"))));
+            assertThat(sample.labelValues, is(equalTo(List.of(engineName))));
             assertThat(sample.value, Matchers.closeTo(TestAbstractEngineImpl.TEST_TEMPERATURE, 0.01));
         }
     }
@@ -192,7 +191,7 @@ public class QpidCollectorTest extends UnitTestBase
 
         _qpidCollector = new QpidCollector(_root,
                                            new IncludeDisabledStatisticPredicate(true),
-                                           new IncludeMetricPredicate(Collections.singleton(QPID_TEST_CAR_AGE_COUNT)));
+                                           new IncludeMetricPredicate(Set.of(QPID_TEST_CAR_AGE_COUNT)));
         final List<Collector.MetricFamilySamples> metrics = _qpidCollector.collect();
 
         final String[] expectedFamilyNames = {QPID_TEST_CAR_AGE_COUNT};
@@ -203,8 +202,8 @@ public class QpidCollectorTest extends UnitTestBase
         final Collector.MetricFamilySamples engineMetricFamilySamples = metricsMap.get(QPID_TEST_CAR_AGE_COUNT);
         assertMetricFamilySamplesSize(engineMetricFamilySamples, 1);
         final Collector.MetricFamilySamples.Sample engineSample = engineMetricFamilySamples.samples.get(0);
-        assertThat(engineSample.labelNames, is(equalTo(Collections.emptyList())));
-        assertThat(engineSample.labelValues, is(equalTo(Collections.emptyList())));
+        assertThat(engineSample.labelNames, is(equalTo(List.of())));
+        assertThat(engineSample.labelValues, is(equalTo(List.of())));
         assertThat(engineSample.value, Matchers.closeTo(0.0, 0.01));
 
     }

--- a/broker-plugins/query-engine/src/main/java/org/apache/qpid/server/query/engine/QueryEngine.java
+++ b/broker-plugins/query-engine/src/main/java/org/apache/qpid/server/query/engine/QueryEngine.java
@@ -26,7 +26,6 @@ import java.util.Map;
 import java.util.Objects;
 
 import org.apache.qpid.server.model.Broker;
-import org.apache.qpid.server.model.port.HttpPort;
 import org.apache.qpid.server.query.engine.cache.MaxSizeHashMap;
 import org.apache.qpid.server.query.engine.evaluator.QueryEvaluator;
 import org.apache.qpid.server.query.engine.evaluator.settings.QuerySettings;

--- a/broker-plugins/websocket/src/main/java/org/apache/qpid/server/transport/websocket/WebSocketTransportProviderFactory.java
+++ b/broker-plugins/websocket/src/main/java/org/apache/qpid/server/transport/websocket/WebSocketTransportProviderFactory.java
@@ -20,7 +20,6 @@
  */
 package org.apache.qpid.server.transport.websocket;
 
-import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.Set;
@@ -39,8 +38,7 @@ public class WebSocketTransportProviderFactory implements TransportProviderFacto
     @Override
     public Set<Set<Transport>> getSupportedTransports()
     {
-        return new HashSet<Set<Transport>>(Arrays.asList(EnumSet.of(Transport.WS),
-                                                         EnumSet.of(Transport.WSS)));
+        return new HashSet<>(Set.of(EnumSet.of(Transport.WS), EnumSet.of(Transport.WSS)));
     }
 
     @Override


### PR DESCRIPTION
This PR addresses JIRA [QPID-8653](https://issues.apache.org/jira/browse/QPID-8653), refactoring code in modules broker-plugins/prometheus-exporter, broker-plugins/query-engine and broker-plugins/websocket