### PR TITLE
QPID-8729: [Broker-J] Bump httpclient dependency to the version 5.6

### DIFF
--- a/perftests/src/main/assembly/dependency-verification/DEPENDENCIES_REFERENCE
+++ b/perftests/src/main/assembly/dependency-verification/DEPENDENCIES_REFERENCE
@@ -82,13 +82,13 @@ From: 'QOS.ch' (http://www.qos.ch)
 
 From: 'The Apache Software Foundation' (https://www.apache.org/)
 
-  - Apache HttpClient (https://hc.apache.org/httpcomponents-client-5.5.x/5.5.1/httpclient5/) org.apache.httpcomponents.client5:httpclient5:jar:5.5.1
+  - Apache HttpClient (https://hc.apache.org/httpcomponents-client-5.5.x/5.6/httpclient5/) org.apache.httpcomponents.client5:httpclient5:jar:5.6
     License: Apache License, Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-  - Apache HttpComponents Core HTTP/1.1 (https://hc.apache.org/httpcomponents-core-5.3.x/5.3.6/httpcore5/) org.apache.httpcomponents.core5:httpcore5:jar:5.3.6
+  - Apache HttpComponents Core HTTP/1.1 (https://hc.apache.org/httpcomponents-core-5.4.x/5.4/httpcore5/) org.apache.httpcomponents.core5:httpcore5:jar:5.4
     License: Apache License, Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-  - Apache HttpComponents Core HTTP/2 (https://hc.apache.org/httpcomponents-core-5.3.x/5.3.6/httpcore5-h2/) org.apache.httpcomponents.core5:httpcore5-h2:jar:5.3.6
+  - Apache HttpComponents Core HTTP/2 (https://hc.apache.org/httpcomponents-core-5.4.x/5.4/httpcore5-h2/) org.apache.httpcomponents.core5:httpcore5-h2:jar:5.4
     License: Apache License, Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -135,7 +135,7 @@
     <hamcrest-version>3.0</hamcrest-version>
     <maven-resolver-provider-version>3.8.6</maven-resolver-provider-version>
     <maven-resolver-version>1.9.22</maven-resolver-version>
-    <httpclient-version>5.5.1</httpclient-version>
+    <httpclient-version>5.6</httpclient-version>
     <qpid-jms-client-version>1.15.0</qpid-jms-client-version>
     <qpid-jms-client-amqp-0-x-version>6.4.0</qpid-jms-client-amqp-0-x-version>
     <nashorn-version>15.7</nashorn-version>


### PR DESCRIPTION
This PR addresses JIRA [QPID-8729](https://issues.apache.org/jira/browse/QPID-8729), updating httpclient dependency to the version 5.6