### PR TITLE
QPID-8698: [Broker-J] Bump bouncycastle dependencies versions to 1.82

### DIFF
--- a/apache-qpid-broker-j/src/main/assembly/dependency-verification/DEPENDENCIES_REFERENCE
+++ b/apache-qpid-broker-j/src/main/assembly/dependency-verification/DEPENDENCIES_REFERENCE
@@ -44,13 +44,13 @@ From: 'an unknown organization'
   - Prometheus Java Span Context Supplier - OpenTelemetry Agent (http://github.com/prometheus/client_java/simpleclient_tracer/simpleclient_tracer_otel_agent) io.prometheus:simpleclient_tracer_otel_agent:bundle:0.16.0
     License: The Apache Software License, Version 2.0  (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-  - Bouncy Castle PKIX, CMS, EAC, TSP, PKCS, OCSP, CMP, and CRMF APIs (https://www.bouncycastle.org/download/bouncy-castle-java/) org.bouncycastle:bcpkix-jdk18on:jar:1.81
+  - Bouncy Castle PKIX, CMS, EAC, TSP, PKCS, OCSP, CMP, and CRMF APIs (https://www.bouncycastle.org/download/bouncy-castle-java/) org.bouncycastle:bcpkix-jdk18on:jar:1.82
     License: Bouncy Castle Licence  (https://www.bouncycastle.org/licence.html)
 
-  - Bouncy Castle Provider (https://www.bouncycastle.org/download/bouncy-castle-java/) org.bouncycastle:bcprov-jdk18on:jar:1.81
+  - Bouncy Castle Provider (https://www.bouncycastle.org/download/bouncy-castle-java/) org.bouncycastle:bcprov-jdk18on:jar:1.82
     License: Bouncy Castle Licence  (https://www.bouncycastle.org/licence.html)
 
-  - Bouncy Castle ASN.1 Extension and Utility APIs (https://www.bouncycastle.org/download/bouncy-castle-java/) org.bouncycastle:bcutil-jdk18on:jar:1.81
+  - Bouncy Castle ASN.1 Extension and Utility APIs (https://www.bouncycastle.org/download/bouncy-castle-java/) org.bouncycastle:bcutil-jdk18on:jar:1.82
     License: Bouncy Castle Licence  (https://www.bouncycastle.org/licence.html)
 
   - dgrid (https://www.webjars.org) org.webjars.bower:dgrid:jar:1.3.3

--- a/pom.xml
+++ b/pom.xml
@@ -159,8 +159,8 @@
     <h2.version>2.3.232</h2.version>
     <apache-directory-version>2.0.0.AM27</apache-directory-version>
     <kerby-version>2.1.0</kerby-version>
-    <bcprov-version>1.81</bcprov-version>
-    <bcpkix-version>1.81</bcpkix-version>
+    <bcprov-version>1.82</bcprov-version>
+    <bcpkix-version>1.82</bcpkix-version>
     <logback-gelf-version>6.1.1</logback-gelf-version>
     <prometheus-client-version>0.16.0</prometheus-client-version>
     <resilience4j-version>2.3.0</resilience4j-version>


### PR DESCRIPTION
This PR addresses JIRA [QPID-8698](https://issues.apache.org/jira/browse/QPID-8698), updating dependencies org.bouncycastle:bcprov-jdk18on and org.bouncycastle:bcpkix-jdk18on to the version 1.82