### PR TITLE
QPID-8680 - [Broker-J] Broker should interpret the value of qpid.port.heartbeatDelay as half of the actual idle timeout

### DIFF
--- a/broker-plugins/amqp-1-0-protocol/src/main/java/org/apache/qpid/server/protocol/v1_0/AMQPConnection_1_0Impl.java
+++ b/broker-plugins/amqp-1-0-protocol/src/main/java/org/apache/qpid/server/protocol/v1_0/AMQPConnection_1_0Impl.java
@@ -897,7 +897,7 @@ public class AMQPConnection_1_0Impl extends AbstractAMQPConnection<AMQPConnectio
         }
         else
         {
-            initialiseHeartbeating(_outgoingIdleTimeout / 2L, _incomingIdleTimeout);
+            initialiseHeartbeating(_outgoingIdleTimeout / 2L, _incomingIdleTimeout * 2);
             final NamedAddressSpace addressSpace = getPort().getAddressSpace(_localHostname);
             if (addressSpace == null)
             {


### PR DESCRIPTION
This PR addresses JIRA [QPID-8680](https://issues.apache.org/jira/browse/QPID-8680), changing interpretation of parameter "qpid.port.heartbeatDelay" to the half of the actual idle timeout