### PR TITLE
QPID-8729: [Broker-J] Bump netty to the version 4.2.9.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -131,7 +131,7 @@
     <!-- test dependency version numbers -->
     <junit-version>6.0.1</junit-version>
     <mockito-version>5.20.0</mockito-version>
-    <netty-version>4.2.7.Final</netty-version>
+    <netty-version>4.2.9.Final</netty-version>
     <hamcrest-version>3.0</hamcrest-version>
     <maven-resolver-provider-version>3.8.6</maven-resolver-provider-version>
     <maven-resolver-version>1.9.22</maven-resolver-version>


### PR DESCRIPTION
This PR addresses JIRA [QPID-8729](https://issues.apache.org/jira/browse/QPID-8729), updating netty dependencies to version 4.2.9.Final