### PR TITLE
QPID-8013: [Broker-J] Reduce footprint of AMQP 1.0 protocol objects

### DIFF
--- a/broker-codegen/src/main/java/org/apache/qpid/server/protocol/v1_0/CompositeTypeConstructorGenerator.java
+++ b/broker-codegen/src/main/java/org/apache/qpid/server/protocol/v1_0/CompositeTypeConstructorGenerator.java
@@ -77,6 +77,7 @@ public class CompositeTypeConstructorGenerator  extends AbstractProcessor
             "org.apache.qpid.server.protocol.v1_0.type.messaging.TerminusExpiryPolicy",
             "org.apache.qpid.server.protocol.v1_0.type.transaction.TxnCapability");
 
+    private static final List<String> SINGLETONS = List.of("Accepted");
 
     @Override
     public SourceVersion getSupportedSourceVersion()
@@ -188,7 +189,14 @@ public class CompositeTypeConstructorGenerator  extends AbstractProcessor
             pw.println("    @Override");
             pw.println("    protected " + objectSimpleName + " construct(final FieldValueReader fieldValueReader) throws AmqpErrorException");
             pw.println("    {");
-            pw.println("        " + objectSimpleName + " obj = new " + objectSimpleName + "();");
+            if (SINGLETONS.contains(objectSimpleName))
+            {
+                pw.println("        " + objectSimpleName + " obj = " + objectSimpleName + ".INSTANCE;");
+            }
+            else
+            {
+                pw.println("        " + objectSimpleName + " obj = new " + objectSimpleName + "();");
+            }
             pw.println();
             generateAssigners(pw, typeElement);
             pw.println("        return obj;");

--- a/broker-plugins/amqp-1-0-protocol/src/main/java/org/apache/qpid/server/protocol/v1_0/AMQPConnection_1_0Impl.java
+++ b/broker-plugins/amqp-1-0-protocol/src/main/java/org/apache/qpid/server/protocol/v1_0/AMQPConnection_1_0Impl.java
@@ -51,14 +51,13 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.apache.qpid.server.logging.EventLogger;
-import org.apache.qpid.server.logging.messages.ResourceLimitMessages;
-import org.apache.qpid.server.security.limit.ConnectionLimitException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.qpid.server.bytebuffer.QpidByteBuffer;
+import org.apache.qpid.server.logging.EventLogger;
 import org.apache.qpid.server.logging.messages.ConnectionMessages;
+import org.apache.qpid.server.logging.messages.ResourceLimitMessages;
 import org.apache.qpid.server.model.AuthenticationProvider;
 import org.apache.qpid.server.model.Broker;
 import org.apache.qpid.server.model.Connection;
@@ -74,6 +73,7 @@ import org.apache.qpid.server.protocol.v1_0.codec.ProtocolHandler;
 import org.apache.qpid.server.protocol.v1_0.codec.SectionDecoderRegistry;
 import org.apache.qpid.server.protocol.v1_0.codec.ValueHandler;
 import org.apache.qpid.server.protocol.v1_0.codec.ValueWriter;
+import org.apache.qpid.server.protocol.v1_0.constants.Bytes;
 import org.apache.qpid.server.protocol.v1_0.framing.AMQFrame;
 import org.apache.qpid.server.protocol.v1_0.framing.FrameHandler;
 import org.apache.qpid.server.protocol.v1_0.framing.OversizeFrameException;
@@ -117,6 +117,7 @@ import org.apache.qpid.server.security.auth.SubjectAuthenticationResult;
 import org.apache.qpid.server.security.auth.manager.AnonymousAuthenticationManager;
 import org.apache.qpid.server.security.auth.manager.ExternalAuthenticationManagerImpl;
 import org.apache.qpid.server.security.auth.sasl.SaslNegotiator;
+import org.apache.qpid.server.security.limit.ConnectionLimitException;
 import org.apache.qpid.server.session.AMQPSession;
 import org.apache.qpid.server.transport.AbstractAMQPConnection;
 import org.apache.qpid.server.transport.AggregateTicker;
@@ -145,31 +146,6 @@ public class AMQPConnection_1_0Impl extends AbstractAMQPConnection<AMQPConnectio
 
     private final AtomicBoolean _stateChanged = new AtomicBoolean();
     private final AtomicReference<Action<ProtocolEngine>> _workListener = new AtomicReference<>();
-
-
-    private static final byte[] SASL_HEADER = new byte[]
-            {
-                    (byte) 'A',
-                    (byte) 'M',
-                    (byte) 'Q',
-                    (byte) 'P',
-                    (byte) 3,
-                    (byte) 1,
-                    (byte) 0,
-                    (byte) 0
-            };
-
-    private static final byte[] AMQP_HEADER = new byte[]
-            {
-                    (byte) 'A',
-                    (byte) 'M',
-                    (byte) 'Q',
-                    (byte) 'P',
-                    (byte) 0,
-                    (byte) 1,
-                    (byte) 0,
-                    (byte) 0
-            };
 
     private final FrameWriter _frameWriter;
     private ProtocolHandler _frameHandler;
@@ -286,7 +262,7 @@ public class AMQPConnection_1_0Impl extends AbstractAMQPConnection<AMQPConnectio
         }
         String mechanism = saslInit.getMechanism().toString();
         final Binary initialResponse = saslInit.getInitialResponse();
-        byte[] response = initialResponse == null ? new byte[0] : initialResponse.getArray();
+        byte[] response = initialResponse == null ? Bytes.EMPTY_BYTE_ARRAY : initialResponse.getArray();
 
         List<String> availableMechanisms =
                 _subjectCreator.getAuthenticationProvider().getAvailableMechanisms(getTransport().isSecure());
@@ -306,7 +282,7 @@ public class AMQPConnection_1_0Impl extends AbstractAMQPConnection<AMQPConnectio
     {
         assertState(ConnectionState.AWAIT_SASL_RESPONSE);
         final Binary responseBinary = saslResponse.getResponse();
-        byte[] response = responseBinary == null ? new byte[0] : responseBinary.getArray();
+        byte[] response = responseBinary == null ? Bytes.EMPTY_BYTE_ARRAY : responseBinary.getArray();
 
         processSaslResponse(response);
     }
@@ -338,7 +314,7 @@ public class AMQPConnection_1_0Impl extends AbstractAMQPConnection<AMQPConnectio
         SubjectAuthenticationResult authenticationResult = _successfulAuthenticationResult;
         if (authenticationResult == null)
         {
-            authenticationResult = _subjectCreator.authenticate(_saslNegotiator, response != null ? response : new byte[0]);
+            authenticationResult = _subjectCreator.authenticate(_saslNegotiator, response != null ? response : Bytes.EMPTY_BYTE_ARRAY);
             challenge = authenticationResult.getChallenge();
         }
 
