### PR TITLE
NO-JIRA: virtualhostnode type was set to DERBY in java-dby.1-0 and java-dby.0-9 maven profiles

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1473,6 +1473,7 @@
         <profile>java-dby.0-9</profile>
         <profile.broker.version>0-9</profile.broker.version>
         <profile.test.amqp_port_protocols>["AMQP_0_8","AMQP_0_9"]</profile.test.amqp_port_protocols>
+        <profile.virtualhostnode.type>DERBY</profile.virtualhostnode.type>
         <profile.virtualhostnode.context.blueprint>{"type":"ProvidedStore","globalAddressDomains":"${dollar.sign}{qpid.globalAddressDomains}"}</profile.virtualhostnode.context.blueprint>
         <profile.test_receive_timeout>2000</profile.test_receive_timeout>
       </properties>
@@ -1524,6 +1525,7 @@
         <profile>java-dby.1-0</profile>
         <profile.broker.version>1.0</profile.broker.version>
         <profile.test.amqp_port_protocols>["AMQP_1_0"]</profile.test.amqp_port_protocols>
+        <profile.virtualhostnode.type>DERBY</profile.virtualhostnode.type>
         <profile.virtualhostnode.context.blueprint>{"type":"ProvidedStore","globalAddressDomains":"${dollar.sign}{qpid.globalAddressDomains}"}</profile.virtualhostnode.context.blueprint>
       </properties>
     </profile>


### PR DESCRIPTION
This PR sets property virtualhostnode.type=DERBY in maven profiles java-dby.1-0 and java-dby.0-9 (otherwise they're using Memory virtualhostnode type by default)