### PR TITLE
QPID-8708: [Broker-J] Docker entrypoint script copies links instead of files

### DIFF
--- a/qpid-docker/entrypoint.sh
+++ b/qpid-docker/entrypoint.sh
@@ -23,11 +23,11 @@ set -e
 
 if ! [ -f ./work/config.json ]; then
   if [ -d ./work-init ]; then
-      for file in `ls ./work-init`; do echo copying file to work folder: $file; cp -r ./work-init/$file ./work || :; done
+      for file in `ls ./work-init`; do echo copying file to work folder: $file; cp -r -L ./work-init/$file ./work || :; done
   fi
   sed -i "s/QPID_ADMIN_USER/${QPID_ADMIN_USER}/g" /qpid-broker-j/work/broker.acl
   if [ -d ./work-override ]; then
-    for file in `ls ./work-override`; do echo copying file to work folder: $file; cp -r ./work-override/$file ./work || :; done
+    for file in `ls ./work-override`; do echo copying file to work folder: $file; cp -r -L ./work-override/$file ./work || :; done
   fi
 else
   echo "skipping broker instance creation; instance already exists"


### PR DESCRIPTION
This PR addresses JIRA [QPID-8708](https://issues.apache.org/jira/browse/QPID-8708), adding the -L switch to copy command