### PR TITLE
QPID-8686: [Broker-J] Bump apache httpclient5 dependency version to 5.5

### DIFF
--- a/perftests/src/main/assembly/dependency-verification/DEPENDENCIES_REFERENCE
+++ b/perftests/src/main/assembly/dependency-verification/DEPENDENCIES_REFERENCE
@@ -82,7 +82,7 @@ From: 'QOS.ch' (http://www.qos.ch)
 
 From: 'The Apache Software Foundation' (https://www.apache.org/)
 
-  - Apache HttpClient (https://hc.apache.org/httpcomponents-client-5.4.x/5.4.4/httpclient5/) org.apache.httpcomponents.client5:httpclient5:jar:5.4.4
+  - Apache HttpClient (https://hc.apache.org/httpcomponents-client-5.5.x/5.5/httpclient5/) org.apache.httpcomponents.client5:httpclient5:jar:5.5
     License: Apache License, Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
 
   - Apache HttpComponents Core HTTP/1.1 (https://hc.apache.org/httpcomponents-core-5.3.x/5.3.4/httpcore5/) org.apache.httpcomponents.core5:httpcore5:jar:5.3.4

--- a/pom.xml
+++ b/pom.xml
@@ -135,7 +135,7 @@
     <hamcrest-version>3.0</hamcrest-version>
     <maven-resolver-provider-version>3.8.6</maven-resolver-provider-version>
     <maven-resolver-version>1.9.22</maven-resolver-version>
-    <httpclient-version>5.4.4</httpclient-version>
+    <httpclient-version>5.5</httpclient-version>
     <qpid-jms-client-version>1.13.0</qpid-jms-client-version>
     <qpid-jms-client-amqp-0-x-version>6.4.0</qpid-jms-client-amqp-0-x-version>
     <nashorn-version>15.6</nashorn-version>


### PR DESCRIPTION
This PR updates apache httpclient dependencies to the version 5.5