### PR TITLE
NO-JIRA: [Broker-J] Update github action cache to the version 5 and upload-artifact to the version 6

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
@@ -62,7 +62,7 @@ jobs:
 
       - name: Upload Test Logs On Failure
         if: failure()
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: surefire-reports-jdk-${{ matrix.java }}
           path: surefire-reports-jdk-${{ matrix.java }}.tar.gz


### PR DESCRIPTION
This PR updates github action versions:
cache 4 => 5 
upload-artifact 5 => 6