### PR TITLE
NO-JIRA: [Broker-J] Update checkout github actions to version 5

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
         java: [ 17, 21 ]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/cache@v4
         with:
           path: ~/.m2/repository


### PR DESCRIPTION
This PR updates github actions "checkout" to version 5