@@ -1204,21 +1180,30 @@ public class AMQPConnection_1_0Impl extends AbstractAMQPConnection<AMQPConnectio
     {
         if (!_closedForOutput)
         {
-            ValueWriter<FrameBody> writer = _describedTypeRegistry.getValueWriter(body);
-            if (payload == null)
+            final int payloadRemaining = payload == null ? 0 : payload.remaining();
+            final boolean hasPayload = payloadRemaining > 0;
+
+            if (hasPayload && !(body instanceof Transfer))
             {
-                send(new TransportFrame(channel, body));
+                throw new ConnectionScopedRuntimeException("Non-empty payload is only supported for Transfer frames. " +
+                        "body=" + (body == null ? "null" : body.getClass().getName()) +
+                        ", payloadRemaining=" + payloadRemaining);
+            }
+
+            ValueWriter<FrameBody> writer = body == null ? null : _describedTypeRegistry.getValueWriter(body);
+            if (!hasPayload)
+            {
+                send(new TransportFrame(channel, body, writer));
                 return 0;
             }
             else
             {
                 int size = writer.getEncodedSize();
                 int maxPayloadSize = _maxFrameSize - (size + 9);
-                long payloadLength = (long) payload.remaining();
-                if (payloadLength <= maxPayloadSize)
+                if (payloadRemaining <= maxPayloadSize)
                 {
-                    send(new TransportFrame(channel, body, payload));
-                    return (int)payloadLength;
+                    send(new TransportFrame(channel, body, payload, writer));
+                    return payloadRemaining;
                 }
                 else
                 {
@@ -1231,7 +1216,7 @@ public class AMQPConnection_1_0Impl extends AbstractAMQPConnection<AMQPConnectio
                     try (QpidByteBuffer payloadDup = payload.view(0, maxPayloadSize))
                     {
                         payload.position(payload.position() + maxPayloadSize);
-                        send(new TransportFrame(channel, body, payloadDup));
+                        send(new TransportFrame(channel, body, payloadDup, writer));
                     }
 
                     return maxPayloadSize;
@@ -1361,14 +1346,16 @@ public class AMQPConnection_1_0Impl extends AbstractAMQPConnection<AMQPConnectio
 
             final AuthenticationProvider<?> authenticationProvider = getPort().getAuthenticationProvider();
 
-            if(Arrays.equals(header, SASL_HEADER))
+            final byte[] amqpHeader = Bytes.amqpHeader();
+            final byte[] saslHeader = Bytes.saslHeader();
+            if (Arrays.equals(header, saslHeader))
             {
                 if(_saslComplete)
                 {
                     throw new ConnectionScopedRuntimeException("SASL Layer header received after SASL already established");
                 }
 
-                try (QpidByteBuffer protocolHeader = QpidByteBuffer.wrap(SASL_HEADER))
+                try (QpidByteBuffer protocolHeader = QpidByteBuffer.wrap(saslHeader))
                 {
                     getSender().send(protocolHeader);
                 }
@@ -1384,7 +1371,7 @@ public class AMQPConnection_1_0Impl extends AbstractAMQPConnection<AMQPConnectio
                 _connectionState = ConnectionState.AWAIT_SASL_INIT;
                 _frameHandler = getFrameHandler(true);
             }
-            else if(Arrays.equals(header, AMQP_HEADER))
+            else if(Arrays.equals(header, amqpHeader))
             {
                 if(!_saslComplete)
                 {
@@ -1406,7 +1393,7 @@ public class AMQPConnection_1_0Impl extends AbstractAMQPConnection<AMQPConnectio
                     }
 
                 }
-                try (QpidByteBuffer protocolHeader = QpidByteBuffer.wrap(AMQP_HEADER))
+                try (QpidByteBuffer protocolHeader = QpidByteBuffer.wrap(amqpHeader))
                 {
                     getSender().send(protocolHeader);
                 }

--- a/broker-plugins/amqp-1-0-protocol/src/main/java/org/apache/qpid/server/protocol/v1_0/AnonymousRelayDestination.java
+++ b/broker-plugins/amqp-1-0-protocol/src/main/java/org/apache/qpid/server/protocol/v1_0/AnonymousRelayDestination.java
@@ -37,6 +37,8 @@ import org.apache.qpid.server.txn.ServerTransaction;
 
 public class AnonymousRelayDestination implements ReceivingDestination
 {
+    private static final Symbol[] CAPABILITIES = { DELAYED_DELIVERY };
+
     private final Target _target;
     private final NamedAddressSpace _addressSpace;
     private final EventLogger _eventLogger;
@@ -53,10 +55,17 @@ public class AnonymousRelayDestination implements ReceivingDestination
                                                                        .contains(DISCARD_UNROUTABLE);
     }
 
+    /**
+     * Returns the target capabilities for an anonymous relay.
+     * <br>
+     * Note: returns a shared array instance to avoid per-call allocation. The returned array must be treated as
+     * immutable and must not be modified by callers.
+     * @return {@link Symbol} array
+     */
     @Override
     public Symbol[] getCapabilities()
     {
-        return new Symbol[]{DELAYED_DELIVERY};
+        return CAPABILITIES;
     }
 
     @Override

--- a/broker-plugins/amqp-1-0-protocol/src/main/java/org/apache/qpid/server/protocol/v1_0/ExchangeSendingDestination.java
+++ b/broker-plugins/amqp-1-0-protocol/src/main/java/org/apache/qpid/server/protocol/v1_0/ExchangeSendingDestination.java
@@ -58,7 +58,7 @@ import org.apache.qpid.server.virtualhost.QueueManagingVirtualHost;
 
 public class ExchangeSendingDestination extends StandardSendingDestination
 {
-    private static final Accepted ACCEPTED = new Accepted();
+    private static final Accepted ACCEPTED = Accepted.INSTANCE;
     private static final Rejected REJECTED = new Rejected();
     private static final Outcome[] OUTCOMES = { ACCEPTED, REJECTED};
     public static final Symbol TOPIC_CAPABILITY = Symbol.getSymbol("topic");

--- a/broker-plugins/amqp-1-0-protocol/src/main/java/org/apache/qpid/server/protocol/v1_0/MessageConverter_Internal_to_v1_0.java
+++ b/broker-plugins/amqp-1-0-protocol/src/main/java/org/apache/qpid/server/protocol/v1_0/MessageConverter_Internal_to_v1_0.java
@@ -62,7 +62,6 @@ import org.apache.qpid.server.util.ConnectionScopedRuntimeException;
 @PluggableService
 public class MessageConverter_Internal_to_v1_0 extends MessageConverter_to_1_0<InternalMessage>
 {
-
     private static final Set<Class<?>> TYPES_EXPRESSIBLE_AS_AMQP_1_0_VALUE = Set.of(String.class,
             Character.class,
             Boolean.class,
@@ -163,8 +162,7 @@ public class MessageConverter_Internal_to_v1_0 extends MessageConverter_to_1_0<I
         {
             contentTypeAnnotationValue = isSectionValidForJmsMap(convertedMessageBody) ? MAP_MESSAGE.getType() : null;
         }
-        else if (originalMessageBody != null
-                 && TYPES_EXPRESSIBLE_AS_AMQP_1_0_VALUE.stream().anyMatch(clazz -> clazz.isAssignableFrom(originalMessageBody.getClass())))
+        else if (originalMessageBody != null && expressibleAsAmqpValue(originalMessageBody))
         {
             contentTypeAnnotationValue = null;
         }
@@ -211,8 +209,7 @@ public class MessageConverter_Internal_to_v1_0 extends MessageConverter_to_1_0<I
         {
             contentTypeAsString = null;
         }
-        else if (messageBody != null
-                 && TYPES_EXPRESSIBLE_AS_AMQP_1_0_VALUE.stream().anyMatch(clazz -> clazz.isAssignableFrom(messageBody.getClass())))
+        else if (messageBody != null && expressibleAsAmqpValue(messageBody))
         {
             contentTypeAsString = mimeType;
         }
@@ -280,8 +277,7 @@ public class MessageConverter_Internal_to_v1_0 extends MessageConverter_to_1_0<I
 
     public NonEncodingRetainingSection<?> convertToBody(Object object)
     {
-        if (object == null
-            || TYPES_EXPRESSIBLE_AS_AMQP_1_0_VALUE.stream().anyMatch(clazz -> clazz.isAssignableFrom(object.getClass())))
+        if (object == null || expressibleAsAmqpValue(object))
         {
             return new AmqpValue(object);
         }
@@ -312,4 +308,20 @@ public class MessageConverter_Internal_to_v1_0 extends MessageConverter_to_1_0<I
         }
     }
 
+    private static boolean expressibleAsAmqpValue(final Object object)
+    {
+        if (object == null)
+        {
+            return true;
+        }
+        final Class<?> type = object.getClass();
+        for (final Class<?> amqpType : TYPES_EXPRESSIBLE_AS_AMQP_1_0_VALUE)
+        {
+            if (amqpType.isAssignableFrom(type))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
 }

--- a/broker-plugins/amqp-1-0-protocol/src/main/java/org/apache/qpid/server/protocol/v1_0/MessageConverter_to_1_0.java
+++ b/broker-plugins/amqp-1-0-protocol/src/main/java/org/apache/qpid/server/protocol/v1_0/MessageConverter_to_1_0.java
@@ -68,12 +68,24 @@ import org.apache.qpid.server.util.GZIPUtils;
 
 public abstract class MessageConverter_to_1_0<M extends ServerMessage> implements MessageConverter<M, Message_1_0>
 {
+    /** Must be treated as immutable and must not be modified */
     private static final byte[] SERIALIZED_NULL = getObjectBytes(null);
+    /** Must be treated as immutable and must not be modified */
+    private static final NonEncodingRetainingSection<?> AMQP_VALUE_NULL = new AmqpValue(null);
+    /** Must be treated as immutable and must not be modified */
+    private static final NonEncodingRetainingSection<?> AMQP_VALUE_EMPTY_STRING = new AmqpValue("");
+    /** Must be treated as immutable and must not be modified */
+    private static final NonEncodingRetainingSection<?> AMQP_VALUE_EMPTY_LIST = new AmqpSequence(Collections.emptyList());
+    /** Must be treated as immutable and must not be modified */
+    private static final NonEncodingRetainingSection<?> AMQP_VALUE_EMPTY_MAP = new AmqpValue(Collections.emptyMap());
+    /** Must be treated as immutable and must not be modified */
+    private static final NonEncodingRetainingSection<?> DATA_SERIALIZED_NULL = new Data(new Binary(SERIALIZED_NULL.clone()));
+
     private final AMQPDescribedTypeRegistry _typeRegistry = AMQPDescribedTypeRegistry.newInstance()
-                                                                                     .registerTransportLayer()
-                                                                                     .registerMessagingLayer()
-                                                                                     .registerTransactionLayer()
-                                                                                     .registerSecurityLayer();
+            .registerTransportLayer()
+            .registerMessagingLayer()
+            .registerTransactionLayer()
+            .registerSecurityLayer();
 
     public static Symbol getContentType(final String contentMimeType)
     {
@@ -280,23 +292,23 @@ public abstract class MessageConverter_to_1_0<M extends ServerMessage> implement
         }
         else if (mimeType == null)
         {
-            return new AmqpValue(null);
+            return AMQP_VALUE_NULL;
         }
         else if (OBJECT_MESSAGE_CONTENT_TYPES.matcher(mimeType).matches())
         {
-            return new Data(new Binary(SERIALIZED_NULL));
+            return DATA_SERIALIZED_NULL;
         }
         else if (TEXT_CONTENT_TYPES.matcher(mimeType).matches())
         {
-            return new AmqpValue("");
+            return AMQP_VALUE_EMPTY_STRING;
         }
         else if (MAP_MESSAGE_CONTENT_TYPES.matcher(mimeType).matches())
         {
-            return new AmqpValue(Collections.emptyMap());
+            return AMQP_VALUE_EMPTY_MAP;
         }
         else if (LIST_MESSAGE_CONTENT_TYPES.matcher(mimeType).matches())
         {
-            return new AmqpSequence(Collections.emptyList());
+            return AMQP_VALUE_EMPTY_LIST;
         }
         return new Data(new Binary(data));
     }

--- a/broker-plugins/amqp-1-0-protocol/src/main/java/org/apache/qpid/server/protocol/v1_0/MessageMetaData_1_0.java
+++ b/broker-plugins/amqp-1-0-protocol/src/main/java/org/apache/qpid/server/protocol/v1_0/MessageMetaData_1_0.java
@@ -404,6 +404,7 @@ public class MessageMetaData_1_0 implements StorableMessageMetaData
     private static class MetaDataFactory implements MessageMetaDataType.Factory<MessageMetaData_1_0>
     {
         private final AMQPDescribedTypeRegistry _typeRegistry = AMQPDescribedTypeRegistry.newInstance();
+        private final SectionDecoder _sectionDecoder = new SectionDecoderImpl(_typeRegistry.getSectionDecoderRegistry());
 
         private MetaDataFactory()
         {
@@ -449,9 +450,7 @@ public class MessageMetaData_1_0 implements StorableMessageMetaData
                             versionByte));
                 }
 
-                SectionDecoder sectionDecoder = new SectionDecoderImpl(_typeRegistry.getSectionDecoderRegistry());
-
-                List<EncodingRetainingSection<?>> sections = sectionDecoder.parseAll(buf);
+                List<EncodingRetainingSection<?>> sections = _sectionDecoder.parseAll(buf);
 
                 if (versionByte == 0)
                 {

--- a/broker-plugins/amqp-1-0-protocol/src/main/java/org/apache/qpid/server/protocol/v1_0/Message_1_0.java
+++ b/broker-plugins/amqp-1-0-protocol/src/main/java/org/apache/qpid/server/protocol/v1_0/Message_1_0.java
@@ -55,6 +55,8 @@ public class Message_1_0 extends AbstractServerMessageImpl<Message_1_0, MessageM
                                                                                                       .registerSecurityLayer();
     private static final MessageMetaData_1_0 DELETED_MESSAGE_METADATA = new MessageMetaData_1_0(null, null, null, null, null, null, 0L, 0L);
     private static final String AMQP_1_0 = "AMQP 1.0";
+    private static final SectionDecoder SECTION_DECODER =
+            new SectionDecoderImpl(DESCRIBED_TYPE_REGISTRY.getSectionDecoderRegistry());
 
     public Message_1_0(final StoredMessage<MessageMetaData_1_0> storedMessage)
     {
@@ -176,8 +178,6 @@ public class Message_1_0 extends AbstractServerMessageImpl<Message_1_0, MessageM
     {
         if(getMessageMetaData().getVersion() == 0)
         {
-            SectionDecoder sectionDecoder = new SectionDecoderImpl(DESCRIBED_TYPE_REGISTRY.getSectionDecoderRegistry());
-
             try
             {
                 List<EncodingRetainingSection<?>> sections;
@@ -185,7 +185,7 @@ public class Message_1_0 extends AbstractServerMessageImpl<Message_1_0, MessageM
                 // not just #getSize()
                 try (QpidByteBuffer allSectionsContent = super.getContent(0, Integer.MAX_VALUE))
                 {
-                    sections = sectionDecoder.parseAll(allSectionsContent);
+                    sections = SECTION_DECODER.parseAll(allSectionsContent);
                 }
                 List<QpidByteBuffer> bodySectionContent = new ArrayList<>();
 

--- a/broker-plugins/amqp-1-0-protocol/src/main/java/org/apache/qpid/server/protocol/v1_0/ProtocolEngineCreator_1_0_0.java
+++ b/broker-plugins/amqp-1-0-protocol/src/main/java/org/apache/qpid/server/protocol/v1_0/ProtocolEngineCreator_1_0_0.java
@@ -33,6 +33,7 @@ import org.apache.qpid.server.model.Transport;
 import org.apache.qpid.server.model.port.AmqpPort;
 import org.apache.qpid.server.plugin.PluggableService;
 import org.apache.qpid.server.plugin.ProtocolEngineCreator;
+import org.apache.qpid.server.protocol.v1_0.constants.Bytes;
 import org.apache.qpid.server.transport.ProtocolEngine;
 import org.apache.qpid.server.security.auth.manager.AnonymousAuthenticationManager;
 import org.apache.qpid.server.security.auth.manager.ExternalAuthenticationManagerImpl;
@@ -44,17 +45,6 @@ public class ProtocolEngineCreator_1_0_0 implements ProtocolEngineCreator
 {
     private static final Logger LOGGER = LoggerFactory.getLogger(ProtocolEngineCreator_1_0_0.class);
 
-    private static final byte[] AMQP_1_0_0_HEADER =
-            new byte[] { (byte) 'A',
-                         (byte) 'M',
-                         (byte) 'Q',
-                         (byte) 'P',
-                         (byte) 0,
-                         (byte) 1,
-                         (byte) 0,
-                         (byte) 0
-            };
-
     public ProtocolEngineCreator_1_0_0()
     {
     }
@@ -65,11 +55,15 @@ public class ProtocolEngineCreator_1_0_0 implements ProtocolEngineCreator
         return Protocol.AMQP_1_0;
     }
 
-
+    /**
+     * Returns a AMQP header shared array instance to avoid per-call allocation.
+     * The returned array must be treated as immutable and must not be modified by callers.
+     * @return AMQP header byte array
+     */
     @Override
     public byte[] getHeaderIdentifier()
     {
-        return AMQP_1_0_0_HEADER;
+        return Bytes.amqpHeader();
     }
 
     @Override

--- a/broker-plugins/amqp-1-0-protocol/src/main/java/org/apache/qpid/server/protocol/v1_0/ProtocolEngineCreator_1_0_0_SASL.java
+++ b/broker-plugins/amqp-1-0-protocol/src/main/java/org/apache/qpid/server/protocol/v1_0/ProtocolEngineCreator_1_0_0_SASL.java
@@ -20,30 +20,20 @@
  */
 package org.apache.qpid.server.protocol.v1_0;
 
-import org.apache.qpid.server.transport.ProtocolEngine;
 import org.apache.qpid.server.model.Broker;
 import org.apache.qpid.server.model.Protocol;
 import org.apache.qpid.server.model.Transport;
 import org.apache.qpid.server.model.port.AmqpPort;
 import org.apache.qpid.server.plugin.PluggableService;
 import org.apache.qpid.server.plugin.ProtocolEngineCreator;
-import org.apache.qpid.server.transport.ServerNetworkConnection;
+import org.apache.qpid.server.protocol.v1_0.constants.Bytes;
 import org.apache.qpid.server.transport.AggregateTicker;
+import org.apache.qpid.server.transport.ProtocolEngine;
+import org.apache.qpid.server.transport.ServerNetworkConnection;
 
 @PluggableService
 public class ProtocolEngineCreator_1_0_0_SASL implements ProtocolEngineCreator
 {
-    private static final byte[] AMQP_SASL_1_0_0_HEADER =
-            new byte[] { (byte) 'A',
-                         (byte) 'M',
-                         (byte) 'Q',
-                         (byte) 'P',
-                         (byte) 3,
-                         (byte) 1,
-                         (byte) 0,
-                         (byte) 0
-            };
-
     public ProtocolEngineCreator_1_0_0_SASL()
     {
     }
@@ -54,11 +44,15 @@ public class ProtocolEngineCreator_1_0_0_SASL implements ProtocolEngineCreator
         return Protocol.AMQP_1_0;
     }
 
-
+    /**
+     * Returns a AMQP header shared array instance to avoid per-call allocation.
+     * The returned array must be treated as immutable and must not be modified by callers.
+     * @return AMQP header byte array
+     */
     @Override
     public byte[] getHeaderIdentifier()
     {
-        return AMQP_SASL_1_0_0_HEADER;
+        return Bytes.saslHeader();
     }
 
     @Override

--- a/broker-plugins/amqp-1-0-protocol/src/main/java/org/apache/qpid/server/protocol/v1_0/SendingLinkEndpoint.java
+++ b/broker-plugins/amqp-1-0-protocol/src/main/java/org/apache/qpid/server/protocol/v1_0/SendingLinkEndpoint.java
@@ -533,7 +533,7 @@ public class SendingLinkEndpoint extends AbstractLinkEndpoint<Source, Target>
 
         while(!_resumeAcceptedTransfers.isEmpty() && hasCreditToSend())
         {
-            Accepted accepted = new Accepted();
+            Accepted accepted = Accepted.INSTANCE;
             Transfer xfr = new Transfer();
             Binary dt = _resumeAcceptedTransfers.remove(0);
             xfr.setDeliveryTag(dt);

--- a/broker-plugins/amqp-1-0-protocol/src/main/java/org/apache/qpid/server/protocol/v1_0/StandardReceivingLinkEndpoint.java
+++ b/broker-plugins/amqp-1-0-protocol/src/main/java/org/apache/qpid/server/protocol/v1_0/StandardReceivingLinkEndpoint.java
@@ -81,7 +81,7 @@ public class StandardReceivingLinkEndpoint extends AbstractReceivingLinkEndpoint
 {
     private static final Logger LOGGER = LoggerFactory.getLogger(StandardReceivingLinkEndpoint.class);
     private static final Symbol DELIVERY_TAG = Symbol.valueOf("delivery-tag");
-    private static final Accepted ACCEPTED = new Accepted();
+    private static final Accepted ACCEPTED = Accepted.INSTANCE;
     private static final String LINK = "link";
 
     private final java.util.Queue<AsyncCommand> _unfinishedCommandsQueue = new ConcurrentLinkedQueue<>();

--- a/broker-plugins/amqp-1-0-protocol/src/main/java/org/apache/qpid/server/protocol/v1_0/StandardSendingDestination.java
+++ b/broker-plugins/amqp-1-0-protocol/src/main/java/org/apache/qpid/server/protocol/v1_0/StandardSendingDestination.java
@@ -34,7 +34,7 @@ import org.apache.qpid.server.protocol.v1_0.type.messaging.Accepted;
 
 public class StandardSendingDestination implements SendingDestination
 {
-    private static final Accepted ACCEPTED = new Accepted();
+    private static final Accepted ACCEPTED = Accepted.INSTANCE;
     private static final Outcome[] OUTCOMES = new Outcome[] { ACCEPTED };
 
 

--- a/broker-plugins/amqp-1-0-protocol/src/main/java/org/apache/qpid/server/protocol/v1_0/TxnCoordinatorReceivingLinkEndpoint.java
+++ b/broker-plugins/amqp-1-0-protocol/src/main/java/org/apache/qpid/server/protocol/v1_0/TxnCoordinatorReceivingLinkEndpoint.java
@@ -119,7 +119,7 @@ public class TxnCoordinatorReceivingLinkEndpoint extends AbstractReceivingLinkEn
                             final DeliveryState outcome;
                             if (error == null)
                             {
-                                outcome = new Accepted();
+                                outcome = Accepted.INSTANCE;
                             }
                             else if (CollectionUtils.nullSafeList(getSource().getOutcomes()).contains(Rejected.REJECTED_SYMBOL))
                             {

--- a/broker-plugins/amqp-1-0-protocol/src/main/java/org/apache/qpid/server/protocol/v1_0/codec/FrameWriter.java
+++ b/broker-plugins/amqp-1-0-protocol/src/main/java/org/apache/qpid/server/protocol/v1_0/codec/FrameWriter.java
@@ -30,7 +30,6 @@ public class FrameWriter
 {
     private final ByteBufferSender _sender;
     private final ValueWriter.Registry _registry;
-    private static final byte[] EMPTY_BYTE_ARRAY = new byte[] {};
 
     public FrameWriter(final ValueWriter.Registry registry, final ByteBufferSender sender)
     {
@@ -45,7 +44,18 @@ public class FrameWriter
         final int payloadLength = payload == null ? 0 : payload.remaining();
         final T frameBody = frame.getFrameBody();
 
-        final ValueWriter<T> typeWriter = frameBody == null ? null : _registry.getValueWriter(frameBody);
+        final ValueWriter<T> typeWriter;
+
+        if (frameBody == null)
+        {
+            typeWriter = null;
+        }
+        else
+        {
+            final ValueWriter<T> cachedWriter = frame.getFrameBodyWriter();
+            typeWriter = cachedWriter == null ? _registry.getValueWriter(frameBody) : cachedWriter;
+        }
+
         int bodySize;
         if (typeWriter == null)
         {

--- a/broker-plugins/amqp-1-0-protocol/src/main/java/org/apache/qpid/server/protocol/v1_0/codec/ValueHandler.java
+++ b/broker-plugins/amqp-1-0-protocol/src/main/java/org/apache/qpid/server/protocol/v1_0/codec/ValueHandler.java
@@ -25,6 +25,7 @@ import org.apache.qpid.server.protocol.v1_0.type.AmqpErrorException;
 import org.apache.qpid.server.protocol.v1_0.type.transport.AmqpError;
 import org.apache.qpid.server.protocol.v1_0.type.transport.ConnectionError;
 
+/** {@link ValueHandler} is thread safe */
 public class ValueHandler implements DescribedTypeConstructorRegistry.Source
 {
     public static final byte DESCRIBED_TYPE = (byte)0;

--- a/broker-plugins/amqp-1-0-protocol/src/main/java/org/apache/qpid/server/protocol/v1_0/constants/Bytes.java
+++ b/broker-plugins/amqp-1-0-protocol/src/main/java/org/apache/qpid/server/protocol/v1_0/constants/Bytes.java
@@ -1,0 +1,62 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package org.apache.qpid.server.protocol.v1_0.constants;
+
+/** Utility class holding frequently used byte arrays */
+public final class Bytes
+{
+    private Bytes()
+    {
+        // constructor is private for utility class
+    }
+
+    /** AMQP header byte array representation  */
+    private static final byte[] AMQP_HEADER_BYTES = { (byte) 'A', (byte) 'M', (byte) 'Q', (byte) 'P',
+            (byte) 0, (byte) 1, (byte) 0, (byte) 0 };
+
+    /** Empty byte array  */
+    public static final byte[] EMPTY_BYTE_ARRAY = { };
+
+    /** SASL header byte array representation  */
+    private static final byte[] SASL_HEADER_BYTES = { (byte) 'A', (byte) 'M', (byte) 'Q', (byte) 'P',
+            (byte) 3, (byte) 1, (byte) 0, (byte) 0 };
+
+    /**
+     * Returns a AMQP header shared array instance to avoid per-call allocation.
+     * The returned array must be treated as immutable and must not be modified by callers.
+     * @return AMQP header byte array
+     */
+    public static byte[] amqpHeader()
+    {
+        return AMQP_HEADER_BYTES;
+    }
+
+    /**
+     * Returns a SASL header shared array instance to avoid per-call allocation.
+     * The returned array must be treated as immutable and must not be modified by callers.
+     * @return SASL header byte array
+     */
+    public static byte[] saslHeader()
+    {
+        return SASL_HEADER_BYTES;
+    }
+}

--- a/broker-plugins/amqp-1-0-protocol/src/main/java/org/apache/qpid/server/protocol/v1_0/framing/TransportFrame.java
+++ b/broker-plugins/amqp-1-0-protocol/src/main/java/org/apache/qpid/server/protocol/v1_0/framing/TransportFrame.java
@@ -19,6 +19,8 @@
 package org.apache.qpid.server.protocol.v1_0.framing;
 
 import org.apache.qpid.server.bytebuffer.QpidByteBuffer;
+import org.apache.qpid.server.protocol.v1_0.codec.FrameWriter;
+import org.apache.qpid.server.protocol.v1_0.codec.ValueWriter;
 import org.apache.qpid.server.protocol.v1_0.type.FrameBody;
 
 public final class TransportFrame extends AMQFrame<FrameBody>
@@ -27,15 +29,57 @@ public final class TransportFrame extends AMQFrame<FrameBody>
 
     private final int _channel;
 
+    /**
+     * Base Transport frame.
+     * @param channel channel
+     * @param frameBody frame body (may be null for heartbeat-like frames)
+     */
     public TransportFrame(int channel, FrameBody frameBody)
     {
         super(frameBody);
         _channel = channel;
     }
 
+    /**
+     * Base Transport frame.
+     * @param channel channel
+     * @param frameBody frame body (may be null for heartbeat-like frames)
+     * @param frameBodyWriter  optional cached writer for {@code frameBody}.
+     * Use only when the writer was resolved for this exact instance/state of {@code frameBody}
+     * and the body will not be mutated afterwards; otherwise pass null and let {@link FrameWriter}
+     * resolve the writer from the registry.
+     */
+    public TransportFrame(int channel, FrameBody frameBody, ValueWriter<FrameBody> frameBodyWriter)
+    {
+        super(frameBody, null, frameBodyWriter);
+        _channel = channel;
+    }
+
+    /**
+     * Base Transport frame.
+     * @param channel channel
+     * @param frameBody frame body (may be null for heartbeat-like frames)
+     * @param payload optional payload; remaining bytes will be written
+     */
     public TransportFrame(int channel, FrameBody frameBody, QpidByteBuffer payload)
     {
         super(frameBody, payload);
+        _channel = channel;
+    }
+
+    /**
+     * Base Transport frame.
+     * @param channel channel
+     * @param frameBody frame body (may be null for heartbeat-like frames)
+     * @param payload optional payload; remaining bytes will be written
+     * @param frameBodyWriter  optional cached writer for {@code frameBody}.
+     * Use only when the writer was resolved for this exact instance/state of {@code frameBody}
+     * and the body will not be mutated afterwards; otherwise pass null and let {@link FrameWriter}
+     * resolve the writer from the registry.
+     */
+    public TransportFrame(int channel, FrameBody frameBody, QpidByteBuffer payload, ValueWriter<FrameBody> frameBodyWriter)
+    {
+        super(frameBody, payload, frameBodyWriter);
         _channel = channel;
     }
 

--- a/broker-plugins/amqp-1-0-protocol/src/main/java/org/apache/qpid/server/protocol/v1_0/messaging/SectionDecoderImpl.java
+++ b/broker-plugins/amqp-1-0-protocol/src/main/java/org/apache/qpid/server/protocol/v1_0/messaging/SectionDecoderImpl.java
@@ -29,6 +29,7 @@ import org.apache.qpid.server.protocol.v1_0.type.AmqpErrorException;
 import org.apache.qpid.server.protocol.v1_0.type.messaging.EncodingRetainingSection;
 import org.apache.qpid.server.protocol.v1_0.type.transport.AmqpError;
 
+/** {@link SectionDecoderImpl} is thread safe */
 public class SectionDecoderImpl implements SectionDecoder
 {
 

--- a/broker-plugins/amqp-1-0-protocol/src/main/java/org/apache/qpid/server/protocol/v1_0/type/Binary.java
+++ b/broker-plugins/amqp-1-0-protocol/src/main/java/org/apache/qpid/server/protocol/v1_0/type/Binary.java
@@ -40,6 +40,20 @@ public class Binary
         _hashCode = hc;
     }
 
+    public static Binary ofDeliveryTag(final long value)
+    {
+        final byte[] data = new byte[8];
+        data[0] = (byte) (value >>> 56);
+        data[1] = (byte) (value >>> 48);
+        data[2] = (byte) (value >>> 40);
+        data[3] = (byte) (value >>> 32);
+        data[4] = (byte) (value >>> 24);
+        data[5] = (byte) (value >>> 16);
+        data[6] = (byte) (value >>> 8);
+        data[7] = (byte) value;
+        return new Binary(data);
+    }
+
     public ByteBuffer asByteBuffer()
     {
         return ByteBuffer.wrap(_data);

--- a/broker-plugins/amqp-1-0-protocol/src/main/java/org/apache/qpid/server/protocol/v1_0/type/codec/AMQPDescribedTypeRegistry.java
+++ b/broker-plugins/amqp-1-0-protocol/src/main/java/org/apache/qpid/server/protocol/v1_0/type/codec/AMQPDescribedTypeRegistry.java
@@ -69,8 +69,9 @@ import org.apache.qpid.server.protocol.v1_0.type.transport.codec.*;
 
 public class AMQPDescribedTypeRegistry implements DescribedTypeConstructorRegistry, ValueWriter.Registry
 {
-
+    /** Is initialized once during startup, treated as read-only afterward */
     private final Map<Object, DescribedTypeConstructor> _constructorRegistry = new HashMap<>();
+    /** Is initialized once during startup, treated as read-only afterward */
     private final Map<Object, DescribedTypeConstructor> _sectionDecoderRegistryMap = new HashMap<>();
 
 

--- a/broker-plugins/amqp-1-0-protocol/src/main/java/org/apache/qpid/server/protocol/v1_0/type/messaging/Accepted.java
+++ b/broker-plugins/amqp-1-0-protocol/src/main/java/org/apache/qpid/server/protocol/v1_0/type/messaging/Accepted.java
@@ -31,6 +31,7 @@ import org.apache.qpid.server.protocol.v1_0.type.Symbol;
 public class Accepted implements Outcome
 {
     public static final Symbol ACCEPTED_SYMBOL = Symbol.valueOf("amqp:accepted:list");
+    public static final Accepted INSTANCE = new Accepted();
 
     @Override
     public Symbol getSymbol()

--- a/broker-plugins/amqp-1-0-protocol/src/main/java/org/apache/qpid/server/protocol/v1_0/type/messaging/AmqpValue.java
+++ b/broker-plugins/amqp-1-0-protocol/src/main/java/org/apache/qpid/server/protocol/v1_0/type/messaging/AmqpValue.java
@@ -45,7 +45,7 @@ public class AmqpValue implements NonEncodingRetainingSection<Object>
     @Override
     public String toString()
     {
-        return "AmqpValue{(" + _value.getClass().getName() + ')' + _value + '}';
+        return "AmqpValue{(" + (_value == null ? "null" : _value.getClass().getName()) + ')' + _value + '}';
     }
 
 

--- a/broker-plugins/amqp-1-0-protocol/src/main/java/org/apache/qpid/server/protocol/v1_0/type/transport/Transfer.java
+++ b/broker-plugins/amqp-1-0-protocol/src/main/java/org/apache/qpid/server/protocol/v1_0/type/transport/Transfer.java
@@ -295,6 +295,12 @@ public class Transfer implements FrameBody
         conn.receiveTransfer(channel, this);
     }
 
+    public int getPayloadRemaining()
+    {
+        final QpidByteBuffer payload = _payload;
+        return payload == null ? 0 : payload.remaining();
+    }
+
     public QpidByteBuffer getPayload()
     {
         if (_payload == null)

--- a/broker-plugins/amqp-1-0-protocol/src/test/java/org/apache/qpid/server/protocol/v1_0/ConsumerTarget_1_0Test.java
+++ b/broker-plugins/amqp-1-0-protocol/src/test/java/org/apache/qpid/server/protocol/v1_0/ConsumerTarget_1_0Test.java
@@ -20,7 +20,11 @@
  */
 package org.apache.qpid.server.protocol.v1_0;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
@@ -36,7 +40,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.junit.jupiter.api.BeforeAll;
+import org.apache.qpid.server.protocol.v1_0.type.Binary;
+import org.apache.qpid.server.protocol.v1_0.type.UnsignedByte;
+import org.apache.qpid.server.protocol.v1_0.type.messaging.Data;
+import org.apache.qpid.server.protocol.v1_0.type.messaging.DataSection;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import org.apache.qpid.server.bytebuffer.QpidByteBuffer;
@@ -75,7 +83,7 @@ class ConsumerTarget_1_0Test extends UnitTestBase
     private ConsumerTarget_1_0 _consumerTarget;
     private SendingLinkEndpoint _sendingLinkEndpoint;
 
-    @BeforeAll
+    @BeforeEach
     void setUp()
     {
         final AMQPConnection_1_0 connection = mock(AMQPConnection_1_0.class);
@@ -110,9 +118,7 @@ class ConsumerTarget_1_0Test extends UnitTestBase
         {
             final Object[] args = invocation.getArguments();
             final Transfer transfer = (Transfer) args[0];
-
             final QpidByteBuffer transferPayload = transfer.getPayload();
-
             final QpidByteBuffer payloadCopy = transferPayload.duplicate();
             payloadRef.set(payloadCopy);
             return null;
@@ -137,8 +143,8 @@ class ConsumerTarget_1_0Test extends UnitTestBase
         }
 
         assertNotNull(sentHeader, "Header is not found");
-        assertNotNull(sentHeader.getTtl(), "Ttl is not set");
-        assertTrue(sentHeader.getTtl().longValue() <= 1000, "Unexpected ttl");
+        assertNotNull(sentHeader.getTtl(), "TTL is not set");
+        assertTrue(sentHeader.getTtl().longValue() <= 1000, "Unexpected TTL");
     }
 
     private Message_1_0 createTestMessage(final Header header, long arrivalTime)
@@ -162,6 +168,255 @@ class ConsumerTarget_1_0Test extends UnitTestBase
         final StoredMessage<MessageMetaData_1_0> storedMessage = mock(StoredMessage.class);
         when(storedMessage.getContent(eq(0), anyInt())).thenReturn(QpidByteBuffer.emptyQpidByteBuffer());
         when(storedMessage.getMetaData()).thenReturn(metaData);
+        return new Message_1_0(storedMessage);
+    }
+
+    @Test
+    void bodyOnlyMessageIsSentAsSingleDataSection() throws Exception
+    {
+        final MessageInstanceConsumer consumer = mock(MessageInstanceConsumer.class);
+        final byte[] body = new byte[]{10, 11, 12};
+        final Message_1_0 message = createBodyOnlyMessage(body);
+
+        final MessageInstance messageInstance = mock(MessageInstance.class);
+        when(messageInstance.getMessage()).thenReturn(message);
+        when(messageInstance.getDeliveryCount()).thenReturn(0);
+
+        final AtomicReference<QpidByteBuffer> payloadRef = new AtomicReference<>();
+        doAnswer(invocation ->
+        {
+            final Transfer transfer = (Transfer) invocation.getArguments()[0];
+            try (QpidByteBuffer transferPayload = transfer.getPayload())
+            {
+                payloadRef.set(transferPayload == null ? null : transferPayload.duplicate());
+            }
+            return null;
+        }).when(_sendingLinkEndpoint).transfer(any(Transfer.class), anyBoolean());
+
+        _consumerTarget.doSend(consumer, messageInstance, false);
+
+        try (final QpidByteBuffer payload = payloadRef.get())
+        {
+            final List<EncodingRetainingSection<?>> sections =
+                    new SectionDecoderImpl(AMQP_DESCRIBED_TYPE_REGISTRY.getSectionDecoderRegistry()).parseAll(payload);
+
+            assertEquals(1, sections.size());
+            assertInstanceOf(DataSection.class, sections.get(0));
+            final DataSection dataSection = (DataSection) sections.get(0);
+            assertArrayEquals(body, dataSection.getValue().getArray());
+            sections.forEach(EncodingRetainingSection::dispose);
+        }
+    }
+
+    @Test
+    void headerAndBodyOnlyMessageIncludesHeaderSection() throws Exception
+    {
+        final MessageInstanceConsumer consumer = mock(MessageInstanceConsumer.class);
+        final byte[] body = new byte[]{1, 2, 3, 4};
+
+        final Header header = new Header();
+        header.setDurable(true);
+        header.setPriority(UnsignedByte.valueOf((byte) 7));
+
+        final Message_1_0 message = createHeaderAndBodyOnlyMessage(header, body, System.currentTimeMillis());
+
+        final MessageInstance messageInstance = mock(MessageInstance.class);
+        when(messageInstance.getMessage()).thenReturn(message);
+        when(messageInstance.getDeliveryCount()).thenReturn(0);
+
+        final AtomicReference<QpidByteBuffer> payloadRef = new AtomicReference<>();
+        doAnswer(invocation ->
+        {
+            final Transfer transfer = (Transfer) invocation.getArguments()[0];
+            try (QpidByteBuffer transferPayload = transfer.getPayload())
+            {
+                payloadRef.set(transferPayload == null ? null : transferPayload.duplicate());
+            }
+            return null;
+        }).when(_sendingLinkEndpoint).transfer(any(Transfer.class), anyBoolean());
+
+        _consumerTarget.doSend(consumer, messageInstance, false);
+
+        try (final QpidByteBuffer payload = payloadRef.get())
+        {
+            final List<EncodingRetainingSection<?>> sections =
+                    new SectionDecoderImpl(AMQP_DESCRIBED_TYPE_REGISTRY.getSectionDecoderRegistry()).parseAll(payload);
+
+            assertEquals(2, sections.size(), "Unexpected number of sections");
+
+            Header sentHeader = null;
+            Binary sentBody = null;
+            for (final EncodingRetainingSection<?> section : sections)
+            {
+                if (section instanceof HeaderSection)
+                {
+                    sentHeader = ((HeaderSection) section).getValue();
+                }
+                else if (section instanceof DataSection)
+                {
+                    sentBody = ((DataSection) section).getValue();
+                }
+            }
+
+            assertNotNull(sentHeader, "Header is not found");
+            assertEquals(Boolean.TRUE, sentHeader.getDurable());
+            assertEquals(UnsignedInteger.valueOf(7).intValue(), sentHeader.getPriority().intValue());
+            assertNotNull(sentBody, "Body is not found");
+            assertArrayEquals(body, sentBody.getArray());
+
+            sections.forEach(EncodingRetainingSection::dispose);
+        }
+    }
+
+    @Test
+    void deliveryCountAndTtlAreAppliedForHeaderAndBodyOnlyMessage() throws Exception
+    {
+        final MessageInstanceConsumer consumer = mock(MessageInstanceConsumer.class);
+        final byte[] body = new byte[]{10, 20, 30};
+
+        final long ttl = 2000L;
+        final long arrivalTime = System.currentTimeMillis() - 1000L;
+
+        final Header header = new Header();
+        header.setTtl(UnsignedInteger.valueOf(ttl));
+
+        final Message_1_0 message = createHeaderAndBodyOnlyMessage(header, body, arrivalTime);
+
+        final int deliveryCount = 5;
+        final MessageInstance messageInstance = mock(MessageInstance.class);
+        when(messageInstance.getMessage()).thenReturn(message);
+        when(messageInstance.getDeliveryCount()).thenReturn(deliveryCount);
+
+        final AtomicReference<QpidByteBuffer> payloadRef = new AtomicReference<>();
+        doAnswer(invocation ->
+        {
+            final Transfer transfer = (Transfer) invocation.getArguments()[0];
+            try (QpidByteBuffer transferPayload = transfer.getPayload())
+            {
+                payloadRef.set(transferPayload == null ? null : transferPayload.duplicate());
+            }
+            return null;
+        }).when(_sendingLinkEndpoint).transfer(any(Transfer.class), anyBoolean());
+
+        _consumerTarget.doSend(consumer, messageInstance, false);
+
+        final List<EncodingRetainingSection<?>> sections;
+        try (final QpidByteBuffer payload = payloadRef.get())
+        {
+            sections = new SectionDecoderImpl(AMQP_DESCRIBED_TYPE_REGISTRY.getSectionDecoderRegistry()).parseAll(payload);
+        }
+
+        Header sentHeader = null;
+        Binary sentBody = null;
+        for (final EncodingRetainingSection<?> section : sections)
+        {
+            if (section instanceof HeaderSection)
+            {
+                sentHeader = ((HeaderSection) section).getValue();
+            }
+            else if (section instanceof DataSection)
+            {
+                sentBody = ((DataSection) section).getValue();
+            }
+        }
+
+        assertNotNull(sentHeader, "Header is not found");
+        assertEquals(UnsignedInteger.valueOf(deliveryCount), sentHeader.getDeliveryCount(), "Delivery count not set");
+        assertNotNull(sentHeader.getTtl(), "TTL is not set");
+        assertTrue(sentHeader.getTtl().longValue() <= 1000, "Unexpected TTL");
+
+        assertNotNull(sentBody, "Body is not found");
+        assertArrayEquals(body, sentBody.getArray());
+
+        sections.forEach(EncodingRetainingSection::dispose);
+    }
+
+    @Test
+    void nullBodyContentDoesNotSetPayloadAndDoesNotThrow()
+    {
+        final MessageInstanceConsumer consumer = mock(MessageInstanceConsumer.class);
+        final Message_1_0 message = mock(Message_1_0.class);
+        when(message.getContent()).thenReturn(null);
+        when(message.getHeaderSection()).thenReturn(null);
+        when(message.getDeliveryAnnotationsSection()).thenReturn(null);
+        when(message.getMessageAnnotationsSection()).thenReturn(null);
+        when(message.getPropertiesSection()).thenReturn(null);
+        when(message.getApplicationPropertiesSection()).thenReturn(null);
+        when(message.getFooterSection()).thenReturn(null);
+        when(message.getSize()).thenReturn(0L);
+
+        final MessageInstance messageInstance = mock(MessageInstance.class);
+        when(messageInstance.getMessage()).thenReturn(message);
+        when(messageInstance.getDeliveryCount()).thenReturn(0);
+
+        final AtomicReference<QpidByteBuffer> payloadRef = new AtomicReference<>();
+        doAnswer(invocation ->
+        {
+            final Transfer transfer = (Transfer) invocation.getArguments()[0];
+            payloadRef.set(transfer.getPayload());
+            return null;
+        }).when(_sendingLinkEndpoint).transfer(any(Transfer.class), anyBoolean());
+
+        _consumerTarget.doSend(consumer, messageInstance, false);
+
+        assertNull(payloadRef.get(), "Payload must remain null when body content is null");
+    }
+
+    private Message_1_0 createHeaderAndBodyOnlyMessage(final Header header, final byte[] body, final long arrivalTime)
+    {
+        final DataSection dataSection = new Data(new Binary(body)).createEncodingRetainingSection();
+        final byte[] encodedBody;
+        try (final QpidByteBuffer encoded = dataSection.getEncodedForm())
+        {
+            encodedBody = new byte[encoded.remaining()];
+            encoded.copyTo(encodedBody);
+        }
+        finally
+        {
+            dataSection.dispose();
+        }
+
+        final StoredMessage<MessageMetaData_1_0> storedMessage = mock(StoredMessage.class);
+        when(storedMessage.getMetaData()).thenReturn(new MessageMetaData_1_0(
+                header.createEncodingRetainingSection(), null, null, null, null, null, arrivalTime, encodedBody.length));
+        when(storedMessage.getContentSize()).thenReturn(encodedBody.length);
+        when(storedMessage.isInContentInMemory()).thenReturn(true);
+        when(storedMessage.getContent(anyInt(), anyInt())).thenAnswer(inv ->
+        {
+            final int offset = inv.getArgument(0);
+            final int length = inv.getArgument(1);
+            return QpidByteBuffer.wrap(encodedBody, offset, length);
+        });
+
+        return new Message_1_0(storedMessage);
+    }
+
+    private Message_1_0 createBodyOnlyMessage(final byte[] body)
+    {
+        final DataSection dataSection = new Data(new Binary(body)).createEncodingRetainingSection();
+        final byte[] encodedBody;
+        try (final QpidByteBuffer encoded = dataSection.getEncodedForm())
+        {
+            encodedBody = new byte[encoded.remaining()];
+            encoded.copyTo(encodedBody);
+        }
+        finally
+        {
+            dataSection.dispose();
+        }
+
+        final StoredMessage<MessageMetaData_1_0> storedMessage = mock(StoredMessage.class);
+        when(storedMessage.getMetaData()).thenReturn(new MessageMetaData_1_0(
+                null, null, null, null, null, null, System.currentTimeMillis(), encodedBody.length));
+        when(storedMessage.getContentSize()).thenReturn(encodedBody.length);
+        when(storedMessage.isInContentInMemory()).thenReturn(true);
+        when(storedMessage.getContent(anyInt(), anyInt())).thenAnswer(inv ->
+        {
+            final int offset = inv.getArgument(0);
+            final int length = inv.getArgument(1);
+            return QpidByteBuffer.wrap(encodedBody, offset, length);
+        });
+
         return new Message_1_0(storedMessage);
     }
 }

--- a/broker-plugins/amqp-1-0-protocol/src/test/java/org/apache/qpid/server/protocol/v1_0/DeliveryTest.java
+++ b/broker-plugins/amqp-1-0-protocol/src/test/java/org/apache/qpid/server/protocol/v1_0/DeliveryTest.java
@@ -1,0 +1,118 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package org.apache.qpid.server.protocol.v1_0;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+
+import org.junit.jupiter.api.Test;
+
+import org.apache.qpid.server.bytebuffer.QpidByteBuffer;
+import org.apache.qpid.server.protocol.v1_0.type.BaseSource;
+import org.apache.qpid.server.protocol.v1_0.type.BaseTarget;
+import org.apache.qpid.server.protocol.v1_0.type.Binary;
+import org.apache.qpid.server.protocol.v1_0.type.UnsignedInteger;
+import org.apache.qpid.server.protocol.v1_0.type.transport.Transfer;
+import org.apache.qpid.test.utils.UnitTestBase;
+
+class DeliveryTest extends UnitTestBase
+{
+    @Test
+    void singleTransferPayloadIsReturnedAndSizeIsCounted()
+    {
+        final byte[] bytes = new byte[]{1, 2, 3, 4};
+        final Transfer t = new Transfer();
+        t.setDeliveryId(UnsignedInteger.valueOf(1));
+        t.setDeliveryTag(new Binary(new byte[]{0x01}));
+
+        try (final QpidByteBuffer buf = QpidByteBuffer.wrap(bytes))
+        {
+            t.setPayload(buf);
+        }
+
+        final LinkEndpoint<? extends BaseSource, ? extends BaseTarget> endpoint = mock(LinkEndpoint.class);
+        final Delivery delivery = new Delivery(t, endpoint);
+
+        assertEquals(4L, delivery.getTotalPayloadSize());
+
+        try (final QpidByteBuffer payload = delivery.getPayload())
+        {
+            final byte[] actual = new byte[payload.remaining()];
+            payload.copyTo(actual);
+            assertArrayEquals(bytes, actual);
+        }
+    }
+
+    @Test
+    void singleTransferWithNullPayloadReturnsEmptyBuffer()
+    {
+        final Transfer t = new Transfer();
+        t.setDeliveryId(UnsignedInteger.valueOf(1));
+        t.setDeliveryTag(new Binary(new byte[]{0x01}));
+
+        final LinkEndpoint<? extends BaseSource, ? extends BaseTarget> endpoint = mock(LinkEndpoint.class);
+        final Delivery delivery = new Delivery(t, endpoint);
+
+        assertEquals(0L, delivery.getTotalPayloadSize());
+
+        try (final QpidByteBuffer payload = delivery.getPayload())
+        {
+            assertEquals(0, payload.remaining());
+        }
+    }
+
+    @Test
+    void multipleTransfersAreConcatenatedAndSizeIsSum()
+    {
+        final LinkEndpoint<? extends BaseSource, ? extends BaseTarget> endpoint = mock(LinkEndpoint.class);
+
+        final Transfer t1 = new Transfer();
+        t1.setDeliveryId(UnsignedInteger.valueOf(1));
+        t1.setDeliveryTag(new Binary(new byte[]{0x01}));
+        t1.setMore(true);
+        try (final QpidByteBuffer buf = QpidByteBuffer.wrap(new byte[]{1, 2}))
+        {
+            t1.setPayload(buf);
+        }
+
+        final Delivery delivery = new Delivery(t1, endpoint);
+
+        final Transfer t2 = new Transfer();
+        t2.setMore(false);
+        try (final QpidByteBuffer buf = QpidByteBuffer.wrap(new byte[]{3, 4, 5}))
+        {
+            t2.setPayload(buf);
+        }
+
+        delivery.addTransfer(t2);
+
+        assertEquals(5L, delivery.getTotalPayloadSize());
+
+        try (final QpidByteBuffer payload = delivery.getPayload())
+        {
+            final byte[] actual = new byte[payload.remaining()];
+            payload.copyTo(actual);
+            assertArrayEquals(new byte[]{1, 2, 3, 4, 5}, actual);
+        }
+    }
+}

--- a/broker-plugins/amqp-1-0-protocol/src/test/java/org/apache/qpid/server/protocol/v1_0/ProtocolEngineCreator_1_0_0Test.java
+++ b/broker-plugins/amqp-1-0-protocol/src/test/java/org/apache/qpid/server/protocol/v1_0/ProtocolEngineCreator_1_0_0Test.java
@@ -1,0 +1,65 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package org.apache.qpid.server.protocol.v1_0;
+
+import org.apache.qpid.server.model.Protocol;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ProtocolEngineCreator_1_0_0Test
+{
+    private static final byte[] ORIGINAL_AMQP_HEADER = { (byte) 'A', (byte) 'M', (byte) 'Q', (byte) 'P',
+            (byte) 0, (byte) 1, (byte) 0, (byte) 0 };
+
+    private static final byte[] ORIGINAL_SASL_HEADER = { (byte) 'A', (byte) 'M', (byte) 'Q', (byte) 'P',
+            (byte) 3, (byte) 1, (byte) 0, (byte) 0 };
+
+    @Test
+    void getHeaderIdentifier()
+    {
+        assertArrayEquals(ORIGINAL_AMQP_HEADER, ProtocolEngineCreator_1_0_0.getInstance().getHeaderIdentifier(),
+                "AMQP header should not be changed");
+    }
+
+    @Test
+    void getSuggestedAlternativeHeader()
+    {
+        assertArrayEquals(ORIGINAL_SASL_HEADER, ProtocolEngineCreator_1_0_0.getInstance().getSuggestedAlternativeHeader(),
+                "SASL header should not be changed");
+    }
+
+    @Test
+    void getVersion()
+    {
+        assertEquals(Protocol.AMQP_1_0, ProtocolEngineCreator_1_0_0.getInstance().getVersion(),
+                "Protocol version should be AMQP_1_0");
+    }
+
+    @Test
+    void getType()
+    {
+        assertEquals("AMQP_1_0", ProtocolEngineCreator_1_0_0.getInstance().getType(),
+                "Protocol version should be AMQP_1_0");
+    }
+}

--- a/broker-plugins/amqp-1-0-protocol/src/test/java/org/apache/qpid/server/protocol/v1_0/ProtocolEngineCreator_1_0_0_SASLTest.java
+++ b/broker-plugins/amqp-1-0-protocol/src/test/java/org/apache/qpid/server/protocol/v1_0/ProtocolEngineCreator_1_0_0_SASLTest.java
@@ -1,0 +1,63 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package org.apache.qpid.server.protocol.v1_0;
+
+import org.apache.qpid.server.model.Protocol;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class ProtocolEngineCreator_1_0_0_SASLTest
+{
+    private static final byte[] ORIGINAL_SASL_HEADER = { (byte) 'A', (byte) 'M', (byte) 'Q', (byte) 'P',
+            (byte) 3, (byte) 1, (byte) 0, (byte) 0 };
+
+    @Test
+    void getHeaderIdentifier()
+    {
+        assertArrayEquals(ORIGINAL_SASL_HEADER, ProtocolEngineCreator_1_0_0_SASL.getInstance().getHeaderIdentifier(),
+                "AMQP header should not be changed");
+    }
+
+    @Test
+    void getSuggestedAlternativeHeader()
+    {
+        assertNull(ProtocolEngineCreator_1_0_0_SASL.getInstance().getSuggestedAlternativeHeader(),
+                "No suggested alternative header expected");
+    }
+
+    @Test
+    void getVersion()
+    {
+        assertEquals(Protocol.AMQP_1_0, ProtocolEngineCreator_1_0_0_SASL.getInstance().getVersion(),
+                "Protocol version should be AMQP_1_0");
+    }
+
+    @Test
+    void getType()
+    {
+        assertEquals("AMQP_1_0", ProtocolEngineCreator_1_0_0_SASL.getInstance().getType(),
+                "Protocol version should be AMQP_1_0");
+    }
+}

--- a/broker-plugins/amqp-1-0-protocol/src/test/java/org/apache/qpid/server/protocol/v1_0/ProtocolEngine_1_0_0Test.java
+++ b/broker-plugins/amqp-1-0-protocol/src/test/java/org/apache/qpid/server/protocol/v1_0/ProtocolEngine_1_0_0Test.java
@@ -20,6 +20,7 @@
  */
 package org.apache.qpid.server.protocol.v1_0;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
@@ -40,6 +41,7 @@ import java.util.UUID;
 
 import javax.security.auth.Subject;
 
+import org.apache.qpid.server.protocol.v1_0.constants.Bytes;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -82,6 +84,12 @@ import org.apache.qpid.test.utils.UnitTestBase;
 @SuppressWarnings({"rawtypes"})
 class ProtocolEngine_1_0_0Test extends UnitTestBase
 {
+    private static final byte[] ORIGINAL_AMQP_HEADER = { (byte) 'A', (byte) 'M', (byte) 'Q', (byte) 'P',
+            (byte) 0, (byte) 1, (byte) 0, (byte) 0 };
+
+    private static final byte[] ORIGINAL_SASL_HEADER = { (byte) 'A', (byte) 'M', (byte) 'Q', (byte) 'P',
+            (byte) 3, (byte) 1, (byte) 0, (byte) 0 };
+
     private AMQPConnection_1_0Impl _protocolEngine_1_0_0;
     private ServerNetworkConnection _networkConnection;
     private Broker<?> _broker;
@@ -197,6 +205,9 @@ class ProtocolEngine_1_0_0Test extends UnitTestBase
         final AuthenticatedPrincipal principal = (AuthenticatedPrincipal) _connection.getAuthorizedPrincipal();
         assertNotNull(principal);
         assertEquals(principal, new AuthenticatedPrincipal(anonymousAuthenticationManager.getAnonymousPrincipal()));
+
+        assertArrayEquals(ORIGINAL_AMQP_HEADER, Bytes.amqpHeader(), "AMQP header should not be changed");
+        assertArrayEquals(ORIGINAL_SASL_HEADER, Bytes.saslHeader(), "SASL header should not be changed");
     }
 
     @Test
@@ -214,6 +225,9 @@ class ProtocolEngine_1_0_0Test extends UnitTestBase
 
         verify(_virtualHost, never()).registerConnection(any(AMQPConnection.class));
         verify(_networkConnection).close();
+
+        assertArrayEquals(ORIGINAL_AMQP_HEADER, Bytes.amqpHeader(), "AMQP header should not be changed");
+        assertArrayEquals(ORIGINAL_SASL_HEADER, Bytes.saslHeader(), "SASL header should not be changed");
     }
 
     @Test
@@ -235,6 +249,9 @@ class ProtocolEngine_1_0_0Test extends UnitTestBase
         final AuthenticatedPrincipal authPrincipal = (AuthenticatedPrincipal) _connection.getAuthorizedPrincipal();
         assertNotNull(authPrincipal);
         assertEquals(authPrincipal, new AuthenticatedPrincipal(principal));
+
+        assertArrayEquals(ORIGINAL_AMQP_HEADER, Bytes.amqpHeader(), "AMQP header should not be changed");
+        assertArrayEquals(ORIGINAL_SASL_HEADER, Bytes.saslHeader(), "SASL header should not be changed");
     }
 
     @Test
@@ -269,6 +286,9 @@ class ProtocolEngine_1_0_0Test extends UnitTestBase
         final AuthenticatedPrincipal principal = (AuthenticatedPrincipal) _connection.getAuthorizedPrincipal();
         assertNotNull(principal);
         assertEquals(principal, new AuthenticatedPrincipal(anonymousAuthenticationManager.getAnonymousPrincipal()));
+
+        assertArrayEquals(ORIGINAL_AMQP_HEADER, Bytes.amqpHeader(), "AMQP header should not be changed");
+        assertArrayEquals(ORIGINAL_SASL_HEADER, Bytes.saslHeader(), "SASL header should not be changed");
     }
 
     private void createEngine(final Transport transport)


### PR DESCRIPTION
This PR addresses JIRA [QPID-8013](https://issues.apache.org/jira/browse/QPID-8013), addressing following issues:

1) ValueWriter can be optionally cached in AMQFrame. This would prevent repeated writer lookup
2) Continuation transfers in Session_1_0 can be optimized to not call continuationTransfer.setPayload() / continuationTransfer.dispose() . This will prevent buffer duplication and disposal.
3) Fast-path for "body only" case in ConsumerTarget_1_0 can be added
4) Fast-path for 0 / 1 transfers in Delivery can be added
5) SectionDecoderImpl can be cached
6) MessageConverter_from_1_0 / MessageConverter_to_1_0 can be optimized to avoid new objects creation
7) "Acceptance" outcome can be used as a singleton