### PR TITLE
QPID-8667: [Broker-J] Database connection with client certificate authentication exposes keystore / truststore passwords

### DIFF
--- a/broker-plugins/management-http/src/main/java/resources/footer.html
+++ b/broker-plugins/management-http/src/main/java/resources/footer.html
@@ -19,7 +19,7 @@
  -
  -->
 
-<div class="footer"><p>&#xA9; 2004-<span class="currentYear">2023</span> The Apache Software Foundation.
+<div class="footer"><p>&#xA9; 2004-<span class="currentYear">2024</span> The Apache Software Foundation.
   <br/>
   Apache Qpid, Qpid, Apache, the Apache feather logo, and the Apache Qpid project logo are trademarks of
   The Apache Software Foundation.

--- a/broker-plugins/management-http/src/main/java/resources/js/qpid/management/addVirtualHostNodeAndVirtualHost.js
+++ b/broker-plugins/management-http/src/main/java/resources/js/qpid/management/addVirtualHostNodeAndVirtualHost.js
@@ -397,37 +397,37 @@ define(["dojo/_base/event",
                         virtualHostData["context"] = virtualHostContext;
                     }
 
-                    const keystore = dijit.registry.byId('addVirtualHost.keyStore').get('value');
+                    const keystore = dijit.registry.byId("addVirtualHost.keyStore")?.get('value');
                     if (keystore)
                     {
                         virtualHostData["keyStore"] = keystore;
                     }
 
-                    const keystorePathPropertyName = dijit.registry.byId("addVirtualHost.keyStorePathPropertyName").get("value");
+                    const keystorePathPropertyName = dijit.registry.byId("addVirtualHost.keyStorePathPropertyName")?.get("value");
                     if (keystorePathPropertyName)
                     {
                         virtualHostData["keystorePathPropertyName"] = keystorePathPropertyName;
                     }
 
-                    const keystorePasswordPropertyName = dijit.registry.byId("addVirtualHost.keyStorePasswordPropertyName").get("value");
+                    const keystorePasswordPropertyName = dijit.registry.byId("addVirtualHost.keyStorePasswordPropertyName")?.get("value");
                     if (keystorePasswordPropertyName)
                     {
                         virtualHostData["keystorePasswordPropertyName"] = keystorePasswordPropertyName;
                     }
 
-                    const truststore = dijit.registry.byId("addVirtualHost.trustStore").get("value");
+                    const truststore = dijit.registry.byId("addVirtualHost.trustStore")?.get("value");
                     if (truststore)
                     {
                         virtualHostData["trustStore"] = truststore;
                     }
 
-                    const truststorePathPropertyName = dijit.registry.byId("addVirtualHost.trustStorePathPropertyName").get("value");
+                    const truststorePathPropertyName = dijit.registry.byId("addVirtualHost.trustStorePathPropertyName")?.get("value");
                     if (truststorePathPropertyName)
                     {
                         virtualHostData["truststorePathPropertyName"] = truststorePathPropertyName;
                     }
 
-                    const truststorePasswordPropertyName = dijit.registry.byId("addVirtualHost.trustStorePasswordPropertyName").get("value");
+                    const truststorePasswordPropertyName = dijit.registry.byId("addVirtualHost.trustStorePasswordPropertyName")?.get("value");
                     if (truststorePasswordPropertyName)
                     {
                         virtualHostData["truststorePasswordPropertyName"] = truststorePasswordPropertyName;


### PR DESCRIPTION
This PR addresses JIRA [QPID-8667](https://issues.apache.org/jira/browse/QPID-8667), adding a UI fix for the issue when creating a JSON Virtual Host Node with BDB Virtual host resulting in "dijit.registry.byId(...) is undefined" error.