### PR TITLE
NO-JIRA: [Broker-J] Bump checkout github action to the version 6

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
         java: [ 17, 21 ]
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: actions/cache@v4
         with:
           path: ~/.m2/repository


### PR DESCRIPTION
This PR updates github action "checkout" to version 6