### PR TITLE
QPID-8705: [Broker-J] Bump hikaricp dependency to the version 6.3.0

### DIFF
--- a/apache-qpid-broker-j/src/main/assembly/dependency-verification/DEPENDENCIES_REFERENCE
+++ b/apache-qpid-broker-j/src/main/assembly/dependency-verification/DEPENDENCIES_REFERENCE
@@ -277,7 +277,7 @@ From: 'Webtide' (https://webtide.com)
 
 From: 'Zaxxer.com' (https://github.com/brettwooldridge)
 
-  - HikariCP (https://github.com/brettwooldridge/HikariCP) com.zaxxer:HikariCP:bundle:6.2.1
+  - HikariCP (https://github.com/brettwooldridge/HikariCP) com.zaxxer:HikariCP:bundle:6.3.0
     License: The Apache Software License, Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,7 @@
     <jetty-version>12.0.22</jetty-version>
 
     <!-- dependency version numbers -->
-    <hikari-cp-version>6.2.1</hikari-cp-version>
+    <hikari-cp-version>6.3.0</hikari-cp-version>
     <commons-cli-version>1.9.0</commons-cli-version>
 
     <geronimo-jms-1-1-version>1.1.1</geronimo-jms-1-1-version>


### PR DESCRIPTION
This PR addresses JIRA [QPID-8705](https://issues.apache.org/jira/browse/QPID-8705), updating hikaricp dependency to the version 6.3.0