### PR TITLE
QPID-8716: [Broker-J] Maven plugins and test dependencies updates for version 10.0.1

### DIFF
--- a/perftests/src/main/assembly/dependency-verification/DEPENDENCIES_REFERENCE
+++ b/perftests/src/main/assembly/dependency-verification/DEPENDENCIES_REFERENCE
@@ -82,13 +82,13 @@ From: 'QOS.ch' (http://www.qos.ch)
 
 From: 'The Apache Software Foundation' (https://www.apache.org/)
 
-  - Apache HttpClient (https://hc.apache.org/httpcomponents-client-5.5.x/5.5/httpclient5/) org.apache.httpcomponents.client5:httpclient5:jar:5.5
+  - Apache HttpClient (https://hc.apache.org/httpcomponents-client-5.5.x/5.5.1/httpclient5/) org.apache.httpcomponents.client5:httpclient5:jar:5.5.1
     License: Apache License, Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-  - Apache HttpComponents Core HTTP/1.1 (https://hc.apache.org/httpcomponents-core-5.3.x/5.3.4/httpcore5/) org.apache.httpcomponents.core5:httpcore5:jar:5.3.4
+  - Apache HttpComponents Core HTTP/1.1 (https://hc.apache.org/httpcomponents-core-5.3.x/5.3.6/httpcore5/) org.apache.httpcomponents.core5:httpcore5:jar:5.3.6
     License: Apache License, Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-  - Apache HttpComponents Core HTTP/2 (https://hc.apache.org/httpcomponents-core-5.3.x/5.3.4/httpcore5-h2/) org.apache.httpcomponents.core5:httpcore5-h2:jar:5.3.4
+  - Apache HttpComponents Core HTTP/2 (https://hc.apache.org/httpcomponents-core-5.3.x/5.3.6/httpcore5-h2/) org.apache.httpcomponents.core5:httpcore5-h2:jar:5.3.6
     License: Apache License, Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -129,36 +129,36 @@
     <dgrid-version>1.3.3</dgrid-version>
 
     <!-- test dependency version numbers -->
-    <junit-version>5.13.4</junit-version>
-    <mockito-version>5.19.0</mockito-version>
-    <netty-version>4.2.6.Final</netty-version>
+    <junit-version>6.0.1</junit-version>
+    <mockito-version>5.20.0</mockito-version>
+    <netty-version>4.2.7.Final</netty-version>
     <hamcrest-version>3.0</hamcrest-version>
     <maven-resolver-provider-version>3.8.6</maven-resolver-provider-version>
     <maven-resolver-version>1.9.22</maven-resolver-version>
-    <httpclient-version>5.5</httpclient-version>
+    <httpclient-version>5.5.1</httpclient-version>
     <qpid-jms-client-version>1.15.0</qpid-jms-client-version>
     <qpid-jms-client-amqp-0-x-version>6.4.0</qpid-jms-client-amqp-0-x-version>
     <nashorn-version>15.7</nashorn-version>
 
-    <exec-maven-plugin-version>3.5.1</exec-maven-plugin-version>
+    <exec-maven-plugin-version>3.6.2</exec-maven-plugin-version>
     <javacc-maven-plugin-version>3.1.1</javacc-maven-plugin-version>
-    <maven-enforcer-plugin-version>3.6.1</maven-enforcer-plugin-version>
+    <maven-enforcer-plugin-version>3.6.2</maven-enforcer-plugin-version>
     <maven-rar-plugin-version>3.0.0</maven-rar-plugin-version>
-    <license-maven-plugin-version>2.6.0</license-maven-plugin-version>
+    <license-maven-plugin-version>2.7.0</license-maven-plugin-version>
     <maven-jxr-plugin-version>3.6.0</maven-jxr-plugin-version>
     <findbugs-maven-plugin-version>3.0.5</findbugs-maven-plugin-version>
-    <jacoco-plugin-version>0.8.13</jacoco-plugin-version>
+    <jacoco-plugin-version>0.8.14</jacoco-plugin-version>
     <apache-rat-plugin-version>0.16.1</apache-rat-plugin-version>
     <maven-docbx-plugin-version>2.0.17</maven-docbx-plugin-version>
     <maven-docbook-xml-plugin-version>5.0-all</maven-docbook-xml-plugin-version>
     <buildnumber-maven-plugin-version>3.2.1</buildnumber-maven-plugin-version>
-    <maven-compiler-plugin-version>3.14.0</maven-compiler-plugin-version>
-    <maven-jar-plugin-version>3.4.2</maven-jar-plugin-version>
+    <maven-compiler-plugin-version>3.14.1</maven-compiler-plugin-version>
+    <maven-jar-plugin-version>3.5.0</maven-jar-plugin-version>
     <maven-surefire-plugin-version>3.5.4</maven-surefire-plugin-version>
     <maven-surefire-report-plugin-version>3.5.4</maven-surefire-report-plugin-version>
-    <h2.version>2.3.232</h2.version>
+    <h2.version>2.4.240</h2.version>
     <apache-directory-version>2.0.0.AM27</apache-directory-version>
-    <kerby-version>2.1.0</kerby-version>
+    <kerby-version>2.1.1</kerby-version>
     <bcprov-version>1.82</bcprov-version>
     <bcpkix-version>1.82</bcpkix-version>
     <logback-gelf-version>6.1.1</logback-gelf-version>


### PR DESCRIPTION
This PR addresses JIRA [QPID-8716](https://issues.apache.org/jira/browse/QPID-8716), updating broker-j test dependencies and maven plugins.

Following dependencies are updated:

**test dependencies**

com.h2database:h2 2.3.232 => 2.4.240
io.netty:netty-buffer 4.2.6.Final => 4.2.7.Final
io.netty:netty-common 4.2.6.Final => 4.2.7.Final
io.netty:netty-handler 4.2.6.Final => 4.2.7.Final
io.netty:netty-transport 4.2.6.Final => 4.2.7.Final
io.netty:netty-codec-http 4.2.6.Final => 4.2.7.Final
org.apache.httpcomponents.client5:httpclient5 5.5 => 5.5.1
org.apache.httpcomponents.client5:httpclient5-fluent 5.5 => 5.5.1
org.apache.kerby:kerb-simplekdc 2.1.0 => 2.1.1
org.mockito:mockito-core 5.19.0 => 5.20.0
org.junit.jupiter:junit-jupiter-api 5.13.4 => 6.0.1
org.junit.jupiter:junit-jupiter-engine 5.13.4 => 6.0.1
org.junit.jupiter:junit-jupiter-params 5.13.4 => 6.0.1

**maven plugins**

org.apache.maven.plugins:maven-compiler-plugin 3.14.0 => 3.14.1
org.apache.maven.plugins:maven-enforcer-plugin 3.6.1 => 3.6.2
org.apache.maven.plugins:maven-jar-plugin 3.4.2 => 3.5.0
org.codehaus.mojo:exec-maven-plugin 3.5.1 => 3.6.2
org.codehaus.mojo:license-maven-plugin 2.6.0 => 2.7.0
org.jacoco:jacoco-maven-plugin 0.8.13 => 0.8.14