### PR TITLE
QPID-8684: [Broker-J] Bump netty dependency version to 4.2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -131,7 +131,7 @@
     <!-- test dependency version numbers -->
     <junit-version>5.12.2</junit-version>
     <mockito-version>5.17.0</mockito-version>
-    <netty-version>4.2.0.Final</netty-version>
+    <netty-version>4.2.2.Final</netty-version>
     <hamcrest-version>3.0</hamcrest-version>
     <maven-resolver-provider-version>3.8.6</maven-resolver-provider-version>
     <maven-resolver-version>1.9.22</maven-resolver-version>


### PR DESCRIPTION
This PR updates netty dependencies to the version 4.2.2