### PR TITLE
QPID-8697: [Broker-J] Bump fasterxml jackson dependencies versions to 2.20.0

### DIFF
--- a/apache-qpid-broker-j/src/main/assembly/dependency-verification/DEPENDENCIES_REFERENCE
+++ b/apache-qpid-broker-j/src/main/assembly/dependency-verification/DEPENDENCIES_REFERENCE
@@ -81,13 +81,13 @@ From: 'Eclipse Foundation' (https://www.eclipse.org)
 
 From: 'FasterXML' (http://fasterxml.com/)
 
-  - Jackson-annotations (https://github.com/FasterXML/jackson) com.fasterxml.jackson.core:jackson-annotations:jar:2.19.2
+  - Jackson-annotations (https://github.com/FasterXML/jackson) com.fasterxml.jackson.core:jackson-annotations:jar:2.20
     License: The Apache Software License, Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-  - Jackson-core (https://github.com/FasterXML/jackson-core) com.fasterxml.jackson.core:jackson-core:jar:2.19.2
+  - Jackson-core (https://github.com/FasterXML/jackson-core) com.fasterxml.jackson.core:jackson-core:jar:2.20.0
     License: The Apache Software License, Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-  - jackson-databind (https://github.com/FasterXML/jackson) com.fasterxml.jackson.core:jackson-databind:jar:2.19.2
+  - jackson-databind (https://github.com/FasterXML/jackson) com.fasterxml.jackson.core:jackson-databind:jar:2.20.0
     License: The Apache Software License, Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
 
 

--- a/perftests/src/main/assembly/dependency-verification/DEPENDENCIES_REFERENCE
+++ b/perftests/src/main/assembly/dependency-verification/DEPENDENCIES_REFERENCE
@@ -56,13 +56,13 @@ From: 'Apache Software Foundation' (http://www.apache.org)
 
 From: 'FasterXML' (http://fasterxml.com/)
 
-  - Jackson-annotations (https://github.com/FasterXML/jackson) com.fasterxml.jackson.core:jackson-annotations:jar:2.19.2
+  - Jackson-annotations (https://github.com/FasterXML/jackson) com.fasterxml.jackson.core:jackson-annotations:jar:2.20
     License: The Apache Software License, Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-  - Jackson-core (https://github.com/FasterXML/jackson-core) com.fasterxml.jackson.core:jackson-core:jar:2.19.2
+  - Jackson-core (https://github.com/FasterXML/jackson-core) com.fasterxml.jackson.core:jackson-core:jar:2.20.0
     License: The Apache Software License, Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-  - jackson-databind (https://github.com/FasterXML/jackson) com.fasterxml.jackson.core:jackson-databind:jar:2.19.2
+  - jackson-databind (https://github.com/FasterXML/jackson) com.fasterxml.jackson.core:jackson-databind:jar:2.20.0
     License: The Apache Software License, Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
 
 

--- a/perftests/src/main/java/org/apache/qpid/disttest/jms/QpidRestAPIQueueCreator.java
+++ b/perftests/src/main/java/org/apache/qpid/disttest/jms/QpidRestAPIQueueCreator.java
@@ -58,6 +58,7 @@ import org.apache.hc.core5.http.HttpHost;
 import org.apache.hc.core5.http.ProtocolVersion;
 import org.apache.hc.core5.http.io.HttpClientResponseHandler;
 import org.apache.hc.core5.http.io.entity.StringEntity;
+import org.apache.qpid.disttest.json.ObjectMapperFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -325,6 +326,8 @@ public class QpidRestAPIQueueCreator implements QueueCreator
 
     static class ResponseHandler implements HttpClientResponseHandler<Object>
     {
+        private static final ObjectMapper OBJECT_MAPPER = new ObjectMapperFactory().createObjectMapper();
+
         @Override
         public Object handleResponse(ClassicHttpResponse response) throws IOException
         {
@@ -344,7 +347,7 @@ public class QpidRestAPIQueueCreator implements QueueCreator
                     response.getEntity().writeTo(bos);
                     if (bos.size() > 0)
                     {
-                        return new ObjectMapper().readValue(bos.toByteArray(), Object.class);
+                        return OBJECT_MAPPER.readValue(bos.toByteArray(), Object.class);
                     }
                 }
             }

--- a/pom.xml
+++ b/pom.xml
@@ -107,8 +107,8 @@
     <logback-version>1.5.18</logback-version>
     <logback-db-version>1.2.11.1</logback-db-version>
     <caffeine-version>3.2.2</caffeine-version>
-    <fasterxml-jackson-version>2.19.2</fasterxml-jackson-version>
-    <fasterxml-jackson-databind-version>2.19.2</fasterxml-jackson-databind-version>
+    <fasterxml-jackson-version>2.20.0</fasterxml-jackson-version>
+    <fasterxml-jackson-databind-version>2.20.0</fasterxml-jackson-databind-version>
     <slf4j-version>2.0.17</slf4j-version>
     <jetty-version>12.1.0</jetty-version>
 


### PR DESCRIPTION
This PR addresses JIRA [QPID-8697](https://issues.apache.org/jira/browse/QPID-8697), updating fasterxml jackson dependencies versions to 2.20.0