### PR TITLE
QPID-8716: [Broker-J] Update apache-rat-plugin to the version 0.17

### DIFF
--- a/bdbstore/pom.xml
+++ b/bdbstore/pom.xml
@@ -111,9 +111,9 @@
         <groupId>org.apache.rat</groupId>
         <artifactId>apache-rat-plugin</artifactId>
         <configuration>
-          <excludes>
-            <exclude>systests/**</exclude>
-          </excludes>
+          <inputExcludes>
+            <inputExclude>systests/**</inputExclude>
+          </inputExcludes>
         </configuration>
       </plugin>
     </plugins>

--- a/broker-core/pom.xml
+++ b/broker-core/pom.xml
@@ -166,10 +166,10 @@
         <groupId>org.apache.rat</groupId>
         <artifactId>apache-rat-plugin</artifactId>
         <configuration>
-          <excludes>
-            <exclude>src/test/resources/ssl/**</exclude>
-            <exclude>src/main/resources/org/apache/qpid/server/configuration/fallback-version.txt</exclude>
-          </excludes>
+          <inputExcludes>
+            <inputExclude>src/test/resources/ssl/**</inputExclude>
+            <inputExclude>src/main/resources/org/apache/qpid/server/configuration/fallback-version.txt</inputExclude>
+          </inputExcludes>
         </configuration>
       </plugin>
 

--- a/broker-plugins/management-http/pom.xml
+++ b/broker-plugins/management-http/pom.xml
@@ -159,9 +159,9 @@
         <groupId>org.apache.rat</groupId>
         <artifactId>apache-rat-plugin</artifactId>
         <configuration>
-          <excludes>
-            <exclude>src/main/java/resources/js/crypto-js/**</exclude>
-          </excludes>
+          <inputExcludes>
+            <inputExclude>src/main/java/resources/js/crypto-js/**</inputExclude>
+          </inputExcludes>
         </configuration>
       </plugin>
     </plugins>

--- a/doc/developer-guide/pom.xml
+++ b/doc/developer-guide/pom.xml
@@ -43,10 +43,10 @@
                 <groupId>org.apache.rat</groupId>
                 <artifactId>apache-rat-plugin</artifactId>
                 <configuration>
-                    <excludes>
-                        <exclude>**/*.gliffy</exclude>
-                        <exclude>**/*.md</exclude>
-                    </excludes>
+                  <inputExcludes>
+                    <inputExclude>**/*.gliffy</inputExclude>
+                    <inputExclude>**/*.md</inputExclude>
+                  </inputExcludes>
                 </configuration>
             </plugin>
         </plugins>

--- a/perftests/pom.xml
+++ b/perftests/pom.xml
@@ -181,12 +181,12 @@
         <groupId>org.apache.rat</groupId>
         <artifactId>apache-rat-plugin</artifactId>
         <configuration>
-          <excludes>
-            <exclude>src/main/java/json2.js</exclude>
-            <exclude>src/test/java/org/apache/qpid/disttest/controller/config/sampleConfig.json</exclude>
-            <exclude>src/test/java/org/apache/qpid/disttest/results/formatting/expectedOutput.csv</exclude>
-            <exclude>visualisation-jfc/**</exclude>
-          </excludes>
+          <inputExcludes>
+            <inputExclude>src/main/java/json2.js</inputExclude>
+            <inputExclude>src/test/java/org/apache/qpid/disttest/controller/config/sampleConfig.json</inputExclude>
+            <inputExclude>src/test/java/org/apache/qpid/disttest/results/formatting/expectedOutput.csv</inputExclude>
+            <inputExclude>visualisation-jfc/**</inputExclude>
+          </inputExcludes>
         </configuration>
       </plugin>
       <plugin>

--- a/perftests/visualisation-jfc/pom.xml
+++ b/perftests/visualisation-jfc/pom.xml
@@ -168,9 +168,9 @@
         <groupId>org.apache.rat</groupId>
         <artifactId>apache-rat-plugin</artifactId>
         <configuration>
-          <excludes>
-            <exclude>src/test/java/org/apache/qpid/disttest/charting/writer/expected-chart-summary.html</exclude>
-          </excludes>
+          <inputExcludes>
+            <inputExclude>src/test/java/org/apache/qpid/disttest/charting/writer/expected-chart-summary.html</inputExclude>
+          </inputExcludes>
         </configuration>
       </plugin>
     </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -148,7 +148,7 @@
     <maven-jxr-plugin-version>3.6.0</maven-jxr-plugin-version>
     <findbugs-maven-plugin-version>3.0.5</findbugs-maven-plugin-version>
     <jacoco-plugin-version>0.8.14</jacoco-plugin-version>
-    <apache-rat-plugin-version>0.16.1</apache-rat-plugin-version>
+    <apache-rat-plugin-version>0.17</apache-rat-plugin-version>
     <maven-docbx-plugin-version>2.0.17</maven-docbx-plugin-version>
     <maven-docbook-xml-plugin-version>5.0-all</maven-docbook-xml-plugin-version>
     <buildnumber-maven-plugin-version>3.2.1</buildnumber-maven-plugin-version>
@@ -1220,14 +1220,14 @@
         <groupId>org.apache.rat</groupId>
         <artifactId>apache-rat-plugin</artifactId>
         <configuration>
-          <excludes>
-            <exclude>test-profiles/test_resources/ssl/**</exclude>
-            <exclude>specs/**</exclude>
-            <exclude>**/*.md</exclude>
-            <exclude>DEPENDENCIES</exclude>
-            <exclude>appveyor.yml</exclude>
-          </excludes>
-        </configuration>
+          <inputExcludes>
+            <inputExclude>test-profiles/test_resources/ssl/**</inputExclude>
+            <inputExclude>specs/**</inputExclude>
+            <inputExclude>**/*.md</inputExclude>
+            <inputExclude>DEPENDENCIES</inputExclude>
+            <inputExclude>appveyor.yml</inputExclude>
+          </inputExcludes>
+          </configuration>
       </plugin>
     </plugins>
 
@@ -1297,12 +1297,12 @@
         <artifactId>apache-rat-plugin</artifactId>
         <version>${apache-rat-plugin-version}</version>
         <configuration>
-          <excludes>
-            <exclude>build/**</exclude>
-            <exclude>lib/**</exclude>
-            <exclude>test-profiles/test_resources/ssl/**</exclude>
-            <exclude>DEPENDENCIES</exclude>
-          </excludes>
+          <inputExcludes>
+            <inputExclude>build/**</inputExclude>
+            <inputExclude>lib/**</inputExclude>
+            <inputExclude>test-profiles/test_resources/ssl/**</inputExclude>
+            <inputExclude>DEPENDENCIES</inputExclude>
+          </inputExcludes>
         </configuration>
       </plugin>
 

--- a/qpid-test-utils/pom.xml
+++ b/qpid-test-utils/pom.xml
@@ -122,9 +122,9 @@
         <groupId>org.apache.rat</groupId>
         <artifactId>apache-rat-plugin</artifactId>
         <configuration>
-          <excludes>
-            <exclude>src/main/resources/ssl/**</exclude>
-          </excludes>
+          <inputExcludes>
+            <inputExclude>src/main/resources/ssl/**</inputExclude>
+          </inputExcludes>
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
This PR addresses JIRA [QPID-8716](https://issues.apache.org/jira/browse/QPID-8716), updating apache-rat-plugin to version 0.17.

Version 0.17 of the apache-rat-plugin introduces configuration changes, which were done according to the migration guide:
https://creadur.apache.org/rat100/apache-rat/migrationguide/0.17.html