### PR TITLE
QPID-8697: [Broker-J] Bump fasterxml jackson dependencies versions to 2.19.1

### DIFF
--- a/apache-qpid-broker-j/src/main/assembly/dependency-verification/DEPENDENCIES_REFERENCE
+++ b/apache-qpid-broker-j/src/main/assembly/dependency-verification/DEPENDENCIES_REFERENCE
@@ -84,13 +84,13 @@ From: 'Eclipse Foundation' (https://www.eclipse.org)
 
 From: 'FasterXML' (http://fasterxml.com/)
 
-  - Jackson-annotations (https://github.com/FasterXML/jackson) com.fasterxml.jackson.core:jackson-annotations:jar:2.18.2
+  - Jackson-annotations (https://github.com/FasterXML/jackson) com.fasterxml.jackson.core:jackson-annotations:jar:2.19.1
     License: The Apache Software License, Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-  - Jackson-core (https://github.com/FasterXML/jackson-core) com.fasterxml.jackson.core:jackson-core:jar:2.18.2
+  - Jackson-core (https://github.com/FasterXML/jackson-core) com.fasterxml.jackson.core:jackson-core:jar:2.19.1
     License: The Apache Software License, Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-  - jackson-databind (https://github.com/FasterXML/jackson) com.fasterxml.jackson.core:jackson-databind:jar:2.18.2
+  - jackson-databind (https://github.com/FasterXML/jackson) com.fasterxml.jackson.core:jackson-databind:jar:2.19.1
     License: The Apache Software License, Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
 
 

--- a/perftests/src/main/assembly/dependency-verification/DEPENDENCIES_REFERENCE
+++ b/perftests/src/main/assembly/dependency-verification/DEPENDENCIES_REFERENCE
@@ -56,13 +56,13 @@ From: 'Apache Software Foundation' (http://www.apache.org)
 
 From: 'FasterXML' (http://fasterxml.com/)
 
-  - Jackson-annotations (https://github.com/FasterXML/jackson) com.fasterxml.jackson.core:jackson-annotations:jar:2.18.2
+  - Jackson-annotations (https://github.com/FasterXML/jackson) com.fasterxml.jackson.core:jackson-annotations:jar:2.19.1
     License: The Apache Software License, Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-  - Jackson-core (https://github.com/FasterXML/jackson-core) com.fasterxml.jackson.core:jackson-core:jar:2.18.2
+  - Jackson-core (https://github.com/FasterXML/jackson-core) com.fasterxml.jackson.core:jackson-core:jar:2.19.1
     License: The Apache Software License, Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-  - jackson-databind (https://github.com/FasterXML/jackson) com.fasterxml.jackson.core:jackson-databind:jar:2.18.2
+  - jackson-databind (https://github.com/FasterXML/jackson) com.fasterxml.jackson.core:jackson-databind:jar:2.19.1
     License: The Apache Software License, Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -107,8 +107,8 @@
     <logback-version>1.5.16</logback-version>
     <logback-db-version>1.2.11.1</logback-db-version>
     <caffeine-version>3.1.8</caffeine-version>
-    <fasterxml-jackson-version>2.18.2</fasterxml-jackson-version>
-    <fasterxml-jackson-databind-version>2.18.2</fasterxml-jackson-databind-version>
+    <fasterxml-jackson-version>2.19.1</fasterxml-jackson-version>
+    <fasterxml-jackson-databind-version>2.19.1</fasterxml-jackson-databind-version>
     <slf4j-version>2.0.16</slf4j-version>
     <jetty-version>12.0.22</jetty-version>
 


### PR DESCRIPTION
This PR updates dependencies com.fasterxml.jackson.core:jackson-annotations, com.fasterxml.jackson.core:jackson-core and com.fasterxml.jackson.core:jackson-databind to the version 2.19.1