### PR TITLE
QPID-8684: [Broker-J] Maven plugins and test dependencies updates for version 10.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -129,9 +129,9 @@
     <dgrid-version>1.3.3</dgrid-version>
 
     <!-- test dependency version numbers -->
-    <junit-version>5.11.4</junit-version>
-    <mockito-version>5.15.2</mockito-version>
-    <netty-version>4.1.118.Final</netty-version>
+    <junit-version>5.12.2</junit-version>
+    <mockito-version>5.17.0</mockito-version>
+    <netty-version>4.2.0.Final</netty-version>
     <hamcrest-version>3.0</hamcrest-version>
     <maven-resolver-provider-version>3.8.6</maven-resolver-provider-version>
     <maven-resolver-version>1.9.22</maven-resolver-version>
@@ -141,22 +141,22 @@
     <nashorn-version>15.6</nashorn-version>
 
     <exec-maven-plugin-version>3.5.0</exec-maven-plugin-version>
-    <javacc-maven-plugin-version>2.6</javacc-maven-plugin-version>
+    <javacc-maven-plugin-version>3.1.1</javacc-maven-plugin-version>
     <ph-javacc-maven-plugin-version>4.1.5</ph-javacc-maven-plugin-version>
     <maven-enforcer-plugin-version>3.5.0</maven-enforcer-plugin-version>
     <maven-rar-plugin-version>3.0.0</maven-rar-plugin-version>
     <license-maven-plugin-version>2.5.0</license-maven-plugin-version>
     <maven-jxr-plugin-version>3.6.0</maven-jxr-plugin-version>
     <findbugs-maven-plugin-version>3.0.5</findbugs-maven-plugin-version>
-    <jacoco-plugin-version>0.8.12</jacoco-plugin-version>
+    <jacoco-plugin-version>0.8.13</jacoco-plugin-version>
     <apache-rat-plugin-version>0.16.1</apache-rat-plugin-version>
     <maven-docbx-plugin-version>2.0.17</maven-docbx-plugin-version>
     <maven-docbook-xml-plugin-version>5.0-all</maven-docbook-xml-plugin-version>
     <buildnumber-maven-plugin-version>3.2.1</buildnumber-maven-plugin-version>
-    <maven-compiler-plugin-version>3.13.0</maven-compiler-plugin-version>
+    <maven-compiler-plugin-version>3.14.0</maven-compiler-plugin-version>
     <maven-jar-plugin-version>3.4.2</maven-jar-plugin-version>
-    <maven-surefire-plugin-version>3.5.2</maven-surefire-plugin-version>
-    <maven-surefire-report-plugin-version>3.5.2</maven-surefire-report-plugin-version>
+    <maven-surefire-plugin-version>3.5.3</maven-surefire-plugin-version>
+    <maven-surefire-report-plugin-version>3.5.3</maven-surefire-report-plugin-version>
     <h2.version>2.3.232</h2.version>
     <apache-directory-version>2.0.0.AM27</apache-directory-version>
     <kerby-version>2.1.0</kerby-version>


### PR DESCRIPTION
This PR addresses JIRA [QPID-8684](https://issues.apache.org/jira/browse/QPID-8684), updating broker-j dependencies.

Following dependencies are updated:



**test dependencies**

io.netty:netty-buffer 4.1.118.Final => 4.2.0.Final
io.netty:netty-common 4.1.118.Final => 4.2.0.Final
io.netty:netty-handler 4.1.118.Final => 4.2.0.Final
io.netty:netty-transport 4.1.118.Final => 4.2.0.Final
io.netty:netty-codec-http 4.1.118.Final => 4.2.0.Final
org.mockito:mockito-core 5.15.2 => 5.17.0
org.junit.jupiter:junit-jupiter-api 5.11.4 => 5.12.2
org.junit.jupiter:junit-jupiter-engine 5.11.4 => 5.12.2
org.junit.jupiter:junit-jupiter-params 5.11.4 => 5.12.2

**maven plugins**

org.codehaus.mojo:javacc-maven-plugin 2.6 => 3.1.1
org.apache.rat:apache-rat-plugin 0.15 => 0.16.1
org.apache.maven.plugins:maven-compiler-plugin 3.13.0 => 3.14.0
org.apache.maven.plugins:maven-jxr-plugin 3.3.0 => 3.3.2
org.apache.maven.plugins:maven-surefire-plugin 3.5.2 => 3.5.3
org.apache.maven.plugins:maven-surefire-report-plugin 3.5.2 => 3.5.3
org.jacoco:jacoco-maven-plugin 0.8.12 => 0.8.13