### PR TITLE
QPID-8684: [Broker-J] Bump mockito dependency version to 5.19.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -130,7 +130,7 @@
 
     <!-- test dependency version numbers -->
     <junit-version>5.13.4</junit-version>
-    <mockito-version>5.18.0</mockito-version>
+    <mockito-version>5.19.0</mockito-version>
     <netty-version>4.2.3.Final</netty-version>
     <hamcrest-version>3.0</hamcrest-version>
     <maven-resolver-provider-version>3.8.6</maven-resolver-provider-version>


### PR DESCRIPTION
This PR updates dependency org.mockito:mockito-core to the version 5.19.0