### PR TITLE
QPID-8709: [Broker-J] Docker image 9.2.1-alpine does not contain entrypoint.sh

### DIFF
--- a/qpid-docker/entrypoint.sh
+++ b/qpid-docker/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information


### PR DESCRIPTION
This PR addresses [QPID-8709](https://issues.apache.org/jira/browse/QPID-8709), replacing bash shell with the system shell in entrypoint.sh script