### PR TITLE
QPID-8718: [Broker-J] Broker query engine should support newline characters

### DIFF
--- a/broker-plugins/management-http/src/main/java/org/apache/qpid/server/management/plugin/servlet/rest/QueryServlet.java
+++ b/broker-plugins/management-http/src/main/java/org/apache/qpid/server/management/plugin/servlet/rest/QueryServlet.java
@@ -27,7 +27,6 @@ import java.time.ZoneId;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import jakarta.servlet.ServletContext;
 import jakarta.servlet.ServletException;
@@ -100,9 +99,10 @@ public abstract class QueryServlet<X extends ConfiguredObject<?>> extends Abstra
         final ConfiguredObject<?> managedObject
     ) throws IOException
     {
+        String content = "";
         try
         {
-            final String content = request.getReader().lines().collect(Collectors.joining());
+            content = String.join(" ", request.getReader().lines().toList());
             if (content.isEmpty())
             {
                 performQuery(request, response, managedObject);
@@ -119,7 +119,7 @@ public abstract class QueryServlet<X extends ConfiguredObject<?>> extends Abstra
         catch (Exception e)
         {
             sendJsonErrorResponse(request, response, HttpServletResponse.SC_INTERNAL_SERVER_ERROR, GENERIC_ERROR_MESSAGE);
-            LOGGER.error("Error when executing query", e);
+            LOGGER.error("Error when executing query '%s'".formatted(content), e);
         }
     }
 

--- a/broker-plugins/query-engine/src/test/java/org/apache/qpid/server/query/engine/evaluator/QueryEvaluatorTest.java
+++ b/broker-plugins/query-engine/src/test/java/org/apache/qpid/server/query/engine/evaluator/QueryEvaluatorTest.java
@@ -30,6 +30,9 @@ import org.apache.qpid.server.query.engine.evaluator.settings.QuerySettings;
 import org.apache.qpid.server.query.engine.exception.Errors;
 import org.apache.qpid.server.query.engine.exception.QueryValidationException;
 
+import java.util.List;
+import java.util.Map;
+
 /**
  * Tests designed to verify the {@link QueryEvaluator} functionality
  */
@@ -150,6 +153,21 @@ public class QueryEvaluatorTest
         {
             assertEquals(NullPointerException.class, e.getClass());
             assertEquals(Errors.EVALUATION.QUERY_NOT_SUPPLIED, e.getMessage());
+        }
+    }
+
+    @Test
+    public void multiLineQuery()
+    {
+        final QueryEvaluator evaluator = new QueryEvaluator(null, new QuerySettings(), TestBroker.createBroker());
+        final List<String> delimiters = List.of("\n", "\r", "\r\n");
+        for (final String delimiter : delimiters)
+        {
+            final String query = "select * " + delimiter +
+                    "from queue " + delimiter +
+                    "where name = 'QUEUE_1'";
+            final List<Map<String, Object>> result = evaluator.execute(query).getResults();
+            assertEquals(1, result.size());
         }
     }
 }


### PR DESCRIPTION
This PR addresses JIRA [QPID-8718](https://issues.apache.org/jira/browse/QPID-8718), adding support of newline characters to the query engine