### PR TITLE
QPID-8653: [Broker-J] Code cleanup: access-control - collection type arguments, collection factory methods, lambdas

### DIFF
--- a/broker-plugins/access-control/src/main/java/org/apache/qpid/server/security/access/config/RuleBasedAccessControl.java
+++ b/broker-plugins/access-control/src/main/java/org/apache/qpid/server/security/access/config/RuleBasedAccessControl.java
@@ -21,7 +21,6 @@
 package org.apache.qpid.server.security.access.config;
 
 import java.security.AccessController;
-import java.util.Collections;
 import java.util.Map;
 
 import javax.security.auth.Subject;
@@ -104,7 +103,7 @@ public class RuleBasedAccessControl implements AccessControl<CachingSecurityToke
                             final Operation operation,
                             final PermissionedObject configuredObject)
     {
-        return authorise(token, operation, configuredObject, Collections.<String,Object>emptyMap());
+        return authorise(token, operation, configuredObject, Map.of());
     }
 
     @Override

--- a/broker-plugins/access-control/src/main/java/org/apache/qpid/server/security/access/plugins/AclFileAccessControlProviderImpl.java
+++ b/broker-plugins/access-control/src/main/java/org/apache/qpid/server/security/access/plugins/AclFileAccessControlProviderImpl.java
@@ -20,7 +20,6 @@
  */
 package org.apache.qpid.server.security.access.plugins;
 
-import java.util.Collections;
 import java.util.Map;
 
 import org.apache.qpid.server.logging.messages.AccessControlMessages;
@@ -86,7 +85,7 @@ public class AclFileAccessControlProviderImpl
             recreateAccessController();
             LOGGER.debug("Calling changeAttributes to try to force update");
             // force the change listener to fire, causing the parent broker to update its cache
-            changeAttributes(Collections.<String,Object>emptyMap());
+            changeAttributes(Map.of());
             getEventLogger().message(AccessControlMessages.LOADED(StringUtil.elideDataUrl(getPath())));
 
         }

--- a/broker-plugins/graylog-logging-logback/src/test/java/org/apache/qpid/server/logging/logback/validator/TestConfiguredObjectFactory.java
+++ b/broker-plugins/graylog-logging-logback/src/test/java/org/apache/qpid/server/logging/logback/validator/TestConfiguredObjectFactory.java
@@ -31,8 +31,9 @@ import org.apache.qpid.server.store.ConfiguredObjectRecord;
 import org.apache.qpid.server.store.UnresolvedConfiguredObject;
 
 import java.util.Collection;
-import java.util.Collections;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public class TestConfiguredObjectFactory implements ConfiguredObjectFactory
 {
@@ -88,9 +89,9 @@ public class TestConfiguredObjectFactory implements ConfiguredObjectFactory
     {
         if (TestConfiguredObject.class.equals(category))
         {
-            return Collections.singleton(TestConfiguredObject.TYPE);
+            return Set.of(TestConfiguredObject.TYPE);
         }
-        return Collections.emptyList();
+        return List.of();
     }
 
     @Override

--- a/broker-plugins/graylog-logging-logback/src/test/java/org/apache/qpid/server/logging/logback/validator/TestConfiguredObjectTypeFactory.java
+++ b/broker-plugins/graylog-logging-logback/src/test/java/org/apache/qpid/server/logging/logback/validator/TestConfiguredObjectTypeFactory.java
@@ -59,7 +59,7 @@ public class TestConfiguredObjectTypeFactory implements ConfiguredObjectTypeFact
     @Override
     public UnresolvedConfiguredObject<TestConfiguredObject> recover(final ConfiguredObjectFactory factory, final ConfiguredObjectRecord record, final ConfiguredObject<?> parent)
     {
-        return new UnresolvedConfiguredObject<TestConfiguredObject>()
+        return new UnresolvedConfiguredObject<>()
         {
             @Override
             public ConfiguredObject<?> getParent()


### PR DESCRIPTION
This PR addresses JIRA [QPID-8653](https://issues.apache.org/jira/browse/QPID-8653), refactoring code in module broker-plugins/access-control