### PR TITLE
QPID-8665: [Broker-J] Changing queue exclusive mode throws exception

### DIFF
--- a/broker-core/src/main/java/org/apache/qpid/server/queue/AbstractQueue.java
+++ b/broker-core/src/main/java/org/apache/qpid/server/queue/AbstractQueue.java
@@ -766,15 +766,17 @@ public abstract class AbstractQueue<X extends AbstractQueue<X>>
     @Override
     public String getOwner()
     {
-        if(_exclusiveOwner != null)
+        if (_exclusiveOwner instanceof String)
         {
-            switch(_exclusive)
-            {
-                case CONTAINER:
-                    return (String) _exclusiveOwner;
-                case PRINCIPAL:
-                    return ((Principal)_exclusiveOwner).getName();
-            }
+            return (String) _exclusiveOwner;
+        }
+        else if (_exclusiveOwner instanceof ConfiguredObject)
+        {
+            return ((ConfiguredObject<?>) _exclusiveOwner).getName();
+        }
+        else if (_exclusiveOwner instanceof Principal)
+        {
+            return ((Principal) _exclusiveOwner).getName();
         }
         return null;
     }

--- a/broker-core/src/test/java/org/apache/qpid/server/consumer/TestConsumerTarget.java
+++ b/broker-core/src/test/java/org/apache/qpid/server/consumer/TestConsumerTarget.java
@@ -24,6 +24,7 @@ package org.apache.qpid.server.consumer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.security.Principal;
 import java.util.ArrayList;
 
 import com.google.common.util.concurrent.Futures;
@@ -52,8 +53,18 @@ public class TestConsumerTarget implements ConsumerTarget<TestConsumerTarget>
 
     public TestConsumerTarget()
     {
+        when(_sessionModel.getName()).thenReturn("mock session");
+
+        final Principal principal = mock(Principal.class);
+        when(principal.getName()).thenReturn("mock principal");
+
+        final AMQPConnection amqpConnection = mock(AMQPConnection.class);
+        when(amqpConnection.getAuthorizedPrincipal()).thenReturn(principal);
+        when(amqpConnection.getName()).thenReturn("mock connection");
+        when(amqpConnection.getRemoteContainerName()).thenReturn("mock container");
+
         when(_sessionModel.getChannelId()).thenReturn(0);
-        when(_sessionModel.getAMQPConnection()).thenReturn(mock(AMQPConnection.class));
+        when(_sessionModel.getAMQPConnection()).thenReturn(amqpConnection);
     }
 
     @Override


### PR DESCRIPTION
This PR addresses JIRA [QPID-8665](https://issues.apache.org/jira/browse/QPID-8665), fixing an exception thrown when changing queue exclusive mode