### PR TITLE
QPID-8688: [Broker-J] Remove unneeded jaxb dependencies

### DIFF
--- a/bdbstore/systests/pom.xml
+++ b/bdbstore/systests/pom.xml
@@ -131,16 +131,6 @@
           <artifactId>qpid-client</artifactId>
           <scope>test</scope>
         </dependency>
-        <dependency>
-          <groupId>javax.xml.bind</groupId>
-          <artifactId>jaxb-api</artifactId>
-          <scope>test</scope>
-        </dependency>
-        <dependency>
-          <groupId>org.glassfish.jaxb</groupId>
-          <artifactId>jaxb-runtime</artifactId>
-          <scope>test</scope>
-        </dependency>
       </dependencies>
     </profile>
   </profiles>

--- a/joramtests/pom.xml
+++ b/joramtests/pom.xml
@@ -238,16 +238,6 @@
                     <version>${qpid-amqp-1-0-client-jms-version}</version>
                     <scope>runtime</scope>
                 </dependency>
-                <dependency>
-                    <groupId>javax.xml.bind</groupId>
-                    <artifactId>jaxb-api</artifactId>
-                    <scope>runtime</scope>
-                </dependency>
-                <dependency>
-                    <groupId>org.glassfish.jaxb</groupId>
-                    <artifactId>jaxb-runtime</artifactId>
-                    <scope>runtime</scope>
-                </dependency>
             </dependencies>
         </profile>
 
@@ -295,16 +285,6 @@
                     <artifactId>qpid-client</artifactId>
                     <scope>runtime</scope>
                 </dependency>
-                <dependency>
-                    <groupId>javax.xml.bind</groupId>
-                    <artifactId>jaxb-api</artifactId>
-                    <scope>runtime</scope>
-                </dependency>
-                <dependency>
-                    <groupId>org.glassfish.jaxb</groupId>
-                    <artifactId>jaxb-runtime</artifactId>
-                    <scope>runtime</scope>
-                </dependency>
             </dependencies>
         </profile>
 
@@ -326,16 +306,6 @@
                 <dependency>
                     <groupId>org.apache.qpid</groupId>
                     <artifactId>qpid-client</artifactId>
-                    <scope>runtime</scope>
-                </dependency>
-                <dependency>
-                    <groupId>javax.xml.bind</groupId>
-                    <artifactId>jaxb-api</artifactId>
-                    <scope>runtime</scope>
-                </dependency>
-                <dependency>
-                    <groupId>org.glassfish.jaxb</groupId>
-                    <artifactId>jaxb-runtime</artifactId>
                     <scope>runtime</scope>
                 </dependency>
             </dependencies>

--- a/perftests/pom.xml
+++ b/perftests/pom.xml
@@ -378,16 +378,6 @@
           <artifactId>qpid-client</artifactId>
           <scope>runtime</scope>
         </dependency>
-        <dependency>
-          <groupId>javax.xml.bind</groupId>
-          <artifactId>jaxb-api</artifactId>
-          <scope>runtime</scope>
-        </dependency>
-        <dependency>
-          <groupId>org.glassfish.jaxb</groupId>
-          <artifactId>jaxb-runtime</artifactId>
-          <scope>runtime</scope>
-        </dependency>
       </dependencies>
     </profile>
     <profile>
@@ -408,16 +398,6 @@
         <dependency>
           <groupId>org.apache.qpid</groupId>
           <artifactId>qpid-client</artifactId>
-          <scope>runtime</scope>
-        </dependency>
-        <dependency>
-          <groupId>javax.xml.bind</groupId>
-          <artifactId>jaxb-api</artifactId>
-          <scope>runtime</scope>
-        </dependency>
-        <dependency>
-          <groupId>org.glassfish.jaxb</groupId>
-          <artifactId>jaxb-runtime</artifactId>
           <scope>runtime</scope>
         </dependency>
       </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -136,9 +136,8 @@
     <maven-resolver-provider-version>3.8.6</maven-resolver-provider-version>
     <maven-resolver-version>1.9.22</maven-resolver-version>
     <httpclient-version>4.5.13</httpclient-version>
-    <qpid-jms-client-version>0.61.0</qpid-jms-client-version>
+    <qpid-jms-client-version>1.13.0</qpid-jms-client-version>
     <qpid-jms-client-amqp-0-x-version>6.4.0</qpid-jms-client-amqp-0-x-version>
