### PR TITLE
QPID-8684: [Broker-J] Update netty version to 4.2.4.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -131,7 +131,7 @@
     <!-- test dependency version numbers -->
     <junit-version>5.13.4</junit-version>
     <mockito-version>5.18.0</mockito-version>
-    <netty-version>4.2.3.Final</netty-version>
+    <netty-version>4.2.4.Final</netty-version>
     <hamcrest-version>3.0</hamcrest-version>
     <maven-resolver-provider-version>3.8.6</maven-resolver-provider-version>
     <maven-resolver-version>1.9.22</maven-resolver-version>


### PR DESCRIPTION
This PR addresses JIRA [QPID-8684](https://issues.apache.org/jira/browse/QPID-8684), updating netty dependency version to 4.2.4.Final