### PR TITLE
NO-JIRA - Update ubuntu runner to 'ubuntu-24.04'

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ on: [push, pull_request, workflow_dispatch]
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
The Ubuntu 20.04 runner will begin deprecation in February and be fully unsupported by April: https://github.com/actions/runner-images/issues/11101

This PR updates image label to ubuntu-24.04