### PR TITLE
QPID-8723: [Broker-J] Bump caffeine dependency to the version 3.2.3

### DIFF
--- a/apache-qpid-broker-j/src/main/assembly/dependency-verification/DEPENDENCIES_REFERENCE
+++ b/apache-qpid-broker-j/src/main/assembly/dependency-verification/DEPENDENCIES_REFERENCE
@@ -26,7 +26,7 @@ Apache Qpid Broker-J Bundles
 
 From: 'an unknown organization'
 
-  - Caffeine cache (https://github.com/ben-manes/caffeine) com.github.ben-manes.caffeine:caffeine:jar:3.2.2
+  - Caffeine cache (https://github.com/ben-manes/caffeine) com.github.ben-manes.caffeine:caffeine:jar:3.2.3
     License: Apache License, Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
 
   - Prometheus Java Simpleclient (http://github.com/prometheus/client_java/simpleclient) io.prometheus:simpleclient:bundle:0.16.0

--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@
     <derby-version>10.16.1.1</derby-version>
     <logback-version>1.5.18</logback-version>
     <logback-db-version>1.2.11.1</logback-db-version>
-    <caffeine-version>3.2.2</caffeine-version>
+    <caffeine-version>3.2.3</caffeine-version>
     <fasterxml-jackson-version>2.20.0</fasterxml-jackson-version>
     <fasterxml-jackson-databind-version>2.20.0</fasterxml-jackson-databind-version>
     <slf4j-version>2.0.17</slf4j-version>


### PR DESCRIPTION
This PR addresses JIRA [QPID-8723](https://issues.apache.org/jira/browse/QPID-8723), updating caffeine dependency to the version 3.2.3