### PR TITLE
QPID-8617: [Broker-J] Jetty server dependencies update

### DIFF
--- a/systests/qpid-systests-http-management/src/test/java/org/apache/qpid/tests/http/endtoend/message/CompressedMessageContentTest.java
+++ b/systests/qpid-systests-http-management/src/test/java/org/apache/qpid/tests/http/endtoend/message/CompressedMessageContentTest.java
@@ -45,6 +45,7 @@ import javax.jms.TextMessage;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -63,8 +64,16 @@ public class CompressedMessageContentTest extends HttpTestBase
     public void setUp() throws Exception
     {
         assumeTrue(is(not(equalTo(Protocol.AMQP_1_0))).matches(getProtocol()));
-        getHelper().setTls(true);
         getBrokerAdmin().createQueue(TEST_QUEUE);
+        getHelper().createKeyStoreAndSetItOnPort(getFullTestName());
+    }
+
+    @AfterEach
+    public void afterEach() throws Exception
+    {
+        assumeTrue(is(not(equalTo(Protocol.AMQP_1_0))).matches(getProtocol()));
+        getHelper().setAcceptEncoding("Identity");
+        getHelper().removeKeyStoreFromPort(getFullTestName());
     }
 
     @Test

--- a/systests/qpid-systests-http-management/src/test/java/org/apache/qpid/tests/http/endtoend/message/ExportImportMessagesTest.java
+++ b/systests/qpid-systests-http-management/src/test/java/org/apache/qpid/tests/http/endtoend/message/ExportImportMessagesTest.java
@@ -37,6 +37,7 @@ import javax.jms.TextMessage;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -54,7 +55,14 @@ public class ExportImportMessagesTest extends HttpTestBase
     @BeforeEach
     public void setUp() throws Exception
     {
-        getHelper().setTls(true);
+        getHelper().createKeyStoreAndSetItOnPort(getFullTestName());
+    }
+
+    @AfterEach
+    public void afterEach() throws Exception
+    {
+        getHelper().setAcceptEncoding("Identity");
+        getHelper().removeKeyStoreFromPort(getFullTestName());
     }
 
     @Test


### PR DESCRIPTION
This PR fixes system tests failure in CompressedMessageContentTest and ExportImportMessagesTest under profiles java-bdb.1-0 and java-bdb.0-9