### PR TITLE
NO-JIRA: [Broker-J] Logback shutdown hook renamed

### DIFF
--- a/qpid-test-utils/src/main/resources/logback.xml
+++ b/qpid-test-utils/src/main/resources/logback.xml
@@ -42,5 +42,5 @@
     <root level="debug">
         <appender-ref ref="RootSiftAppender"/>
     </root>
-    <shutdownHook class="ch.qos.logback.core.hook.DelayingShutdownHook"/>
+    <shutdownHook class="ch.qos.logback.core.hook.DefaultShutdownHook"/>
 </configuration>

--- a/systests/end-to-end-conversion-tests/src/main/resources/logback-test.xml
+++ b/systests/end-to-end-conversion-tests/src/main/resources/logback-test.xml
@@ -44,5 +44,5 @@
     <root level="debug">
         <appender-ref ref="RootSiftAppender"/>
     </root>
-    <shutdownHook class="ch.qos.logback.core.hook.DelayingShutdownHook"/>
+    <shutdownHook class="ch.qos.logback.core.hook.DefaultShutdownHook"/>
 </configuration>


### PR DESCRIPTION
This PR addresses renaming of the logback shutdown hook (ch.qos.logback.core.hook.DelayingShutdownHook to ch.qos.logback.core.hook.DefaultShutdownHook)