### PR TITLE
QPID-8693: [Broker-J] Update Apache Derby version to 10.16.1.1

### DIFF
--- a/apache-qpid-broker-j/src/main/assembly/dependency-verification/DEPENDENCIES_REFERENCE
+++ b/apache-qpid-broker-j/src/main/assembly/dependency-verification/DEPENDENCIES_REFERENCE
@@ -68,13 +68,13 @@ From: 'an unknown organization'
 
 From: 'Apache Software Foundation' (http://db.apache.org/)
 
-  - Apache Derby Database Engine and Embedded JDBC Driver (http://db.apache.org/derby/) org.apache.derby:derby:jar:10.15.2.0
+  - Apache Derby Database Engine and Embedded JDBC Driver (http://db.apache.org/derby/) org.apache.derby:derby:jar:10.16.1.1
     License: Apache 2  (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-  - Apache Derby Shared Code (http://db.apache.org/derby/) org.apache.derby:derbyshared:jar:10.15.2.0
+  - Apache Derby Shared Code (http://db.apache.org/derby/) org.apache.derby:derbyshared:jar:10.16.1.1
     License: Apache 2  (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-  - Apache Derby Tools (http://db.apache.org/derby/) org.apache.derby:derbytools:jar:10.15.2.0
+  - Apache Derby Tools (http://db.apache.org/derby/) org.apache.derby:derbytools:jar:10.16.1.1
     License: Apache 2  (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,7 @@
     <at.sign>@</at.sign>
 
     <bdb-version>7.4.5</bdb-version>
-    <derby-version>10.15.2.0</derby-version>
+    <derby-version>10.16.1.1</derby-version>
     <logback-version>1.5.16</logback-version>
     <logback-db-version>1.2.11.1</logback-db-version>
     <guava-version>33.4.0-jre</guava-version>


### PR DESCRIPTION
This PR addresses JIRA [QPID-8693](https://issues.apache.org/jira/browse/QPID-8693), updating Apache Derby dependency version to 10.16.1.1