### PR TITLE
NO-JIRA: Update parent pom org.apache:apache to version 34

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache</groupId>
     <artifactId>apache</artifactId>
-    <version>31</version>
+    <version>34</version>
   </parent>
 
   <groupId>org.apache.qpid</groupId>


### PR DESCRIPTION
This PR updates parent pom org.apache:apache to version 34