### PR TITLE
NO-JIRA: [Broker-J] Bump setup-java github action to the version 5

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
       - name: Install JDK ${{ matrix.java }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'


### PR DESCRIPTION
This PR updates setup-java github action to the version 5