### PR TITLE
QPID-8655: [Broker-J] Dependency updates for version 9.1.x

### DIFF
--- a/apache-qpid-broker-j/src/main/assembly/dependency-verification/DEPENDENCIES_REFERENCE
+++ b/apache-qpid-broker-j/src/main/assembly/dependency-verification/DEPENDENCIES_REFERENCE
@@ -29,7 +29,7 @@ From: 'an unknown organization'
   - Guava InternalFutureFailureAccess and InternalFutures (https://github.com/google/guava/failureaccess) com.google.guava:failureaccess:bundle:1.0.1
     License: The Apache Software License, Version 2.0  (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-  - Guava: Google Core Libraries for Java (https://github.com/google/guava) com.google.guava:guava:bundle:32.1.2-jre
+  - Guava: Google Core Libraries for Java (https://github.com/google/guava) com.google.guava:guava:bundle:32.1.3-jre
     License: Apache License, Version 2.0  (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
   - J2ObjC Annotations (https://github.com/google/j2objc/) com.google.j2objc:j2objc-annotations:jar:2.8
@@ -74,13 +74,13 @@ From: 'Apache Software Foundation' (http://db.apache.org/)
 
 From: 'FasterXML' (http://fasterxml.com/)
 
-  - Jackson-annotations (https://github.com/FasterXML/jackson) com.fasterxml.jackson.core:jackson-annotations:jar:2.15.2
+  - Jackson-annotations (https://github.com/FasterXML/jackson) com.fasterxml.jackson.core:jackson-annotations:jar:2.15.3
     License: The Apache Software License, Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-  - Jackson-core (https://github.com/FasterXML/jackson-core) com.fasterxml.jackson.core:jackson-core:jar:2.15.2
+  - Jackson-core (https://github.com/FasterXML/jackson-core) com.fasterxml.jackson.core:jackson-core:jar:2.15.3
     License: The Apache Software License, Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-  - jackson-databind (https://github.com/FasterXML/jackson) com.fasterxml.jackson.core:jackson-databind:jar:2.15.2
+  - jackson-databind (https://github.com/FasterXML/jackson) com.fasterxml.jackson.core:jackson-databind:jar:2.15.3
     License: The Apache Software License, Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
 
 
@@ -105,10 +105,10 @@ From: 'Oracle Corporation' (http://www.oracle.com/)
 
 From: 'OW2' (http://www.ow2.org/)
 
-  - asm (http://asm.ow2.io/) org.ow2.asm:asm:jar:9.5
+  - asm (http://asm.ow2.io/) org.ow2.asm:asm:jar:9.6
     License: BSD-3-Clause  (https://asm.ow2.io/license.html)
 
-  - asm-tree (http://asm.ow2.io/) org.ow2.asm:asm-tree:jar:9.5
+  - asm-tree (http://asm.ow2.io/) org.ow2.asm:asm-tree:jar:9.6
     License: BSD-3-Clause  (https://asm.ow2.io/license.html)
 
 
@@ -130,14 +130,14 @@ From: 'QOS.ch' (http://www.qos.ch)
     License: Eclipse Public License - v 1.0  (http://www.eclipse.org/legal/epl-v10.html)
     License: GNU Lesser General Public License  (http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html)
 
-  - SLF4J API Module (http://www.slf4j.org) org.slf4j:slf4j-api:jar:2.0.7
+  - SLF4J API Module (http://www.slf4j.org) org.slf4j:slf4j-api:jar:2.0.9
     License: MIT License  (http://www.opensource.org/licenses/mit-license.php)
 
 
 From: 'The Apache Software Foundation' (https://www.apache.org/)
 
-  - Apache Commons CLI (https://commons.apache.org/proper/commons-cli/) commons-cli:commons-cli:jar:1.5.0
-    License: Apache License, Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
+  - Apache Commons CLI (https://commons.apache.org/proper/commons-cli/) commons-cli:commons-cli:jar:1.6.0
+    License: Apache-2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
 
   - Apache Qpid Broker-J BDB Message Store Plug-in (http://qpid.apache.org/components/qpid-bdbstore) org.apache.qpid:qpid-bdbstore:jar
     License: Apache-2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -224,60 +224,68 @@ From: 'The CometD Project' (https://cometd.org)
 
 From: 'Webtide' (https://webtide.com)
 
-  - Jetty :: Http Utility (https://eclipse.org/jetty/jetty-http) org.eclipse.jetty:jetty-http:jar:11.0.15
-    License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0)
+  - Jetty :: Http Utility (https://eclipse.dev/jetty/jetty-http) org.eclipse.jetty:jetty-http:jar:11.0.18
+    License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0/)
     License: Apache Software License - Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0)
 
-  - Jetty :: IO Utility (https://eclipse.org/jetty/jetty-io) org.eclipse.jetty:jetty-io:jar:11.0.15
-    License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0)
+  - Jetty :: IO Utility (https://eclipse.dev/jetty/jetty-io) org.eclipse.jetty:jetty-io:jar:11.0.18
+    License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0/)
     License: Apache Software License - Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0)
 
-  - Jetty :: Rewrite Handler (https://eclipse.org/jetty/jetty-rewrite) org.eclipse.jetty:jetty-rewrite:jar:11.0.15
-    License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0)
+  - Jetty :: Rewrite Handler (https://eclipse.dev/jetty/jetty-rewrite) org.eclipse.jetty:jetty-rewrite:jar:11.0.18
+    License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0/)
     License: Apache Software License - Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0)
 
-  - Jetty :: Security (https://eclipse.org/jetty/jetty-security) org.eclipse.jetty:jetty-security:jar:11.0.15
-    License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0)
+  - Jetty :: Security (https://eclipse.dev/jetty/jetty-security) org.eclipse.jetty:jetty-security:jar:11.0.18
+    License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0/)
     License: Apache Software License - Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0)
 
-  - Jetty :: Server Core (https://eclipse.org/jetty/jetty-server) org.eclipse.jetty:jetty-server:jar:11.0.15
-    License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0)
+  - Jetty :: Server Core (https://eclipse.dev/jetty/jetty-server) org.eclipse.jetty:jetty-server:jar:11.0.18
+    License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0/)
     License: Apache Software License - Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0)
 
-  - Jetty :: Servlet Handling (https://eclipse.org/jetty/jetty-servlet) org.eclipse.jetty:jetty-servlet:jar:11.0.15
-    License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0)
+  - Jetty :: Servlet Handling (https://eclipse.dev/jetty/jetty-servlet) org.eclipse.jetty:jetty-servlet:jar:11.0.18
+    License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0/)
     License: Apache Software License - Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0)
 
-  - Jetty :: Utility Servlets and Filters (https://eclipse.org/jetty/jetty-servlets) org.eclipse.jetty:jetty-servlets:jar:11.0.15
-    License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0)
+  - Jetty :: Utility Servlets and Filters (https://eclipse.dev/jetty/jetty-servlets) org.eclipse.jetty:jetty-servlets:jar:11.0.18
+    License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0/)
     License: Apache Software License - Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0)
 
-  - Jetty :: Utilities (https://eclipse.org/jetty/jetty-util) org.eclipse.jetty:jetty-util:jar:11.0.15
-    License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0)
+  - Jetty :: Utilities (https://eclipse.dev/jetty/jetty-util) org.eclipse.jetty:jetty-util:jar:11.0.18
+    License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0/)
     License: Apache Software License - Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0)
 
-  - Jetty :: Websocket :: Core :: Common (https://eclipse.org/jetty/websocket-parent/websocket-core-common) org.eclipse.jetty.websocket:websocket-core-common:jar:11.0.15
-    License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0)
+  - Jetty :: Webapp Application Support (https://eclipse.dev/jetty/jetty-webapp) org.eclipse.jetty:jetty-webapp:jar:11.0.18
+    License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0/)
     License: Apache Software License - Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0)
 
-  - Jetty :: Websocket :: Core :: Server (https://eclipse.org/jetty/websocket-parent/websocket-core-server) org.eclipse.jetty.websocket:websocket-core-server:jar:11.0.15
-    License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0)
+  - Jetty :: XML utilities (https://eclipse.dev/jetty/jetty-xml) org.eclipse.jetty:jetty-xml:jar:11.0.18
+    License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0/)
     License: Apache Software License - Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0)
 
-  - Jetty :: Websocket :: org.eclipse.jetty.websocket :: API (https://eclipse.org/jetty/websocket-parent/websocket-jetty-api) org.eclipse.jetty.websocket:websocket-jetty-api:jar:11.0.15
-    License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0)
+  - Jetty :: Websocket :: Core :: Common (https://eclipse.dev/jetty/websocket-parent/websocket-core-common) org.eclipse.jetty.websocket:websocket-core-common:jar:11.0.18
+    License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0/)
     License: Apache Software License - Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0)
 
-  - Jetty :: Websocket :: org.eclipse.jetty.websocket :: Common (https://eclipse.org/jetty/websocket-parent/websocket-jetty-common) org.eclipse.jetty.websocket:websocket-jetty-common:jar:11.0.15
-    License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0)
+  - Jetty :: Websocket :: Core :: Server (https://eclipse.dev/jetty/websocket-parent/websocket-core-server) org.eclipse.jetty.websocket:websocket-core-server:jar:11.0.18
+    License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0/)
     License: Apache Software License - Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0)
 
-  - Jetty :: Websocket :: org.eclipse.jetty.websocket :: Server (https://eclipse.org/jetty/websocket-parent/websocket-jetty-server) org.eclipse.jetty.websocket:websocket-jetty-server:jar:11.0.15
-    License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0)
+  - Jetty :: Websocket :: org.eclipse.jetty.websocket :: API (https://eclipse.dev/jetty/websocket-parent/websocket-jetty-api) org.eclipse.jetty.websocket:websocket-jetty-api:jar:11.0.18
+    License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0/)
     License: Apache Software License - Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0)
 
-  - Jetty :: Websocket :: Servlet (https://eclipse.org/jetty/websocket-parent/websocket-servlet) org.eclipse.jetty.websocket:websocket-servlet:jar:11.0.15
-    License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0)
+  - Jetty :: Websocket :: org.eclipse.jetty.websocket :: Common (https://eclipse.dev/jetty/websocket-parent/websocket-jetty-common) org.eclipse.jetty.websocket:websocket-jetty-common:jar:11.0.18
+    License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0/)
+    License: Apache Software License - Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0)
+
+  - Jetty :: Websocket :: org.eclipse.jetty.websocket :: Server (https://eclipse.dev/jetty/websocket-parent/websocket-jetty-server) org.eclipse.jetty.websocket:websocket-jetty-server:jar:11.0.18
+    License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0/)
+    License: Apache Software License - Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0)
+
+  - Jetty :: Websocket :: Servlet (https://eclipse.dev/jetty/websocket-parent/websocket-servlet) org.eclipse.jetty.websocket:websocket-servlet:jar:11.0.18
+    License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0/)
     License: Apache Software License - Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0)
 
 

--- a/perftests/src/main/assembly/dependency-verification/DEPENDENCIES_REFERENCE
+++ b/perftests/src/main/assembly/dependency-verification/DEPENDENCIES_REFERENCE
@@ -29,7 +29,7 @@ From: 'an unknown organization'
   - Guava InternalFutureFailureAccess and InternalFutures (https://github.com/google/guava/failureaccess) com.google.guava:failureaccess:bundle:1.0.1
     License: The Apache Software License, Version 2.0  (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-  - Guava: Google Core Libraries for Java (https://github.com/google/guava) com.google.guava:guava:bundle:32.1.2-jre
+  - Guava: Google Core Libraries for Java (https://github.com/google/guava) com.google.guava:guava:bundle:32.1.3-jre
     License: Apache License, Version 2.0  (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
   - J2ObjC Annotations (https://github.com/google/j2objc/) com.google.j2objc:j2objc-annotations:jar:2.8
@@ -44,13 +44,13 @@ From: 'Apache Software Foundation' (http://www.apache.org)
 
 From: 'FasterXML' (http://fasterxml.com/)
 
-  - Jackson-annotations (https://github.com/FasterXML/jackson) com.fasterxml.jackson.core:jackson-annotations:jar:2.15.2
+  - Jackson-annotations (https://github.com/FasterXML/jackson) com.fasterxml.jackson.core:jackson-annotations:jar:2.15.3
     License: The Apache Software License, Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-  - Jackson-core (https://github.com/FasterXML/jackson-core) com.fasterxml.jackson.core:jackson-core:jar:2.15.2
+  - Jackson-core (https://github.com/FasterXML/jackson-core) com.fasterxml.jackson.core:jackson-core:jar:2.15.3
     License: The Apache Software License, Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-  - jackson-databind (https://github.com/FasterXML/jackson) com.fasterxml.jackson.core:jackson-databind:jar:2.15.2
+  - jackson-databind (https://github.com/FasterXML/jackson) com.fasterxml.jackson.core:jackson-databind:jar:2.15.3
     License: The Apache Software License, Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
 
 
@@ -64,7 +64,7 @@ From: 'QOS.ch' (http://www.qos.ch)
     License: Eclipse Public License - v 1.0  (http://www.eclipse.org/legal/epl-v10.html)
     License: GNU Lesser General Public License  (http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html)
 
-  - SLF4J API Module (http://www.slf4j.org) org.slf4j:slf4j-api:jar:2.0.7
+  - SLF4J API Module (http://www.slf4j.org) org.slf4j:slf4j-api:jar:2.0.9
     License: MIT License  (http://www.opensource.org/licenses/mit-license.php)
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -106,19 +106,19 @@
     <derby-version>10.14.2.0</derby-version>
     <logback-version>1.4.11</logback-version>
     <logback-db-version>1.2.11.1</logback-db-version>
-    <guava-version>32.1.2-jre</guava-version>
-    <fasterxml-jackson-version>2.15.2</fasterxml-jackson-version>
-    <fasterxml-jackson-databind-version>2.15.2</fasterxml-jackson-databind-version>
-    <slf4j-version>2.0.7</slf4j-version>
-    <jetty-version>11.0.15</jetty-version>
+    <guava-version>32.1.3-jre</guava-version>
+    <fasterxml-jackson-version>2.15.3</fasterxml-jackson-version>
+    <fasterxml-jackson-databind-version>2.15.3</fasterxml-jackson-databind-version>
+    <slf4j-version>2.0.9</slf4j-version>
+    <jetty-version>11.0.18</jetty-version>
 
     <!-- dependency version numbers -->
     <bonecp-version>0.8.0.RELEASE</bonecp-version>
-    <commons-cli-version>1.5.0</commons-cli-version>
+    <commons-cli-version>1.6.0</commons-cli-version>
 
     <geronimo-jms-1-1-version>1.1.1</geronimo-jms-1-1-version>
     <geronimo-jms-2-0-version>1.0-alpha-2</geronimo-jms-2-0-version>
-    <asm-version>9.5</asm-version>
+    <asm-version>9.6</asm-version>
 
     <velocity-version>1.4</velocity-version>
     <csvjdbc-version>1.0.35</csvjdbc-version>
@@ -129,9 +129,9 @@
     <dgrid-version>1.3.3</dgrid-version>
 
     <!-- test dependency version numbers -->
-    <junit-version>5.10.0</junit-version>
-    <mockito-version>5.4.0</mockito-version>
-    <netty-version>4.1.96.Final</netty-version>
+    <junit-version>5.10.1</junit-version>
+    <mockito-version>5.7.0</mockito-version>
+    <netty-version>4.1.100.Final</netty-version>
     <hamcrest-version>2.2</hamcrest-version>
     <maven-resolver-provider-version>3.8.6</maven-resolver-provider-version>
     <maven-resolver-version>1.8.2</maven-resolver-version>
@@ -144,21 +144,21 @@
     <exec-maven-plugin-version>3.1.0</exec-maven-plugin-version>
     <javacc-maven-plugin-version>2.6</javacc-maven-plugin-version>
     <ph-javacc-maven-plugin-version>4.1.5</ph-javacc-maven-plugin-version>
-    <maven-enforcer-plugin-version>3.3.0</maven-enforcer-plugin-version>
+    <maven-enforcer-plugin-version>3.4.1</maven-enforcer-plugin-version>
     <maven-rar-plugin-version>2.4</maven-rar-plugin-version>
-    <license-maven-plugin-version>2.0.0</license-maven-plugin-version>
+    <license-maven-plugin-version>2.2.0</license-maven-plugin-version>
     <maven-jxr-plugin-version>3.3.0</maven-jxr-plugin-version>
     <findbugs-maven-plugin-version>3.0.5</findbugs-maven-plugin-version>
-    <jacoco-plugin-version>0.8.10</jacoco-plugin-version>
+    <jacoco-plugin-version>0.8.11</jacoco-plugin-version>
     <apache-rat-plugin-version>0.15</apache-rat-plugin-version>
     <maven-docbx-plugin-version>2.0.15</maven-docbx-plugin-version>
     <maven-docbook-xml-plugin-version>5.0-all</maven-docbook-xml-plugin-version>
     <buildnumber-maven-plugin-version>1.4</buildnumber-maven-plugin-version>
     <maven-compiler-plugin-version>3.11.0</maven-compiler-plugin-version>
     <maven-jar-plugin-version>3.3.0</maven-jar-plugin-version>
-    <maven-surefire-plugin-version>3.1.2</maven-surefire-plugin-version>
-    <maven-surefire-report-plugin-version>3.1.2</maven-surefire-report-plugin-version>
-    <h2.version>2.2.220</h2.version>
+    <maven-surefire-plugin-version>3.2.2</maven-surefire-plugin-version>
+    <maven-surefire-report-plugin-version>3.2.2</maven-surefire-report-plugin-version>
+    <h2.version>2.2.224</h2.version>
     <apache-directory-version>2.0.0.AM25</apache-directory-version>
     <kerby-version>2.0.3</kerby-version>
     <bcprov-version>1.76</bcprov-version>
@@ -1689,7 +1689,7 @@
               </includedLicenses>
               <licenseMerges>
                 <licenseMerge>Apache Software License, Version 2.0|The Apache Software License, Version 2.0|Apache Software License - Version 2.0|Apache v2|Apache 2|Apache License, Version 2.0|Apache 2.0|Apache Public License 2.0|Apache License, version 2.0|Apache License 2.0|The Apache License, Version 2.0|Apache 2.0 License|Apache-2.0</licenseMerge>
-                <licenseMerge>The MIT License|MIT License|MIT license</licenseMerge>
+                <licenseMerge>The MIT License|MIT License|MIT license|MIT</licenseMerge>
                 <licenseMerge>BSD License|New BSD|New BSD License|BSD 3-Clause|BSD-3-Clause|BSD Licence 3|BSD License 3|The BSD License</licenseMerge>
                 <licenseMerge>Eclipse Public License - Version 1.0|Eclipse Public License - v 1.0|Eclipse Public License, Version 1.0|Eclipse Public License 1.0|MPL 2.0 or EPL 1.0</licenseMerge>
                 <licenseMerge>Eclipse Public License - Version 2.0|Eclipse Public License - v 2.0|Eclipse Public License, Version 2.0|Eclipse Public License 2.0|Eclipse Public License v2.0|MPL 2.0 or EPL 2.0|EPL 2.0</licenseMerge>

--- a/systests/qpid-systests-http-management/src/test/java/org/apache/qpid/tests/http/authentication/SaslTest.java
+++ b/systests/qpid-systests-http-management/src/test/java/org/apache/qpid/tests/http/authentication/SaslTest.java
@@ -48,6 +48,7 @@ import org.apache.qpid.server.security.auth.sasl.crammd5.CramMd5Negotiator;
 import org.apache.qpid.server.security.auth.sasl.plain.PlainNegotiator;
 import org.apache.qpid.tests.http.HttpTestBase;
 
+// TestInstance.Lifecycle.PER_METHOD fixes rare race conditions
 @TestInstance(TestInstance.Lifecycle.PER_METHOD)
 public class SaslTest extends HttpTestBase
 {

--- a/systests/qpid-systests-http-management/src/test/java/org/apache/qpid/tests/http/authentication/SaslTest.java
+++ b/systests/qpid-systests-http-management/src/test/java/org/apache/qpid/tests/http/authentication/SaslTest.java
@@ -40,6 +40,7 @@ import java.util.UUID;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 
 import org.apache.qpid.server.security.auth.manager.ScramSHA1AuthenticationManager;
 import org.apache.qpid.server.security.auth.manager.ScramSHA256AuthenticationManager;
@@ -47,6 +48,7 @@ import org.apache.qpid.server.security.auth.sasl.crammd5.CramMd5Negotiator;
 import org.apache.qpid.server.security.auth.sasl.plain.PlainNegotiator;
 import org.apache.qpid.tests.http.HttpTestBase;
 
+@TestInstance(TestInstance.Lifecycle.PER_METHOD)
 public class SaslTest extends HttpTestBase
 {
     private static final String SASL_SERVICE = "/service/sasl";


### PR DESCRIPTION
This PR addresses [QPID-8655](https://issues.apache.org/jira/browse/QPID-8655), updating broker dependencies.

Following dependencies are updated:

**runtime dependencies**
com.fasterxml.jackson.core:jackson-core 2.15.2 => 2.15.3
com.fasterxml.jackson.core:jackson-databind 2.15.2 => 2.15.3
com.google.guava:guava 32.1.2-jre => 32.1.3-jre
org.eclipse.jetty:jetty-server 11.0.15 => 11.0.18
org.eclipse.jetty:jetty-servlet 11.0.15 => 11.0.18
org.eclipse.jetty:jetty-servlets 11.0.15 => 11.0.18
org.eclipse.jetty:jetty-rewrite 11.0.15 => 11.0.18
org.eclipse.jetty.websocket:websocket-jetty-server 11.0.15 => 11.0.18
org.ow2.asm:asm 9.5 => 9.6
org.ow2.asm:asm-tree 9.5 => 9.6
org.slf4:slf4j-api 2.0.7 => 2.0.9

**test dependencies**
com.h2database:h2 1.4.220 => 2.1.224
io.netty:netty-buffer 4.1.96.Final => 4.1.100.Final
io.netty:netty-common 4.1.96.Final => 4.1.100.Final
io.netty:netty-handler 4.1.96.Final => 4.1.100.Final
io.netty:netty-transport 4.1.96.Final => 4.1.100.Final
io.netty:netty-codec-http 4.1.96.Final => 4.1.100.Final
org.junit.jupiter:junit-jupiter-api 5.10.0 => 5.10.1
org.junit.jupiter:unit-jupiter-engine 5.10.0 => 5.10.1
org.junit.jupiter:junit-jupiter-params 5.10.0 => 5.10.1
org.mockito:mockito-core 5.4.0 => 5.7.0

**maven plugins**
org.apache.maven.plugins:maven-enforcer-plugin 3.3.0 => 3.4.1
org.codehaus.mojo:license-maven-plugin 2.0.0 => 2.2.0
org.apache.maven.plugins:maven-surefire-plugin 3.1.2 => 3.2.2
org.jacoco:jacoco-maven-plugin 0.8.10 => 0.8.11