### PR TITLE
QPID-8722: [Broker-J] Bump commons-cli dependency to the version 1.11.0

### DIFF
--- a/apache-qpid-broker-j/src/main/assembly/dependency-verification/DEPENDENCIES_REFERENCE
+++ b/apache-qpid-broker-j/src/main/assembly/dependency-verification/DEPENDENCIES_REFERENCE
@@ -130,7 +130,7 @@ From: 'QOS.ch' (http://www.qos.ch)
 
 From: 'The Apache Software Foundation' (https://www.apache.org/)
 
-  - Apache Commons CLI (https://commons.apache.org/proper/commons-cli/) commons-cli:commons-cli:jar:1.10.0
+  - Apache Commons CLI (https://commons.apache.org/proper/commons-cli/) commons-cli:commons-cli:jar:1.11.0
     License: Apache-2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
 
   - Apache Qpid Broker-J BDB Message Store Plug-in (http://qpid.apache.org/components/qpid-bdbstore) org.apache.qpid:qpid-bdbstore:jar

--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
 
     <!-- dependency version numbers -->
     <hikari-cp-version>7.0.2</hikari-cp-version>
-    <commons-cli-version>1.10.0</commons-cli-version>
+    <commons-cli-version>1.11.0</commons-cli-version>
 
     <geronimo-jms-1-1-version>1.1.1</geronimo-jms-1-1-version>
     <geronimo-jms-2-0-version>1.0-alpha-2</geronimo-jms-2-0-version>


### PR DESCRIPTION
This PR addresses JIRA [QPID-8722](https://issues.apache.org/jira/browse/QPID-8722), updating commons-cli dependency to the version 1.11.0