### PR TITLE
QPID-8669 - [Broker-J] Dependency updates for version 9.2.1+

### DIFF
--- a/apache-qpid-broker-j/src/main/assembly/dependency-verification/DEPENDENCIES_REFERENCE
+++ b/apache-qpid-broker-j/src/main/assembly/dependency-verification/DEPENDENCIES_REFERENCE
@@ -29,10 +29,10 @@ From: 'an unknown organization'
   - Guava InternalFutureFailureAccess and InternalFutures (https://github.com/google/guava/failureaccess) com.google.guava:failureaccess:bundle:1.0.2
     License: The Apache Software License, Version 2.0  (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-  - Guava: Google Core Libraries for Java (https://github.com/google/guava) com.google.guava:guava:bundle:33.0.0-jre
+  - Guava: Google Core Libraries for Java (https://github.com/google/guava) com.google.guava:guava:bundle:33.4.0-jre
     License: Apache License, Version 2.0  (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-  - J2ObjC Annotations (https://github.com/google/j2objc/) com.google.j2objc:j2objc-annotations:jar:2.8
+  - J2ObjC Annotations (https://github.com/google/j2objc/) com.google.j2objc:j2objc-annotations:jar:3.0.0
     License: Apache License, Version 2.0  (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
   - Prometheus Java Simpleclient (http://github.com/prometheus/client_java/simpleclient) io.prometheus:simpleclient:bundle:0.16.0
@@ -50,13 +50,13 @@ From: 'an unknown organization'
   - Prometheus Java Span Context Supplier - OpenTelemetry Agent (http://github.com/prometheus/client_java/simpleclient_tracer/simpleclient_tracer_otel_agent) io.prometheus:simpleclient_tracer_otel_agent:bundle:0.16.0
     License: The Apache Software License, Version 2.0  (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-  - Bouncy Castle PKIX, CMS, EAC, TSP, PKCS, OCSP, CMP, and CRMF APIs (https://www.bouncycastle.org/java.html) org.bouncycastle:bcpkix-jdk18on:jar:1.77
+  - Bouncy Castle PKIX, CMS, EAC, TSP, PKCS, OCSP, CMP, and CRMF APIs (https://www.bouncycastle.org/download/bouncy-castle-java/) org.bouncycastle:bcpkix-jdk18on:jar:1.80
     License: Bouncy Castle Licence  (https://www.bouncycastle.org/licence.html)
 
-  - Bouncy Castle Provider (https://www.bouncycastle.org/java.html) org.bouncycastle:bcprov-jdk18on:jar:1.77
+  - Bouncy Castle Provider (https://www.bouncycastle.org/download/bouncy-castle-java/) org.bouncycastle:bcprov-jdk18on:jar:1.80
     License: Bouncy Castle Licence  (https://www.bouncycastle.org/licence.html)
 
-  - Bouncy Castle ASN.1 Extension and Utility APIs (https://www.bouncycastle.org/java.html) org.bouncycastle:bcutil-jdk18on:jar:1.77
+  - Bouncy Castle ASN.1 Extension and Utility APIs (https://www.bouncycastle.org/download/bouncy-castle-java/) org.bouncycastle:bcutil-jdk18on:jar:1.80
     License: Bouncy Castle Licence  (https://www.bouncycastle.org/licence.html)
 
   - dgrid (https://www.webjars.org) org.webjars.bower:dgrid:jar:1.3.3
@@ -68,19 +68,22 @@ From: 'an unknown organization'
 
 From: 'Apache Software Foundation' (http://db.apache.org/)
 
-  - Apache Derby Database Engine and Embedded JDBC Driver (http://db.apache.org/derby/) org.apache.derby:derby:jar:10.14.2.0
+  - Apache Derby Database Engine and Embedded JDBC Driver (http://db.apache.org/derby/) org.apache.derby:derby:jar:10.15.2.0
+    License: Apache 2  (http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+  - Apache Derby Shared Code (http://db.apache.org/derby/) org.apache.derby:derbyshared:jar:10.15.2.0
     License: Apache 2  (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 
 From: 'FasterXML' (http://fasterxml.com/)
 
-  - Jackson-annotations (https://github.com/FasterXML/jackson) com.fasterxml.jackson.core:jackson-annotations:jar:2.16.1
+  - Jackson-annotations (https://github.com/FasterXML/jackson) com.fasterxml.jackson.core:jackson-annotations:jar:2.18.2
     License: The Apache Software License, Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-  - Jackson-core (https://github.com/FasterXML/jackson-core) com.fasterxml.jackson.core:jackson-core:jar:2.16.1
+  - Jackson-core (https://github.com/FasterXML/jackson-core) com.fasterxml.jackson.core:jackson-core:jar:2.18.2
     License: The Apache Software License, Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-  - jackson-databind (https://github.com/FasterXML/jackson) com.fasterxml.jackson.core:jackson-databind:jar:2.16.1
+  - jackson-databind (https://github.com/FasterXML/jackson) com.fasterxml.jackson.core:jackson-databind:jar:2.18.2
     License: The Apache Software License, Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
 
 
@@ -99,20 +102,20 @@ From: 'Oracle Corporation' (http://www.oracle.com/)
 
 From: 'OW2' (http://www.ow2.org/)
 
-  - asm (http://asm.ow2.io/) org.ow2.asm:asm:jar:9.6
+  - asm (http://asm.ow2.io/) org.ow2.asm:asm:jar:9.7.1
     License: BSD-3-Clause  (https://asm.ow2.io/license.html)
 
-  - asm-tree (http://asm.ow2.io/) org.ow2.asm:asm-tree:jar:9.6
+  - asm-tree (http://asm.ow2.io/) org.ow2.asm:asm-tree:jar:9.7.1
     License: BSD-3-Clause  (https://asm.ow2.io/license.html)
 
 
 From: 'QOS.ch' (http://www.qos.ch)
 
-  - Logback Classic Module (http://logback.qos.ch/logback-classic) ch.qos.logback:logback-classic:jar:1.4.14
+  - Logback Classic Module (http://logback.qos.ch/logback-classic) ch.qos.logback:logback-classic:jar:1.5.16
     License: Eclipse Public License - v 1.0  (http://www.eclipse.org/legal/epl-v10.html)
     License: GNU Lesser General Public License  (http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html)
 
-  - Logback Core Module (http://logback.qos.ch/logback-core) ch.qos.logback:logback-core:jar:1.4.14
+  - Logback Core Module (http://logback.qos.ch/logback-core) ch.qos.logback:logback-core:jar:1.5.16
     License: Eclipse Public License - v 1.0  (http://www.eclipse.org/legal/epl-v10.html)
     License: GNU Lesser General Public License  (http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html)
 
@@ -124,13 +127,13 @@ From: 'QOS.ch' (http://www.qos.ch)
     License: Eclipse Public License - v 1.0  (http://www.eclipse.org/legal/epl-v10.html)
     License: GNU Lesser General Public License  (http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html)
 
-  - SLF4J API Module (http://www.slf4j.org) org.slf4j:slf4j-api:jar:2.0.11
+  - SLF4J API Module (http://www.slf4j.org) org.slf4j:slf4j-api:jar:2.0.16
     License: MIT License  (http://www.opensource.org/licenses/mit-license.php)
 
 
 From: 'The Apache Software Foundation' (https://www.apache.org/)
 
-  - Apache Commons CLI (https://commons.apache.org/proper/commons-cli/) commons-cli:commons-cli:jar:1.6.0
+  - Apache Commons CLI (https://commons.apache.org/proper/commons-cli/) commons-cli:commons-cli:jar:1.9.0
     License: Apache-2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
 
   - Apache Qpid Broker-J BDB Message Store Plug-in (http://qpid.apache.org/components/qpid-bdbstore) org.apache.qpid:qpid-bdbstore:jar
@@ -218,74 +221,74 @@ From: 'The CometD Project' (https://cometd.org)
 
 From: 'Webtide' (https://webtide.com)
 
-  - Jetty :: Http Utility (https://eclipse.dev/jetty/jetty-http) org.eclipse.jetty:jetty-http:jar:11.0.19
+  - Jetty :: Http Utility (https://jetty.org/jetty-http) org.eclipse.jetty:jetty-http:jar:11.0.24
     License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0/)
     License: Apache Software License - Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0)
 
-  - Jetty :: IO Utility (https://eclipse.dev/jetty/jetty-io) org.eclipse.jetty:jetty-io:jar:11.0.19
+  - Jetty :: IO Utility (https://jetty.org/jetty-io) org.eclipse.jetty:jetty-io:jar:11.0.24
     License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0/)
     License: Apache Software License - Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0)
 
-  - Jetty :: Rewrite Handler (https://eclipse.dev/jetty/jetty-rewrite) org.eclipse.jetty:jetty-rewrite:jar:11.0.19
+  - Jetty :: Rewrite Handler (https://jetty.org/jetty-rewrite) org.eclipse.jetty:jetty-rewrite:jar:11.0.24
     License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0/)
     License: Apache Software License - Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0)
 
-  - Jetty :: Security (https://eclipse.dev/jetty/jetty-security) org.eclipse.jetty:jetty-security:jar:11.0.19
+  - Jetty :: Security (https://jetty.org/jetty-security) org.eclipse.jetty:jetty-security:jar:11.0.24
     License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0/)
     License: Apache Software License - Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0)
 
-  - Jetty :: Server Core (https://eclipse.dev/jetty/jetty-server) org.eclipse.jetty:jetty-server:jar:11.0.19
+  - Jetty :: Server Core (https://jetty.org/jetty-server) org.eclipse.jetty:jetty-server:jar:11.0.24
     License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0/)
     License: Apache Software License - Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0)
 
-  - Jetty :: Servlet Handling (https://eclipse.dev/jetty/jetty-servlet) org.eclipse.jetty:jetty-servlet:jar:11.0.19
+  - Jetty :: Servlet Handling (https://jetty.org/jetty-servlet) org.eclipse.jetty:jetty-servlet:jar:11.0.24
     License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0/)
     License: Apache Software License - Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0)
 
-  - Jetty :: Utility Servlets and Filters (https://eclipse.dev/jetty/jetty-servlets) org.eclipse.jetty:jetty-servlets:jar:11.0.19
+  - Jetty :: Utility Servlets and Filters (https://jetty.org/jetty-servlets) org.eclipse.jetty:jetty-servlets:jar:11.0.24
     License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0/)
     License: Apache Software License - Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0)
 
-  - Jetty :: Utilities (https://eclipse.dev/jetty/jetty-util) org.eclipse.jetty:jetty-util:jar:11.0.19
+  - Jetty :: Utilities (https://jetty.org/jetty-util) org.eclipse.jetty:jetty-util:jar:11.0.24
     License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0/)
     License: Apache Software License - Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0)
 
-  - Jetty :: Webapp Application Support (https://eclipse.dev/jetty/jetty-webapp) org.eclipse.jetty:jetty-webapp:jar:11.0.19
+  - Jetty :: Webapp Application Support (https://jetty.org/jetty-webapp) org.eclipse.jetty:jetty-webapp:jar:11.0.24
     License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0/)
     License: Apache Software License - Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0)
 
-  - Jetty :: XML utilities (https://eclipse.dev/jetty/jetty-xml) org.eclipse.jetty:jetty-xml:jar:11.0.19
+  - Jetty :: XML utilities (https://jetty.org/jetty-xml) org.eclipse.jetty:jetty-xml:jar:11.0.24
     License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0/)
     License: Apache Software License - Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0)
 
-  - Jetty :: Websocket :: Core :: Common (https://eclipse.dev/jetty/websocket-parent/websocket-core-common) org.eclipse.jetty.websocket:websocket-core-common:jar:11.0.19
+  - Jetty :: Websocket :: Core :: Common (https://jetty.org/websocket-parent/websocket-core-common) org.eclipse.jetty.websocket:websocket-core-common:jar:11.0.24
     License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0/)
     License: Apache Software License - Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0)
 
-  - Jetty :: Websocket :: Core :: Server (https://eclipse.dev/jetty/websocket-parent/websocket-core-server) org.eclipse.jetty.websocket:websocket-core-server:jar:11.0.19
+  - Jetty :: Websocket :: Core :: Server (https://jetty.org/websocket-parent/websocket-core-server) org.eclipse.jetty.websocket:websocket-core-server:jar:11.0.24
     License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0/)
     License: Apache Software License - Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0)
 
-  - Jetty :: Websocket :: org.eclipse.jetty.websocket :: API (https://eclipse.dev/jetty/websocket-parent/websocket-jetty-api) org.eclipse.jetty.websocket:websocket-jetty-api:jar:11.0.19
+  - Jetty :: Websocket :: org.eclipse.jetty.websocket :: API (https://jetty.org/websocket-parent/websocket-jetty-api) org.eclipse.jetty.websocket:websocket-jetty-api:jar:11.0.24
     License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0/)
     License: Apache Software License - Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0)
 
-  - Jetty :: Websocket :: org.eclipse.jetty.websocket :: Common (https://eclipse.dev/jetty/websocket-parent/websocket-jetty-common) org.eclipse.jetty.websocket:websocket-jetty-common:jar:11.0.19
+  - Jetty :: Websocket :: org.eclipse.jetty.websocket :: Common (https://jetty.org/websocket-parent/websocket-jetty-common) org.eclipse.jetty.websocket:websocket-jetty-common:jar:11.0.24
     License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0/)
     License: Apache Software License - Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0)
 
-  - Jetty :: Websocket :: org.eclipse.jetty.websocket :: Server (https://eclipse.dev/jetty/websocket-parent/websocket-jetty-server) org.eclipse.jetty.websocket:websocket-jetty-server:jar:11.0.19
+  - Jetty :: Websocket :: org.eclipse.jetty.websocket :: Server (https://jetty.org/websocket-parent/websocket-jetty-server) org.eclipse.jetty.websocket:websocket-jetty-server:jar:11.0.24
     License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0/)
     License: Apache Software License - Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0)
 
-  - Jetty :: Websocket :: Servlet (https://eclipse.dev/jetty/websocket-parent/websocket-servlet) org.eclipse.jetty.websocket:websocket-servlet:jar:11.0.19
+  - Jetty :: Websocket :: Servlet (https://jetty.org/websocket-parent/websocket-servlet) org.eclipse.jetty.websocket:websocket-servlet:jar:11.0.24
     License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0/)
     License: Apache Software License - Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0)
 
 
 From: 'Zaxxer.com' (https://github.com/brettwooldridge)
 
-  - HikariCP (https://github.com/brettwooldridge/HikariCP) com.zaxxer:HikariCP:bundle:5.1.0
+  - HikariCP (https://github.com/brettwooldridge/HikariCP) com.zaxxer:HikariCP:bundle:6.2.1
     License: The Apache Software License, Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
 
 

--- a/broker-core/src/main/java/org/apache/qpid/server/filter/selector/SelectorParser.java
+++ b/broker-core/src/main/java/org/apache/qpid/server/filter/selector/SelectorParser.java
@@ -1238,7 +1238,7 @@ public class SelectorParser<E> implements SelectorParserConstants {
     throw generateParseException();
   }
 
-  static private final class LookaheadSuccess extends java.lang.Error { }
+  static private final class LookaheadSuccess extends Error { }
   final private LookaheadSuccess jj_ls = new LookaheadSuccess();
   private boolean jj_scan_token(int kind) {
     if (jj_scanpos == jj_lastpos) {

--- a/perftests/pom.xml
+++ b/perftests/pom.xml
@@ -92,6 +92,11 @@
       <artifactId>derby</artifactId>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.derby</groupId>
+      <artifactId>derbytools</artifactId>
+      <scope>provided</scope>
+    </dependency>
 
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>

--- a/perftests/src/main/assembly/dependency-verification/DEPENDENCIES_REFERENCE
+++ b/perftests/src/main/assembly/dependency-verification/DEPENDENCIES_REFERENCE
@@ -29,10 +29,10 @@ From: 'an unknown organization'
   - Guava InternalFutureFailureAccess and InternalFutures (https://github.com/google/guava/failureaccess) com.google.guava:failureaccess:bundle:1.0.2
     License: The Apache Software License, Version 2.0  (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-  - Guava: Google Core Libraries for Java (https://github.com/google/guava) com.google.guava:guava:bundle:33.0.0-jre
+  - Guava: Google Core Libraries for Java (https://github.com/google/guava) com.google.guava:guava:bundle:33.4.0-jre
     License: Apache License, Version 2.0  (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-  - J2ObjC Annotations (https://github.com/google/j2objc/) com.google.j2objc:j2objc-annotations:jar:2.8
+  - J2ObjC Annotations (https://github.com/google/j2objc/) com.google.j2objc:j2objc-annotations:jar:3.0.0
     License: Apache License, Version 2.0  (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 
@@ -44,27 +44,27 @@ From: 'Apache Software Foundation' (http://www.apache.org)
 
 From: 'FasterXML' (http://fasterxml.com/)
 
-  - Jackson-annotations (https://github.com/FasterXML/jackson) com.fasterxml.jackson.core:jackson-annotations:jar:2.16.1
+  - Jackson-annotations (https://github.com/FasterXML/jackson) com.fasterxml.jackson.core:jackson-annotations:jar:2.18.2
     License: The Apache Software License, Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-  - Jackson-core (https://github.com/FasterXML/jackson-core) com.fasterxml.jackson.core:jackson-core:jar:2.16.1
+  - Jackson-core (https://github.com/FasterXML/jackson-core) com.fasterxml.jackson.core:jackson-core:jar:2.18.2
     License: The Apache Software License, Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-  - jackson-databind (https://github.com/FasterXML/jackson) com.fasterxml.jackson.core:jackson-databind:jar:2.16.1
+  - jackson-databind (https://github.com/FasterXML/jackson) com.fasterxml.jackson.core:jackson-databind:jar:2.18.2
     License: The Apache Software License, Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
 
 
 From: 'QOS.ch' (http://www.qos.ch)
 
-  - Logback Classic Module (http://logback.qos.ch/logback-classic) ch.qos.logback:logback-classic:jar:1.4.14
+  - Logback Classic Module (http://logback.qos.ch/logback-classic) ch.qos.logback:logback-classic:jar:1.5.16
     License: Eclipse Public License - v 1.0  (http://www.eclipse.org/legal/epl-v10.html)
     License: GNU Lesser General Public License  (http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html)
 
-  - Logback Core Module (http://logback.qos.ch/logback-core) ch.qos.logback:logback-core:jar:1.4.14
+  - Logback Core Module (http://logback.qos.ch/logback-core) ch.qos.logback:logback-core:jar:1.5.16
     License: Eclipse Public License - v 1.0  (http://www.eclipse.org/legal/epl-v10.html)
     License: GNU Lesser General Public License  (http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html)
 
-  - SLF4J API Module (http://www.slf4j.org) org.slf4j:slf4j-api:jar:2.0.11
+  - SLF4J API Module (http://www.slf4j.org) org.slf4j:slf4j-api:jar:2.0.16
     License: MIT License  (http://www.opensource.org/licenses/mit-license.php)
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache</groupId>
     <artifactId>apache</artifactId>
-    <version>30</version>
+    <version>31</version>
   </parent>
 
   <groupId>org.apache.qpid</groupId>
@@ -103,25 +103,25 @@
     <at.sign>@</at.sign>
 
     <bdb-version>7.4.5</bdb-version>
-    <derby-version>10.14.2.0</derby-version>
-    <logback-version>1.4.14</logback-version>
+    <derby-version>10.15.2.0</derby-version>
+    <logback-version>1.5.16</logback-version>
     <logback-db-version>1.2.11.1</logback-db-version>
-    <guava-version>33.0.0-jre</guava-version>
-    <fasterxml-jackson-version>2.16.1</fasterxml-jackson-version>
-    <fasterxml-jackson-databind-version>2.16.1</fasterxml-jackson-databind-version>
-    <slf4j-version>2.0.11</slf4j-version>
-    <jetty-version>11.0.19</jetty-version>
+    <guava-version>33.4.0-jre</guava-version>
+    <fasterxml-jackson-version>2.18.2</fasterxml-jackson-version>
+    <fasterxml-jackson-databind-version>2.18.2</fasterxml-jackson-databind-version>
+    <slf4j-version>2.0.16</slf4j-version>
+    <jetty-version>11.0.24</jetty-version>
 
     <!-- dependency version numbers -->
-    <hikari-cp-version>5.1.0</hikari-cp-version>
-    <commons-cli-version>1.6.0</commons-cli-version>
+    <hikari-cp-version>6.2.1</hikari-cp-version>
+    <commons-cli-version>1.9.0</commons-cli-version>
 
     <geronimo-jms-1-1-version>1.1.1</geronimo-jms-1-1-version>
     <geronimo-jms-2-0-version>1.0-alpha-2</geronimo-jms-2-0-version>
-    <asm-version>9.6</asm-version>
+    <asm-version>9.7.1</asm-version>
 
     <velocity-version>1.4</velocity-version>
-    <csvjdbc-version>1.0.35</csvjdbc-version>
+    <csvjdbc-version>1.0.46</csvjdbc-version>
     <jfreechart-version>1.0.13</jfreechart-version>
 
     <dojo-version>1.17.3</dojo-version>
@@ -129,41 +129,41 @@
     <dgrid-version>1.3.3</dgrid-version>
 
     <!-- test dependency version numbers -->
-    <junit-version>5.10.1</junit-version>
-    <mockito-version>5.10.0</mockito-version>
-    <netty-version>4.1.106.Final</netty-version>
-    <hamcrest-version>2.2</hamcrest-version>
+    <junit-version>5.11.4</junit-version>
+    <mockito-version>5.15.2</mockito-version>
+    <netty-version>4.1.118.Final</netty-version>
+    <hamcrest-version>3.0</hamcrest-version>
     <maven-resolver-provider-version>3.8.6</maven-resolver-provider-version>
-    <maven-resolver-version>1.8.2</maven-resolver-version>
+    <maven-resolver-version>1.9.22</maven-resolver-version>
     <httpclient-version>4.5.13</httpclient-version>
     <qpid-jms-client-version>0.61.0</qpid-jms-client-version>
     <qpid-jms-client-amqp-0-x-version>6.4.0</qpid-jms-client-amqp-0-x-version>
     <jaxb-api-version>2.3.1</jaxb-api-version>
-    <nashorn-version>15.4</nashorn-version>
+    <nashorn-version>15.6</nashorn-version>
 
-    <exec-maven-plugin-version>3.1.1</exec-maven-plugin-version>
+    <exec-maven-plugin-version>3.5.0</exec-maven-plugin-version>
     <javacc-maven-plugin-version>2.6</javacc-maven-plugin-version>
     <ph-javacc-maven-plugin-version>4.1.5</ph-javacc-maven-plugin-version>
-    <maven-enforcer-plugin-version>3.4.1</maven-enforcer-plugin-version>
-    <maven-rar-plugin-version>2.4</maven-rar-plugin-version>
-    <license-maven-plugin-version>2.2.0</license-maven-plugin-version>
-    <maven-jxr-plugin-version>3.3.0</maven-jxr-plugin-version>
+    <maven-enforcer-plugin-version>3.5.0</maven-enforcer-plugin-version>
+    <maven-rar-plugin-version>3.0.0</maven-rar-plugin-version>
+    <license-maven-plugin-version>2.5.0</license-maven-plugin-version>
+    <maven-jxr-plugin-version>3.6.0</maven-jxr-plugin-version>
     <findbugs-maven-plugin-version>3.0.5</findbugs-maven-plugin-version>
-    <jacoco-plugin-version>0.8.11</jacoco-plugin-version>
-    <apache-rat-plugin-version>0.15</apache-rat-plugin-version>
-    <maven-docbx-plugin-version>2.0.15</maven-docbx-plugin-version>
+    <jacoco-plugin-version>0.8.12</jacoco-plugin-version>
+    <apache-rat-plugin-version>0.16.1</apache-rat-plugin-version>
+    <maven-docbx-plugin-version>2.0.17</maven-docbx-plugin-version>
     <maven-docbook-xml-plugin-version>5.0-all</maven-docbook-xml-plugin-version>
-    <buildnumber-maven-plugin-version>1.4</buildnumber-maven-plugin-version>
-    <maven-compiler-plugin-version>3.12.1</maven-compiler-plugin-version>
-    <maven-jar-plugin-version>3.3.0</maven-jar-plugin-version>
-    <maven-surefire-plugin-version>3.2.3</maven-surefire-plugin-version>
-    <maven-surefire-report-plugin-version>3.2.3</maven-surefire-report-plugin-version>
-    <h2.version>2.2.224</h2.version>
+    <buildnumber-maven-plugin-version>3.2.1</buildnumber-maven-plugin-version>
+    <maven-compiler-plugin-version>3.13.0</maven-compiler-plugin-version>
+    <maven-jar-plugin-version>3.4.2</maven-jar-plugin-version>
+    <maven-surefire-plugin-version>3.5.2</maven-surefire-plugin-version>
+    <maven-surefire-report-plugin-version>3.5.2</maven-surefire-report-plugin-version>
+    <h2.version>2.3.232</h2.version>
     <apache-directory-version>2.0.0.AM27</apache-directory-version>
-    <kerby-version>2.0.3</kerby-version>
-    <bcprov-version>1.77</bcprov-version>
-    <bcpkix-version>1.77</bcpkix-version>
-    <logback-gelf-version>5.0.1</logback-gelf-version>
+    <kerby-version>2.1.0</kerby-version>
+    <bcprov-version>1.80</bcprov-version>
+    <bcpkix-version>1.80</bcpkix-version>
+    <logback-gelf-version>6.1.1</logback-gelf-version>
     <prometheus-client-version>0.16.0</prometheus-client-version>
 
     <bdb-repo-enabled>false</bdb-repo-enabled>
@@ -555,6 +555,11 @@
       <dependency>
         <groupId>org.apache.derby</groupId>
         <artifactId>derby</artifactId>
+        <version>${derby-version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.derby</groupId>
+        <artifactId>derbytools</artifactId>
         <version>${derby-version}</version>
       </dependency>
       <dependency>


### PR DESCRIPTION
This PR addresses JIRA [QPID-8669](https://issues.apache.org/jira/browse/QPID-8669), updating broker-j dependencies.

Following dependencies are updated:

**runtime dependencies**
ch.qos.logback:logback-classic 1.4.14 => 1.5.16
com.google.guava:guava 33.0.0-jre => 33.4.0-jre
com.fasterxml.jackson.core:jackson-core 2.16.1 => 2.18.2
com.fasterxml.jackson.core:jackson-databind 2.16.1 => 2.18.2
com.zaxxer:HikariCP 5.1.0 => 6.2.1
commons-cli:commons-cli 1.6.0 => 1.9.0
org.apache:apache 30 => 31
org.apache.derby:derby 10.14.2.0 => 10.15.2.0
org.bouncycastle:bcprov-jdk18on 1.77 => 1.80
org.bouncycastle:bcpkix-jdk18on 1.77 => 1.80
org.eclipse.jetty:jetty-server 11.0.19 => 11.0.24
org.eclipse.jetty:jetty-servlet 11.0.19 => 11.0.24
org.eclipse.jetty:jetty-servlets 11.0.19 => 11.0.24
org.eclipse.jetty:jetty-rewrite 11.0.19 => 11.0.24
org.eclipse.jetty.websocket:websocket-jetty-server 11.0.19 => 11.0.24
org.openjdk.nashorn:nashorn-core 15.4 => 15.6
org.slf4:slf4j-api 2.0.11 => 2.0.16

**test dependencies**
com.h2database:h2 2.2.224 => 2.3.232
io.netty:netty-buffer 4.1.106.Final => 4.1.118.Final
io.netty:netty-common 4.1.106.Final => 4.1.118.Final
io.netty:netty-handler 4.1.106.Final => 4.1.118.Final
io.netty:netty-transport 4.1.106.Final => 4.1.118.Final
io.netty:netty-codec-http 4.1.106.Final => 4.1.118.Final
org.apache.kerby:kerb-simplekdc 2.0.3 => 2.1.0
org.hamcrest:hamcrest 2.2 => 3.0
org.mockito:mockito-core 5.10.0 => 5.15.2
org.junit.jupiter:junit-jupiter-api 5.10.1 => 5.11.4
org.junit.jupiter:junit-jupiter-engine 5.10.1 => 5.11.4
org.junit.jupiter:junit-jupiter-params 5.10.1 => 5.11.4

**maven plugins**
org.codehaus.mojo:exec-maven-plugin 3.1.1 => 3.5.0
org.apache.rat:apache-rat-plugin 0.15 => 0.16.1
org.apache.maven.plugins:maven-compiler-plugin 3.12.1 => 3.13.0
org.apache.maven.plugins:maven-jxr-plugin 3.3.0 => 3.3.2
org.apache.maven.plugins:maven-surefire-plugin 3.2.3 => 3.5.2
org.apache.maven.plugins:maven-surefire-report-plugin 3.2.3 => 3.5.2