### PR TITLE
QPID-8685: [Broker-J] Update jetty dependency to version 12.1.0

### DIFF
--- a/apache-qpid-broker-j/src/main/assembly/dependency-verification/DEPENDENCIES_REFERENCE
+++ b/apache-qpid-broker-j/src/main/assembly/dependency-verification/DEPENDENCIES_REFERENCE
@@ -74,7 +74,7 @@ From: 'Apache Software Foundation' (http://db.apache.org/)
 
 From: 'Eclipse Foundation' (https://www.eclipse.org)
 
-  - Jakarta Servlet (https://projects.eclipse.org/projects/ee4j.servlet) jakarta.servlet:jakarta.servlet-api:jar:6.0.0
+  - Jakarta Servlet (https://projects.eclipse.org/projects/ee4j.servlet) jakarta.servlet:jakarta.servlet-api:jar:6.1.0
     License: EPL 2.0  (http://www.eclipse.org/legal/epl-2.0)
     License: GPL2 w/ CPE  (https://www.gnu.org/software/classpath/license.html)
 
@@ -218,59 +218,63 @@ From: 'The CometD Project' (https://cometd.org)
 
 From: 'Webtide' (https://webtide.com)
 
-  - Core :: HTTP (https://jetty.org/jetty-core/jetty-http) org.eclipse.jetty:jetty-http:jar:12.0.23
+  - Core :: HTTP (https://jetty.org/jetty-core/jetty-http) org.eclipse.jetty:jetty-http:jar:12.1.0
     License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0/)
     License: Apache Software License - Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0)
 
-  - Core :: IO (https://jetty.org/jetty-core/jetty-io) org.eclipse.jetty:jetty-io:jar:12.0.23
+  - Core :: IO (https://jetty.org/jetty-core/jetty-io) org.eclipse.jetty:jetty-io:jar:12.1.0
     License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0/)
     License: Apache Software License - Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0)
 
-  - Core :: Rewrite (https://jetty.org/jetty-core/jetty-rewrite) org.eclipse.jetty:jetty-rewrite:jar:12.0.23
+  - Core :: Rewrite (https://jetty.org/jetty-core/jetty-rewrite) org.eclipse.jetty:jetty-rewrite:jar:12.1.0
     License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0/)
     License: Apache Software License - Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0)
 
-  - Core :: Security (https://jetty.org/jetty-core/jetty-security) org.eclipse.jetty:jetty-security:jar:12.0.23
+  - Core :: Security (https://jetty.org/jetty-core/jetty-security) org.eclipse.jetty:jetty-security:jar:12.1.0
     License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0/)
     License: Apache Software License - Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0)
 
-  - Core :: Server (https://jetty.org/jetty-core/jetty-server) org.eclipse.jetty:jetty-server:jar:12.0.23
+  - Core :: Server (https://jetty.org/jetty-core/jetty-server) org.eclipse.jetty:jetty-server:jar:12.1.0
     License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0/)
     License: Apache Software License - Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0)
 
-  - Core :: Sessions (https://jetty.org/jetty-core/jetty-session) org.eclipse.jetty:jetty-session:jar:12.0.23
+  - Core :: Sessions (https://jetty.org/jetty-core/jetty-session) org.eclipse.jetty:jetty-session:jar:12.1.0
     License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0/)
     License: Apache Software License - Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0)
 
-  - Core :: Utilities (https://jetty.org/jetty-core/jetty-util) org.eclipse.jetty:jetty-util:jar:12.0.23
+  - Core :: Utilities (https://jetty.org/jetty-core/jetty-util) org.eclipse.jetty:jetty-util:jar:12.1.0
     License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0/)
     License: Apache Software License - Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0)
 
-  - EE10 :: Servlet (https://jetty.org/jetty-ee10/jetty-ee10-servlet) org.eclipse.jetty.ee10:jetty-ee10-servlet:jar:12.0.23
+  - EE11 :: Servlet (https://jetty.org/jetty-ee11/jetty-ee11-servlet) org.eclipse.jetty.ee11:jetty-ee11-servlet:jar:12.1.0
     License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0/)
     License: Apache Software License - Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0)
 
-  - EE10 :: Websocket :: Jetty Server (https://jetty.org/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jetty-server) org.eclipse.jetty.ee10.websocket:jetty-ee10-websocket-jetty-server:jar:12.0.23
+  - EE11 :: Websocket :: Jetty Server (https://jetty.org/jetty-ee11/jetty-ee11-websocket/jetty-ee11-websocket-jetty-server) org.eclipse.jetty.ee11.websocket:jetty-ee11-websocket-jetty-server:jar:12.1.0
     License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0/)
     License: Apache Software License - Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0)
 
-  - EE10 :: Websocket :: Servlet (https://jetty.org/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-servlet) org.eclipse.jetty.ee10.websocket:jetty-ee10-websocket-servlet:jar:12.0.23
+  - EE11 :: Websocket :: Servlet (https://jetty.org/jetty-ee11/jetty-ee11-websocket/jetty-ee11-websocket-servlet) org.eclipse.jetty.ee11.websocket:jetty-ee11-websocket-servlet:jar:12.1.0
     License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0/)
     License: Apache Software License - Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0)
 
-  - Core :: Websocket :: Common (https://jetty.org/jetty-core/jetty-websocket/jetty-websocket-core-common) org.eclipse.jetty.websocket:jetty-websocket-core-common:jar:12.0.23
+  - Core :: Websocket :: Common (https://jetty.org/jetty-core/jetty-websocket/jetty-websocket-core-common) org.eclipse.jetty.websocket:jetty-websocket-core-common:jar:12.1.0
     License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0/)
     License: Apache Software License - Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0)
 
-  - Core :: Websocket :: Server (https://jetty.org/jetty-core/jetty-websocket/jetty-websocket-core-server) org.eclipse.jetty.websocket:jetty-websocket-core-server:jar:12.0.23
+  - Core :: Websocket :: Server (https://jetty.org/jetty-core/jetty-websocket/jetty-websocket-core-server) org.eclipse.jetty.websocket:jetty-websocket-core-server:jar:12.1.0
     License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0/)
     License: Apache Software License - Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0)
 
-  - Core :: Websocket :: Jetty API (https://jetty.org/jetty-core/jetty-websocket/jetty-websocket-jetty-api) org.eclipse.jetty.websocket:jetty-websocket-jetty-api:jar:12.0.23
+  - Core :: Websocket :: Jetty API (https://jetty.org/jetty-core/jetty-websocket/jetty-websocket-jetty-api) org.eclipse.jetty.websocket:jetty-websocket-jetty-api:jar:12.1.0
     License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0/)
     License: Apache Software License - Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0)
 
-  - Core :: Websocket :: Jetty Common (https://jetty.org/jetty-core/jetty-websocket/jetty-websocket-jetty-common) org.eclipse.jetty.websocket:jetty-websocket-jetty-common:jar:12.0.23
+  - Core :: Websocket :: Jetty Common (https://jetty.org/jetty-core/jetty-websocket/jetty-websocket-jetty-common) org.eclipse.jetty.websocket:jetty-websocket-jetty-common:jar:12.1.0
+    License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0/)
+    License: Apache Software License - Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0)
+
+  - Core :: Websocket :: Jetty Server (https://jetty.org/jetty-core/jetty-websocket/jetty-websocket-jetty-server) org.eclipse.jetty.websocket:jetty-websocket-jetty-server:jar:12.1.0
     License: Eclipse Public License - Version 2.0  (https://www.eclipse.org/legal/epl-2.0/)
     License: Apache Software License - Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0)
 

--- a/broker-core/pom.xml
+++ b/broker-core/pom.xml
@@ -84,8 +84,8 @@
     </dependency>
 
     <dependency>
-      <groupId>org.eclipse.jetty.ee10</groupId>
-      <artifactId>jetty-ee10-servlet</artifactId>
+      <groupId>org.eclipse.jetty.ee11</groupId>
+      <artifactId>jetty-ee11-servlet</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/broker-core/src/test/java/org/apache/qpid/server/security/auth/manager/oauth2/OAuth2MockEndpointHolder.java
+++ b/broker-core/src/test/java/org/apache/qpid/server/security/auth/manager/oauth2/OAuth2MockEndpointHolder.java
@@ -37,7 +37,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import org.eclipse.jetty.ee10.servlet.ServletContextHandler;
+import org.eclipse.jetty.ee11.servlet.ServletContextHandler;
 import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.HttpConnectionFactory;
 import org.eclipse.jetty.server.SecureRequestCustomizer;

--- a/broker-plugins/management-http/pom.xml
+++ b/broker-plugins/management-http/pom.xml
@@ -53,8 +53,8 @@
     </dependency>
 
     <dependency>
-      <groupId>org.eclipse.jetty.ee10</groupId>
-      <artifactId>jetty-ee10-servlet</artifactId>
+      <groupId>org.eclipse.jetty.ee11</groupId>
+      <artifactId>jetty-ee11-servlet</artifactId>
     </dependency>
 
     <dependency>

--- a/broker-plugins/management-http/src/main/java/org/apache/qpid/server/management/plugin/HttpManagement.java
+++ b/broker-plugins/management-http/src/main/java/org/apache/qpid/server/management/plugin/HttpManagement.java
@@ -49,8 +49,8 @@ import jakarta.servlet.MultipartConfigElement;
 import jakarta.servlet.http.HttpServletRequest;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.eclipse.jetty.ee10.servlet.ErrorPageErrorHandler;
-import org.eclipse.jetty.ee10.servlet.ServletHandler;
+import org.eclipse.jetty.ee11.servlet.ErrorPageErrorHandler;
+import org.eclipse.jetty.ee11.servlet.ServletHandler;
 import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.UriCompliance;
 import org.eclipse.jetty.io.Connection;
@@ -68,9 +68,9 @@ import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.server.SslConnectionFactory;
 import org.eclipse.jetty.server.handler.ContextHandlerCollection;
-import org.eclipse.jetty.ee10.servlet.FilterHolder;
-import org.eclipse.jetty.ee10.servlet.ServletContextHandler;
-import org.eclipse.jetty.ee10.servlet.ServletHolder;
+import org.eclipse.jetty.ee11.servlet.FilterHolder;
+import org.eclipse.jetty.ee11.servlet.ServletContextHandler;
+import org.eclipse.jetty.ee11.servlet.ServletHolder;
 import org.eclipse.jetty.server.handler.CrossOriginHandler;
 import org.eclipse.jetty.util.annotation.Name;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
@@ -348,12 +348,12 @@ public class HttpManagement extends AbstractPluginAdapter<HttpManagement> implem
         final ErrorPageErrorHandler errorHandler = new ErrorPageErrorHandler()
         {
             @Override
-            protected void writeErrorPageBody(HttpServletRequest request, Writer writer, int code, String message, boolean showStacks)
+            protected void writeErrorHtmlBody(Request request, Writer writer, int code, String message, Throwable cause)
                     throws IOException
             {
-                final String uri = request.getRequestURI();
+                String uri = request.getHttpURI().toString();
 
-                writeErrorPageMessage(request,writer,code,message,uri);
+                writeErrorHtmlMessage(request, writer, code, message, cause, uri);
 
                 for (int i= 0; i < 20; i++)
                 {

--- a/broker-plugins/management-http/src/main/java/org/apache/qpid/server/management/plugin/HttpManagement.java
+++ b/broker-plugins/management-http/src/main/java/org/apache/qpid/server/management/plugin/HttpManagement.java
@@ -351,7 +351,7 @@ public class HttpManagement extends AbstractPluginAdapter<HttpManagement> implem
             protected void writeErrorHtmlBody(Request request, Writer writer, int code, String message, Throwable cause)
                     throws IOException
             {
-                String uri = request.getHttpURI().toString();
+                final String uri = request.getHttpURI().toString();
 
                 writeErrorHtmlMessage(request, writer, code, message, cause, uri);
 

--- a/broker-plugins/websocket/pom.xml
+++ b/broker-plugins/websocket/pom.xml
@@ -48,8 +48,8 @@
         </dependency>
 
         <dependency>
-            <groupId>org.eclipse.jetty.ee10.websocket</groupId>
-            <artifactId>jetty-ee10-websocket-jetty-server</artifactId>
+            <groupId>org.eclipse.jetty.ee11.websocket</groupId>
+            <artifactId>jetty-ee11-websocket-jetty-server</artifactId>
         </dependency>
 
     </dependencies>

--- a/broker-plugins/websocket/src/main/java/org/apache/qpid/server/transport/websocket/WebSocketProvider.java
+++ b/broker-plugins/websocket/src/main/java/org/apache/qpid/server/transport/websocket/WebSocketProvider.java
@@ -41,10 +41,10 @@ import javax.net.ssl.SSLParameters;
 
 import jakarta.servlet.http.HttpServletResponse;
 
-import org.eclipse.jetty.ee10.websocket.server.JettyWebSocketCreator;
-import org.eclipse.jetty.ee10.websocket.server.JettyWebSocketServerContainer;
-import org.eclipse.jetty.ee10.websocket.server.JettyWebSocketServlet;
-import org.eclipse.jetty.ee10.websocket.server.JettyWebSocketServletFactory;
+import org.eclipse.jetty.ee11.websocket.server.JettyWebSocketCreator;
+import org.eclipse.jetty.ee11.websocket.server.JettyWebSocketServerContainer;
+import org.eclipse.jetty.ee11.websocket.server.JettyWebSocketServlet;
+import org.eclipse.jetty.ee11.websocket.server.JettyWebSocketServletFactory;
 import org.eclipse.jetty.io.ssl.SslHandshakeListener;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.HttpConnectionFactory;
@@ -53,8 +53,8 @@ import org.eclipse.jetty.server.Response;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.server.handler.ContextHandlerCollection;
-import org.eclipse.jetty.ee10.servlet.ServletContextHandler;
-import org.eclipse.jetty.ee10.servlet.ServletHolder;
+import org.eclipse.jetty.ee11.servlet.ServletContextHandler;
+import org.eclipse.jetty.ee11.servlet.ServletHolder;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.eclipse.jetty.util.thread.ThreadPool;

--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
     <fasterxml-jackson-version>2.19.2</fasterxml-jackson-version>
     <fasterxml-jackson-databind-version>2.19.2</fasterxml-jackson-databind-version>
     <slf4j-version>2.0.17</slf4j-version>
-    <jetty-version>12.0.23</jetty-version>
+    <jetty-version>12.1.0</jetty-version>
 
     <!-- dependency version numbers -->
     <hikari-cp-version>7.0.1</hikari-cp-version>
@@ -639,13 +639,13 @@
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.eclipse.jetty.ee10</groupId>
-        <artifactId>jetty-ee10-servlet</artifactId>
+        <groupId>org.eclipse.jetty.ee11</groupId>
+        <artifactId>jetty-ee11-servlet</artifactId>
         <version>${jetty-version}</version>
       </dependency>
       <dependency>
-        <groupId>org.eclipse.jetty.ee10</groupId>
-        <artifactId>jetty-ee10-servlets</artifactId>
+        <groupId>org.eclipse.jetty.ee11</groupId>
+        <artifactId>jetty-ee11-servlets</artifactId>
         <version>${jetty-version}</version>
       </dependency>
       <dependency>
@@ -654,32 +654,32 @@
         <version>${jetty-version}</version>
       </dependency>
       <dependency>
-        <groupId>org.eclipse.jetty.ee10.websocket</groupId>
-        <artifactId>jetty-ee10-websocket-jetty-server</artifactId>
+        <groupId>org.eclipse.jetty.ee11.websocket</groupId>
+        <artifactId>jetty-ee11-websocket-jetty-server</artifactId>
         <version>${jetty-version}</version>
         <exclusions>
           <exclusion>
-            <groupId>org.eclipse.jetty.ee10</groupId>
-            <artifactId>jetty-ee10-annotations</artifactId>
+            <groupId>org.eclipse.jetty.ee11</groupId>
+            <artifactId>jetty-ee11-annotations</artifactId>
           </exclusion>
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.eclipse.jetty.ee10.websocket</groupId>
-        <artifactId>jetty-ee10-websocket-jakarta-server</artifactId>
+        <groupId>org.eclipse.jetty.ee11.websocket</groupId>
+        <artifactId>jetty-ee11-websocket-jakarta-server</artifactId>
         <version>${jetty-version}</version>
         <exclusions>
           <exclusion>
-            <groupId>org.eclipse.jetty.ee10</groupId>
-            <artifactId>jetty-ee10-annotations</artifactId>
+            <groupId>org.eclipse.jetty.ee11</groupId>
+            <artifactId>jetty-ee11-annotations</artifactId>
           </exclusion>
           <exclusion>
-            <groupId>org.eclipse.jetty.ee10</groupId>
-            <artifactId>jetty-ee10-webapp</artifactId>
+            <groupId>org.eclipse.jetty.ee11</groupId>
+            <artifactId>jetty-ee11-webapp</artifactId>
           </exclusion>
           <exclusion>
-            <groupId>org.eclipse.jetty.ee10.websocket</groupId>
-            <artifactId>jetty-ee10-websocket-servlet</artifactId>
+            <groupId>org.eclipse.jetty.ee11.websocket</groupId>
+            <artifactId>jetty-ee11-websocket-servlet</artifactId>
           </exclusion>
           <exclusion>
             <groupId>org.eclipse.jetty</groupId>

--- a/systests/systests-utils/pom.xml
+++ b/systests/systests-utils/pom.xml
@@ -61,8 +61,8 @@
             <artifactId>jetty-server</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.eclipse.jetty.ee10</groupId>
-            <artifactId>jetty-ee10-servlet</artifactId>
+            <groupId>org.eclipse.jetty.ee11</groupId>
+            <artifactId>jetty-ee11-servlet</artifactId>
         </dependency>
     </dependencies>
 

--- a/systests/systests-utils/src/main/java/org/apache/qpid/tests/utils/OAuth2MockEndpointHolder.java
+++ b/systests/systests-utils/src/main/java/org/apache/qpid/tests/utils/OAuth2MockEndpointHolder.java
@@ -24,7 +24,6 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -36,15 +35,12 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import org.eclipse.jetty.ee10.servlet.ServletContextHandler;
+import org.eclipse.jetty.ee11.servlet.ServletContextHandler;
 import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.HttpConnectionFactory;
-import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.SecureRequestCustomizer;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
-import org.eclipse.jetty.server.handler.AbstractHandler;
-import org.eclipse.jetty.util.resource.Resource;
 import org.eclipse.jetty.util.resource.ResourceFactory;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 


### PR DESCRIPTION
This PR addresses JIRA [QPID-8685](https://issues.apache.org/jira/browse/QPID-8685), updating jetty dependency version to 12.1.0