### PR TITLE
QPID-8684: [Broker-J] Bump netty dependency to the version 4.2.6.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -131,7 +131,7 @@
     <!-- test dependency version numbers -->
     <junit-version>5.13.4</junit-version>
     <mockito-version>5.19.0</mockito-version>
-    <netty-version>4.2.4.Final</netty-version>
+    <netty-version>4.2.6.Final</netty-version>
     <hamcrest-version>3.0</hamcrest-version>
     <maven-resolver-provider-version>3.8.6</maven-resolver-provider-version>
     <maven-resolver-version>1.9.22</maven-resolver-version>


### PR DESCRIPTION
This PR addresses JIRA [QPID-8684](https://issues.apache.org/jira/browse/QPID-8684), bumping netty dependency to the version 4.2.6.Final