-    <jaxb-api-version>2.3.1</jaxb-api-version>
     <nashorn-version>15.6</nashorn-version>
 
     <exec-maven-plugin-version>3.5.0</exec-maven-plugin-version>
@@ -520,17 +519,6 @@
         <groupId>org.apache.qpid</groupId>
         <artifactId>qpid-client</artifactId>
         <version>${qpid-jms-client-amqp-0-x-version}</version>
-      </dependency>
-      <!-- qpid-client requires jaxb-api for Base64 encoding-->
-      <dependency>
-        <groupId>javax.xml.bind</groupId>
-        <artifactId>jaxb-api</artifactId>
-        <version>${jaxb-api-version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.glassfish.jaxb</groupId>
-        <artifactId>jaxb-runtime</artifactId>
-        <version>${jaxb-api-version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.qpid</groupId>

--- a/qpid-perftests-systests/pom.xml
+++ b/qpid-perftests-systests/pom.xml
@@ -108,17 +108,6 @@
           <artifactId>qpid-client</artifactId>
           <scope>test</scope>
         </dependency>
-
-        <dependency>
-          <groupId>javax.xml.bind</groupId>
-          <artifactId>jaxb-api</artifactId>
-          <scope>test</scope>
-        </dependency>
-        <dependency>
-          <groupId>org.glassfish.jaxb</groupId>
-          <artifactId>jaxb-runtime</artifactId>
-          <scope>test</scope>
-        </dependency>
       </dependencies>
     </profile>
     <profile>

--- a/systests/end-to-end-conversion-tests/pom.xml
+++ b/systests/end-to-end-conversion-tests/pom.xml
@@ -34,7 +34,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <amqp10ClientGavs>org.apache.qpid:qpid-jms-client:${qpid-jms-client-version},org.slf4j:slf4j-simple:${slf4j-version}</amqp10ClientGavs>
-        <amqp0xClientGavs>org.apache.qpid:qpid-client:${qpid-jms-client-amqp-0-x-version},org.apache.geronimo.specs:geronimo-jms_1.1_spec:${geronimo-jms-1-1-version},org.slf4j:slf4j-simple:${slf4j-version},javax.xml.bind:jaxb-api:${jaxb-api-version},org.glassfish.jaxb:jaxb-runtime:${jaxb-api-version}</amqp0xClientGavs>
+        <amqp0xClientGavs>org.apache.qpid:qpid-client:${qpid-jms-client-amqp-0-x-version},org.apache.geronimo.specs:geronimo-jms_1.1_spec:${geronimo-jms-1-1-version},org.slf4j:slf4j-simple:${slf4j-version},org.glassfish.jaxb:jaxb-runtime:${jaxb-api-version}</amqp0xClientGavs>
     </properties>
 
     <dependencies>

--- a/systests/qpid-systests-http-management/pom.xml
+++ b/systests/qpid-systests-http-management/pom.xml
@@ -138,16 +138,6 @@
                     <artifactId>qpid-client</artifactId>
                     <scope>test</scope>
                 </dependency>
-                <dependency>
-                    <groupId>javax.xml.bind</groupId>
-                    <artifactId>jaxb-api</artifactId>
-                    <scope>test</scope>
-                </dependency>
-                <dependency>
-                    <groupId>org.glassfish.jaxb</groupId>
-                    <artifactId>jaxb-runtime</artifactId>
-                    <scope>test</scope>
-                </dependency>
             </dependencies>
         </profile>
     </profiles>

--- a/systests/qpid-systests-jms_1.1/pom.xml
+++ b/systests/qpid-systests-jms_1.1/pom.xml
@@ -97,16 +97,6 @@
                     <artifactId>qpid-client</artifactId>
                     <scope>test</scope>
                 </dependency>
-                <dependency>
-                    <groupId>javax.xml.bind</groupId>
-                    <artifactId>jaxb-api</artifactId>
-                    <scope>test</scope>
-                </dependency>
-                <dependency>
-                    <groupId>org.glassfish.jaxb</groupId>
-                    <artifactId>jaxb-runtime</artifactId>
-                    <scope>test</scope>
-                </dependency>
             </dependencies>
         </profile>
     </profiles>

--- a/systests/qpid-systests-spawn-admin/pom.xml
+++ b/systests/qpid-systests-spawn-admin/pom.xml
@@ -87,16 +87,6 @@
                     <artifactId>geronimo-jms_1.1_spec</artifactId>
                     <scope>provided</scope>
                 </dependency>
-                <dependency>
-                    <groupId>javax.xml.bind</groupId>
-                    <artifactId>jaxb-api</artifactId>
-                    <scope>runtime</scope>
-                </dependency>
-                <dependency>
-                    <groupId>org.glassfish.jaxb</groupId>
-                    <artifactId>jaxb-runtime</artifactId>
-                    <scope>runtime</scope>
-                </dependency>
             </dependencies>
         </profile>
     </profiles>

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -664,16 +664,6 @@
                     <artifactId>qpid-client</artifactId>
                     <scope>runtime</scope>
                 </dependency>
-                <dependency>
-                    <groupId>javax.xml.bind</groupId>
-                    <artifactId>jaxb-api</artifactId>
-                    <scope>runtime</scope>
-                 </dependency>
-                <dependency>
-                    <groupId>org.glassfish.jaxb</groupId>
-                    <artifactId>jaxb-runtime</artifactId>
-                    <scope>runtime</scope>
-                </dependency>
             </dependencies>
         </profile>
 
@@ -696,16 +686,6 @@
                 <dependency>
                     <groupId>org.apache.qpid</groupId>
                     <artifactId>qpid-client</artifactId>
-                    <scope>runtime</scope>
-                </dependency>
-                <dependency>
-                    <groupId>javax.xml.bind</groupId>
-                    <artifactId>jaxb-api</artifactId>
-                    <scope>runtime</scope>
-                </dependency>
-                <dependency>
-                    <groupId>org.glassfish.jaxb</groupId>
-                    <artifactId>jaxb-runtime</artifactId>
                     <scope>runtime</scope>
                 </dependency>
             </dependencies>

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -135,16 +135,6 @@
           <artifactId>geronimo-jms_1.1_spec</artifactId>
           <scope>runtime</scope>
         </dependency>
-        <dependency>
-          <groupId>javax.xml.bind</groupId>
-          <artifactId>jaxb-api</artifactId>
-          <scope>runtime</scope>
-        </dependency>
-        <dependency>
-          <groupId>org.glassfish.jaxb</groupId>
-          <artifactId>jaxb-runtime</artifactId>
-          <scope>runtime</scope>
-        </dependency>
       </dependencies>
     </profile>
     <profile>
@@ -180,16 +170,6 @@
         <dependency>
           <groupId>org.apache.geronimo.specs</groupId>
           <artifactId>geronimo-jms_1.1_spec</artifactId>
-          <scope>runtime</scope>
-        </dependency>
-        <dependency>
-          <groupId>javax.xml.bind</groupId>
-          <artifactId>jaxb-api</artifactId>
-          <scope>runtime</scope>
-        </dependency>
-        <dependency>
-          <groupId>org.glassfish.jaxb</groupId>
-          <artifactId>jaxb-runtime</artifactId>
           <scope>runtime</scope>
         </dependency>
       </dependencies>
@@ -256,16 +236,6 @@
           <artifactId>geronimo-jms_1.1_spec</artifactId>
           <scope>compile</scope>
         </dependency>
-        <dependency>
-          <groupId>javax.xml.bind</groupId>
-          <artifactId>jaxb-api</artifactId>
-          <scope>runtime</scope>
-        </dependency>
-        <dependency>
-          <groupId>org.glassfish.jaxb</groupId>
-          <artifactId>jaxb-runtime</artifactId>
-          <scope>runtime</scope>
-        </dependency>
       </dependencies>
     </profile>
     <profile>
@@ -302,16 +272,6 @@
           <groupId>org.apache.geronimo.specs</groupId>
           <artifactId>geronimo-jms_1.1_spec</artifactId>
           <scope>compile</scope>
-        </dependency>
-        <dependency>
-          <groupId>javax.xml.bind</groupId>
-          <artifactId>jaxb-api</artifactId>
-          <scope>runtime</scope>
-        </dependency>
-        <dependency>
-          <groupId>org.glassfish.jaxb</groupId>
-          <artifactId>jaxb-runtime</artifactId>
-          <scope>runtime</scope>
         </dependency>
       </dependencies>
     </profile>


### PR DESCRIPTION
This PR addresses JIRA [QPID-8688](https://issues.apache.org/jira/browse/QPID-8688), removing unneeded JAXB dependencies and updating qpid JMS client to the latest 1.x version