### PR TITLE
QPID-8696: [Broker-J] Bump caffeine dependency version to 3.2.1

### DIFF
--- a/apache-qpid-broker-j/src/main/assembly/dependency-verification/DEPENDENCIES_REFERENCE
+++ b/apache-qpid-broker-j/src/main/assembly/dependency-verification/DEPENDENCIES_REFERENCE
@@ -26,7 +26,7 @@ Apache Qpid Broker-J Bundles
 
 From: 'an unknown organization'
 
-  - Caffeine cache (https://github.com/ben-manes/caffeine) com.github.ben-manes.caffeine:caffeine:jar:3.1.8
+  - Caffeine cache (https://github.com/ben-manes/caffeine) com.github.ben-manes.caffeine:caffeine:jar:3.2.1
     License: Apache License, Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
 
   - Prometheus Java Simpleclient (http://github.com/prometheus/client_java/simpleclient) io.prometheus:simpleclient:bundle:0.16.0
@@ -52,9 +52,6 @@ From: 'an unknown organization'
 
   - Bouncy Castle ASN.1 Extension and Utility APIs (https://www.bouncycastle.org/download/bouncy-castle-java/) org.bouncycastle:bcutil-jdk18on:jar:1.80
     License: Bouncy Castle Licence  (https://www.bouncycastle.org/licence.html)
-
-  - Checker Qual (https://checkerframework.org/) org.checkerframework:checker-qual:jar:3.37.0
-    License: The MIT License  (http://opensource.org/licenses/MIT)
 
   - dgrid (https://www.webjars.org) org.webjars.bower:dgrid:jar:1.3.3
     License: BSD 3-Clause  (https://spdx.org/licenses/BSD 3-Clause#licenseText)
@@ -92,12 +89,6 @@ From: 'FasterXML' (http://fasterxml.com/)
 
   - jackson-databind (https://github.com/FasterXML/jackson) com.fasterxml.jackson.core:jackson-databind:jar:2.18.2
     License: The Apache Software License, Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-
-From: 'Google LLC' (http://www.google.com)
-
-  - error-prone annotations (https://errorprone.info/error_prone_annotations) com.google.errorprone:error_prone_annotations:jar:2.21.1
-    License: Apache 2.0  (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 
 From: 'Oracle Corporation' (http://www.oracle.com/)

--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@
     <derby-version>10.16.1.1</derby-version>
     <logback-version>1.5.16</logback-version>
     <logback-db-version>1.2.11.1</logback-db-version>
-    <caffeine-version>3.1.8</caffeine-version>
+    <caffeine-version>3.2.1</caffeine-version>
     <fasterxml-jackson-version>2.18.2</fasterxml-jackson-version>
     <fasterxml-jackson-databind-version>2.18.2</fasterxml-jackson-databind-version>
     <slf4j-version>2.0.16</slf4j-version>
@@ -582,6 +582,16 @@
         <groupId>com.github.ben-manes.caffeine</groupId>
         <artifactId>caffeine</artifactId>
         <version>${caffeine-version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>com.google.errorprone</groupId>
+            <artifactId>error_prone_annotations</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
This PR updates dependency com.github.ben-manes.caffeine:caffeine to the version 3.2.1