### PR TITLE
QPID-8684: [Broker-J] Bump junit dependency version to 5.13.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -129,7 +129,7 @@
     <dgrid-version>1.3.3</dgrid-version>
 
     <!-- test dependency version numbers -->
-    <junit-version>5.12.2</junit-version>
+    <junit-version>5.13.2</junit-version>
     <mockito-version>5.17.0</mockito-version>
     <netty-version>4.2.0.Final</netty-version>
     <hamcrest-version>3.0</hamcrest-version>


### PR DESCRIPTION
This PR updates junit dependency to the version 5.13.2