### PR TITLE
QPID-8717: [Broker-J] Broker query engine may produce ClassCastException when using AVG function

### DIFF
--- a/broker-plugins/query-engine/src/main/java/org/apache/qpid/server/query/engine/parsing/expression/function/aggregation/AvgExpression.java
+++ b/broker-plugins/query-engine/src/main/java/org/apache/qpid/server/query/engine/parsing/expression/function/aggregation/AvgExpression.java
@@ -81,6 +81,12 @@ public class AvgExpression<T> extends AbstractAggregationExpression<T, Double>
     {
         final List<?> args = getArguments(items, _typeValidator);
         final OptionalDouble optionalDouble = args.stream().mapToDouble(NumberConverter::toDouble).average();
-        return optionalDouble.isPresent() ? NumberConverter.narrow(BigDecimal.valueOf(optionalDouble.getAsDouble())) : null;
+        if (optionalDouble.isEmpty())
+        {
+            return null;
+        }
+        final BigDecimal bigDecimal = BigDecimal.valueOf(optionalDouble.getAsDouble());
+        final Number narrowed = NumberConverter.narrow(bigDecimal);
+        return Double.valueOf(narrowed.doubleValue());
     }
 }

--- a/broker-plugins/query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/expression/function/aggregation/AvgExpressionTest.java
+++ b/broker-plugins/query-engine/src/test/java/org/apache/qpid/server/query/engine/parsing/expression/function/aggregation/AvgExpressionTest.java
@@ -170,4 +170,13 @@ public class AvgExpressionTest
             assertEquals("QUEUE_" + i, result.get(i - 50).get("name"));
         }
     }
+
+    @Test
+    void avgOnZeroValues()
+    {
+        String query = "SELECT avg(queueDepthMessages) as AverageDepth FROM queue where name = 'QUEUE_1'";
+        List<Map<String, Object>> result = _queryEvaluator.execute(query).getResults();
+        assertEquals(1, result.size());
+        assertEquals(0.0, result.get(0).get("AverageDepth"));
+    }
 }


### PR DESCRIPTION
This PR addresses JIRA [QPID-8717](https://issues.apache.org/jira/browse/QPID-8717), fixing ClassCastException thrown when using AVG function in broker query engine