### PR TITLE
QPID-8655: [Broker-J] Dependency updates for version 9.1.x

### DIFF
--- a/apache-qpid-broker-j/src/main/assembly/dependency-verification/DEPENDENCIES_REFERENCE
+++ b/apache-qpid-broker-j/src/main/assembly/dependency-verification/DEPENDENCIES_REFERENCE
@@ -26,10 +26,10 @@ Apache Qpid Broker-J Bundles
 
 From: 'an unknown organization'
 
-  - Guava InternalFutureFailureAccess and InternalFutures (https://github.com/google/guava/failureaccess) com.google.guava:failureaccess:bundle:1.0.1
+  - Guava InternalFutureFailureAccess and InternalFutures (https://github.com/google/guava/failureaccess) com.google.guava:failureaccess:bundle:1.0.2
     License: The Apache Software License, Version 2.0  (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-  - Guava: Google Core Libraries for Java (https://github.com/google/guava) com.google.guava:guava:bundle:32.1.3-jre
+  - Guava: Google Core Libraries for Java (https://github.com/google/guava) com.google.guava:guava:bundle:33.0.0-jre
     License: Apache License, Version 2.0  (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
   - J2ObjC Annotations (https://github.com/google/j2objc/) com.google.j2objc:j2objc-annotations:jar:2.8
@@ -50,13 +50,13 @@ From: 'an unknown organization'
   - Prometheus Java Span Context Supplier - OpenTelemetry Agent (http://github.com/prometheus/client_java/simpleclient_tracer/simpleclient_tracer_otel_agent) io.prometheus:simpleclient_tracer_otel_agent:bundle:0.16.0
     License: The Apache Software License, Version 2.0  (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-  - Bouncy Castle PKIX, CMS, EAC, TSP, PKCS, OCSP, CMP, and CRMF APIs (https://www.bouncycastle.org/java.html) org.bouncycastle:bcpkix-jdk18on:jar:1.76
+  - Bouncy Castle PKIX, CMS, EAC, TSP, PKCS, OCSP, CMP, and CRMF APIs (https://www.bouncycastle.org/java.html) org.bouncycastle:bcpkix-jdk18on:jar:1.77
     License: Bouncy Castle Licence  (https://www.bouncycastle.org/licence.html)
 
-  - Bouncy Castle Provider (https://www.bouncycastle.org/java.html) org.bouncycastle:bcprov-jdk18on:jar:1.76
+  - Bouncy Castle Provider (https://www.bouncycastle.org/java.html) org.bouncycastle:bcprov-jdk18on:jar:1.77
     License: Bouncy Castle Licence  (https://www.bouncycastle.org/licence.html)
 
-  - Bouncy Castle ASN.1 Extension and Utility APIs (https://www.bouncycastle.org/java.html) org.bouncycastle:bcutil-jdk18on:jar:1.76
+  - Bouncy Castle ASN.1 Extension and Utility APIs (https://www.bouncycastle.org/java.html) org.bouncycastle:bcutil-jdk18on:jar:1.77
     License: Bouncy Castle Licence  (https://www.bouncycastle.org/licence.html)
 
   - dgrid (https://www.webjars.org) org.webjars.bower:dgrid:jar:1.3.3
@@ -74,13 +74,13 @@ From: 'Apache Software Foundation' (http://db.apache.org/)
 
 From: 'FasterXML' (http://fasterxml.com/)
 
-  - Jackson-annotations (https://github.com/FasterXML/jackson) com.fasterxml.jackson.core:jackson-annotations:jar:2.15.3
+  - Jackson-annotations (https://github.com/FasterXML/jackson) com.fasterxml.jackson.core:jackson-annotations:jar:2.16.1
     License: The Apache Software License, Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-  - Jackson-core (https://github.com/FasterXML/jackson-core) com.fasterxml.jackson.core:jackson-core:jar:2.15.3
+  - Jackson-core (https://github.com/FasterXML/jackson-core) com.fasterxml.jackson.core:jackson-core:jar:2.16.1
     License: The Apache Software License, Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-  - jackson-databind (https://github.com/FasterXML/jackson) com.fasterxml.jackson.core:jackson-databind:jar:2.15.3
+  - jackson-databind (https://github.com/FasterXML/jackson) com.fasterxml.jackson.core:jackson-databind:jar:2.16.1
     License: The Apache Software License, Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
 
 
@@ -108,11 +108,11 @@ From: 'OW2' (http://www.ow2.org/)
 
 From: 'QOS.ch' (http://www.qos.ch)
 
-  - Logback Classic Module (http://logback.qos.ch/logback-classic) ch.qos.logback:logback-classic:jar:1.4.11
+  - Logback Classic Module (http://logback.qos.ch/logback-classic) ch.qos.logback:logback-classic:jar:1.4.14
     License: Eclipse Public License - v 1.0  (http://www.eclipse.org/legal/epl-v10.html)
     License: GNU Lesser General Public License  (http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html)
 
-  - Logback Core Module (http://logback.qos.ch/logback-core) ch.qos.logback:logback-core:jar:1.4.11
+  - Logback Core Module (http://logback.qos.ch/logback-core) ch.qos.logback:logback-core:jar:1.4.14
     License: Eclipse Public License - v 1.0  (http://www.eclipse.org/legal/epl-v10.html)
     License: GNU Lesser General Public License  (http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html)
 
@@ -124,7 +124,7 @@ From: 'QOS.ch' (http://www.qos.ch)
     License: Eclipse Public License - v 1.0  (http://www.eclipse.org/legal/epl-v10.html)
     License: GNU Lesser General Public License  (http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html)
 
-  - SLF4J API Module (http://www.slf4j.org) org.slf4j:slf4j-api:jar:2.0.9
+  - SLF4J API Module (http://www.slf4j.org) org.slf4j:slf4j-api:jar:2.0.11
     License: MIT License  (http://www.opensource.org/licenses/mit-license.php)
 
 
@@ -218,67 +218,67 @@ From: 'The CometD Project' (https://cometd.org)
 
 From: 'Webtide' (https://webtide.com)
 
-  - Jetty :: Http Utility (https://eclipse.dev/jetty/jetty-http) org.eclipse.jetty:jetty-http:jar:11.0.18
+  - Jetty :: Http Utility (https://eclipse.dev/jetty/jetty-http) org.eclipse.jetty:jetty-http:jar:11.0.19
     License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0/)
     License: Apache Software License - Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0)
 
-  - Jetty :: IO Utility (https://eclipse.dev/jetty/jetty-io) org.eclipse.jetty:jetty-io:jar:11.0.18
+  - Jetty :: IO Utility (https://eclipse.dev/jetty/jetty-io) org.eclipse.jetty:jetty-io:jar:11.0.19
     License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0/)
     License: Apache Software License - Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0)
 
-  - Jetty :: Rewrite Handler (https://eclipse.dev/jetty/jetty-rewrite) org.eclipse.jetty:jetty-rewrite:jar:11.0.18
+  - Jetty :: Rewrite Handler (https://eclipse.dev/jetty/jetty-rewrite) org.eclipse.jetty:jetty-rewrite:jar:11.0.19
     License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0/)
     License: Apache Software License - Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0)
 
-  - Jetty :: Security (https://eclipse.dev/jetty/jetty-security) org.eclipse.jetty:jetty-security:jar:11.0.18
+  - Jetty :: Security (https://eclipse.dev/jetty/jetty-security) org.eclipse.jetty:jetty-security:jar:11.0.19
     License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0/)
     License: Apache Software License - Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0)
 
-  - Jetty :: Server Core (https://eclipse.dev/jetty/jetty-server) org.eclipse.jetty:jetty-server:jar:11.0.18
+  - Jetty :: Server Core (https://eclipse.dev/jetty/jetty-server) org.eclipse.jetty:jetty-server:jar:11.0.19
     License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0/)
     License: Apache Software License - Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0)
 
-  - Jetty :: Servlet Handling (https://eclipse.dev/jetty/jetty-servlet) org.eclipse.jetty:jetty-servlet:jar:11.0.18
+  - Jetty :: Servlet Handling (https://eclipse.dev/jetty/jetty-servlet) org.eclipse.jetty:jetty-servlet:jar:11.0.19
     License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0/)
     License: Apache Software License - Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0)
 
-  - Jetty :: Utility Servlets and Filters (https://eclipse.dev/jetty/jetty-servlets) org.eclipse.jetty:jetty-servlets:jar:11.0.18
+  - Jetty :: Utility Servlets and Filters (https://eclipse.dev/jetty/jetty-servlets) org.eclipse.jetty:jetty-servlets:jar:11.0.19
     License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0/)
     License: Apache Software License - Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0)
 
-  - Jetty :: Utilities (https://eclipse.dev/jetty/jetty-util) org.eclipse.jetty:jetty-util:jar:11.0.18
+  - Jetty :: Utilities (https://eclipse.dev/jetty/jetty-util) org.eclipse.jetty:jetty-util:jar:11.0.19
     License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0/)
     License: Apache Software License - Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0)
 
-  - Jetty :: Webapp Application Support (https://eclipse.dev/jetty/jetty-webapp) org.eclipse.jetty:jetty-webapp:jar:11.0.18
+  - Jetty :: Webapp Application Support (https://eclipse.dev/jetty/jetty-webapp) org.eclipse.jetty:jetty-webapp:jar:11.0.19
     License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0/)
     License: Apache Software License - Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0)
 
-  - Jetty :: XML utilities (https://eclipse.dev/jetty/jetty-xml) org.eclipse.jetty:jetty-xml:jar:11.0.18
+  - Jetty :: XML utilities (https://eclipse.dev/jetty/jetty-xml) org.eclipse.jetty:jetty-xml:jar:11.0.19
     License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0/)
     License: Apache Software License - Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0)
 
-  - Jetty :: Websocket :: Core :: Common (https://eclipse.dev/jetty/websocket-parent/websocket-core-common) org.eclipse.jetty.websocket:websocket-core-common:jar:11.0.18
+  - Jetty :: Websocket :: Core :: Common (https://eclipse.dev/jetty/websocket-parent/websocket-core-common) org.eclipse.jetty.websocket:websocket-core-common:jar:11.0.19
     License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0/)
     License: Apache Software License - Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0)
 
-  - Jetty :: Websocket :: Core :: Server (https://eclipse.dev/jetty/websocket-parent/websocket-core-server) org.eclipse.jetty.websocket:websocket-core-server:jar:11.0.18
+  - Jetty :: Websocket :: Core :: Server (https://eclipse.dev/jetty/websocket-parent/websocket-core-server) org.eclipse.jetty.websocket:websocket-core-server:jar:11.0.19
     License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0/)
     License: Apache Software License - Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0)
 
-  - Jetty :: Websocket :: org.eclipse.jetty.websocket :: API (https://eclipse.dev/jetty/websocket-parent/websocket-jetty-api) org.eclipse.jetty.websocket:websocket-jetty-api:jar:11.0.18
+  - Jetty :: Websocket :: org.eclipse.jetty.websocket :: API (https://eclipse.dev/jetty/websocket-parent/websocket-jetty-api) org.eclipse.jetty.websocket:websocket-jetty-api:jar:11.0.19
     License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0/)
     License: Apache Software License - Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0)
 
-  - Jetty :: Websocket :: org.eclipse.jetty.websocket :: Common (https://eclipse.dev/jetty/websocket-parent/websocket-jetty-common) org.eclipse.jetty.websocket:websocket-jetty-common:jar:11.0.18
+  - Jetty :: Websocket :: org.eclipse.jetty.websocket :: Common (https://eclipse.dev/jetty/websocket-parent/websocket-jetty-common) org.eclipse.jetty.websocket:websocket-jetty-common:jar:11.0.19
     License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0/)
     License: Apache Software License - Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0)
 
-  - Jetty :: Websocket :: org.eclipse.jetty.websocket :: Server (https://eclipse.dev/jetty/websocket-parent/websocket-jetty-server) org.eclipse.jetty.websocket:websocket-jetty-server:jar:11.0.18
+  - Jetty :: Websocket :: org.eclipse.jetty.websocket :: Server (https://eclipse.dev/jetty/websocket-parent/websocket-jetty-server) org.eclipse.jetty.websocket:websocket-jetty-server:jar:11.0.19
     License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0/)
     License: Apache Software License - Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0)
 
-  - Jetty :: Websocket :: Servlet (https://eclipse.dev/jetty/websocket-parent/websocket-servlet) org.eclipse.jetty.websocket:websocket-servlet:jar:11.0.18
+  - Jetty :: Websocket :: Servlet (https://eclipse.dev/jetty/websocket-parent/websocket-servlet) org.eclipse.jetty.websocket:websocket-servlet:jar:11.0.19
     License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0/)
     License: Apache Software License - Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0)
 

--- a/broker-plugins/graylog-logging-logback/pom.xml
+++ b/broker-plugins/graylog-logging-logback/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.qpid</groupId>
     <artifactId>qpid-broker-parent</artifactId>
-    <version>9.1.0-SNAPSHOT</version>
+    <version>9.1.1-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/broker-plugins/graylog-logging-logback/src/main/java/org/apache/qpid/server/logging/logback/graylog/GraylogAppender.java
+++ b/broker-plugins/graylog-logging-logback/src/main/java/org/apache/qpid/server/logging/logback/graylog/GraylogAppender.java
@@ -118,7 +118,7 @@ final class GraylogAppender extends AsyncAppender
         encoder.setIncludeCallerData(settings.isCallerDataIncluded());
         encoder.setIncludeRootCauseData(settings.hasRootExceptionDataIncluded());
         encoder.setIncludeLevelName(settings.isLogLevelNameIncluded());
-        encoder.setStaticFields(settings.getStaticFields());
+        settings.getStaticFields().forEach(encoder::addStaticField);
         return encoder;
     }
 }

--- a/perftests/src/main/assembly/dependency-verification/DEPENDENCIES_REFERENCE
+++ b/perftests/src/main/assembly/dependency-verification/DEPENDENCIES_REFERENCE
@@ -26,10 +26,10 @@ Apache Qpid Broker-J Performance Tests
 
 From: 'an unknown organization'
 
-  - Guava InternalFutureFailureAccess and InternalFutures (https://github.com/google/guava/failureaccess) com.google.guava:failureaccess:bundle:1.0.1
+  - Guava InternalFutureFailureAccess and InternalFutures (https://github.com/google/guava/failureaccess) com.google.guava:failureaccess:bundle:1.0.2
     License: The Apache Software License, Version 2.0  (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-  - Guava: Google Core Libraries for Java (https://github.com/google/guava) com.google.guava:guava:bundle:32.1.3-jre
+  - Guava: Google Core Libraries for Java (https://github.com/google/guava) com.google.guava:guava:bundle:33.0.0-jre
     License: Apache License, Version 2.0  (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
   - J2ObjC Annotations (https://github.com/google/j2objc/) com.google.j2objc:j2objc-annotations:jar:2.8
@@ -44,27 +44,27 @@ From: 'Apache Software Foundation' (http://www.apache.org)
 
 From: 'FasterXML' (http://fasterxml.com/)
 
-  - Jackson-annotations (https://github.com/FasterXML/jackson) com.fasterxml.jackson.core:jackson-annotations:jar:2.15.3
+  - Jackson-annotations (https://github.com/FasterXML/jackson) com.fasterxml.jackson.core:jackson-annotations:jar:2.16.1
     License: The Apache Software License, Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-  - Jackson-core (https://github.com/FasterXML/jackson-core) com.fasterxml.jackson.core:jackson-core:jar:2.15.3
+  - Jackson-core (https://github.com/FasterXML/jackson-core) com.fasterxml.jackson.core:jackson-core:jar:2.16.1
     License: The Apache Software License, Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-  - jackson-databind (https://github.com/FasterXML/jackson) com.fasterxml.jackson.core:jackson-databind:jar:2.15.3
+  - jackson-databind (https://github.com/FasterXML/jackson) com.fasterxml.jackson.core:jackson-databind:jar:2.16.1
     License: The Apache Software License, Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
 
 
 From: 'QOS.ch' (http://www.qos.ch)
 
-  - Logback Classic Module (http://logback.qos.ch/logback-classic) ch.qos.logback:logback-classic:jar:1.4.11
+  - Logback Classic Module (http://logback.qos.ch/logback-classic) ch.qos.logback:logback-classic:jar:1.4.14
     License: Eclipse Public License - v 1.0  (http://www.eclipse.org/legal/epl-v10.html)
     License: GNU Lesser General Public License  (http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html)
 
-  - Logback Core Module (http://logback.qos.ch/logback-core) ch.qos.logback:logback-core:jar:1.4.11
+  - Logback Core Module (http://logback.qos.ch/logback-core) ch.qos.logback:logback-core:jar:1.4.14
     License: Eclipse Public License - v 1.0  (http://www.eclipse.org/legal/epl-v10.html)
     License: GNU Lesser General Public License  (http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html)
 
-  - SLF4J API Module (http://www.slf4j.org) org.slf4j:slf4j-api:jar:2.0.9
+  - SLF4J API Module (http://www.slf4j.org) org.slf4j:slf4j-api:jar:2.0.11
     License: MIT License  (http://www.opensource.org/licenses/mit-license.php)
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -104,13 +104,13 @@
 
     <bdb-version>7.4.5</bdb-version>
     <derby-version>10.14.2.0</derby-version>
-    <logback-version>1.4.11</logback-version>
+    <logback-version>1.4.14</logback-version>
     <logback-db-version>1.2.11.1</logback-db-version>
-    <guava-version>32.1.3-jre</guava-version>
-    <fasterxml-jackson-version>2.15.3</fasterxml-jackson-version>
-    <fasterxml-jackson-databind-version>2.15.3</fasterxml-jackson-databind-version>
-    <slf4j-version>2.0.9</slf4j-version>
-    <jetty-version>11.0.18</jetty-version>
+    <guava-version>33.0.0-jre</guava-version>
+    <fasterxml-jackson-version>2.16.1</fasterxml-jackson-version>
+    <fasterxml-jackson-databind-version>2.16.1</fasterxml-jackson-databind-version>
+    <slf4j-version>2.0.11</slf4j-version>
+    <jetty-version>11.0.19</jetty-version>
 
     <!-- dependency version numbers -->
     <hikari-cp-version>5.1.0</hikari-cp-version>
@@ -130,8 +130,8 @@
 
     <!-- test dependency version numbers -->
     <junit-version>5.10.1</junit-version>
-    <mockito-version>5.7.0</mockito-version>
-    <netty-version>4.1.100.Final</netty-version>
+    <mockito-version>5.10.0</mockito-version>
+    <netty-version>4.1.106.Final</netty-version>
     <hamcrest-version>2.2</hamcrest-version>
     <maven-resolver-provider-version>3.8.6</maven-resolver-provider-version>
     <maven-resolver-version>1.8.2</maven-resolver-version>
@@ -141,7 +141,7 @@
     <jaxb-api-version>2.3.1</jaxb-api-version>
     <nashorn-version>15.4</nashorn-version>
 
-    <exec-maven-plugin-version>3.1.0</exec-maven-plugin-version>
+    <exec-maven-plugin-version>3.1.1</exec-maven-plugin-version>
     <javacc-maven-plugin-version>2.6</javacc-maven-plugin-version>
     <ph-javacc-maven-plugin-version>4.1.5</ph-javacc-maven-plugin-version>
     <maven-enforcer-plugin-version>3.4.1</maven-enforcer-plugin-version>
@@ -154,16 +154,16 @@
     <maven-docbx-plugin-version>2.0.15</maven-docbx-plugin-version>
     <maven-docbook-xml-plugin-version>5.0-all</maven-docbook-xml-plugin-version>
     <buildnumber-maven-plugin-version>1.4</buildnumber-maven-plugin-version>
-    <maven-compiler-plugin-version>3.11.0</maven-compiler-plugin-version>
+    <maven-compiler-plugin-version>3.12.1</maven-compiler-plugin-version>
     <maven-jar-plugin-version>3.3.0</maven-jar-plugin-version>
-    <maven-surefire-plugin-version>3.2.2</maven-surefire-plugin-version>
-    <maven-surefire-report-plugin-version>3.2.2</maven-surefire-report-plugin-version>
+    <maven-surefire-plugin-version>3.2.3</maven-surefire-plugin-version>
+    <maven-surefire-report-plugin-version>3.2.3</maven-surefire-report-plugin-version>
     <h2.version>2.2.224</h2.version>
     <apache-directory-version>2.0.0.AM27</apache-directory-version>
     <kerby-version>2.0.3</kerby-version>
-    <bcprov-version>1.76</bcprov-version>
-    <bcpkix-version>1.76</bcpkix-version>
-    <logback-gelf-version>3.0.0</logback-gelf-version>
+    <bcprov-version>1.77</bcprov-version>
+    <bcpkix-version>1.77</bcpkix-version>
+    <logback-gelf-version>5.0.1</logback-gelf-version>
     <prometheus-client-version>0.16.0</prometheus-client-version>
 
     <bdb-repo-enabled>false</bdb-repo-enabled>


### PR DESCRIPTION
This PR addresses [QPID-8655](https://issues.apache.org/jira/browse/QPID-8655), updating broker dependencies.

Following dependencies are updated:

**runtime dependencies**
ch.qos.logback:logback-core 1.4.11 => 1.4.14
ch.qos.logback:logback-classic 1.4.11 => 1.4.14
com.fasterxml.jackson.core:jackson-core 2.15.3 => 2.16.1
com.fasterxml.jackson.core:jackson-databind 2.15.3 => 2.16.1
com.google.guava:guava 32.1.3-jre => 33.0.0-jre
org.eclipse.jetty:jetty-server 11.0.18 => 11.0.19
org.eclipse.jetty:jetty-servlet 11.0.18 => 11.0.19
org.eclipse.jetty:jetty-servlets 11.0.18 => 11.0.19
org.eclipse.jetty:jetty-rewrite 11.0.18 => 11.0.19
org.eclipse.jetty.websocket:websocket-jetty-server 11.0.18 => 11.0.19
de.siegmar:logback-gelf 3.0.0 => 5.0.1
org.bouncycastle:bcprov-jdk18on 1.76 => 1.77
org.bouncycastle:bcpkix-jdk18on 1.76 => 1.77
org.slf4:slf4j-api 2.0.9 => 2.0.10

**test dependencies**

io.netty:netty-buffer 4.1.100.Final => 4.1.106.Final
io.netty:netty-common 4.1.100.Final => 4.1.106.Final
io.netty:netty-handler 4.1.100.Final => 4.1.106.Final
io.netty:netty-transport 4.1.100.Final => 4.1.106.Final
io.netty:netty-codec-http 4.1.100.Final => 4.1.106.Final
org.mockito:mockito-core 5.7.0 => 5.9.0

**maven plugins**
org.codehaus.mojo:exec-maven-plugin 3.1.0 => 3.1.1