### PR TITLE
QPID-8729: [Broker-J] Bump junit dependencies to the version 6.0.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -129,7 +129,7 @@
     <dgrid-version>1.3.3</dgrid-version>
 
     <!-- test dependency version numbers -->
-    <junit-version>6.0.2</junit-version>
+    <junit-version>6.0.3</junit-version>
     <mockito-version>5.21.0</mockito-version>
     <netty-version>4.2.9.Final</netty-version>
     <hamcrest-version>3.0</hamcrest-version>


### PR DESCRIPTION
This PR addresses JIRA [QPID-8729](https://issues.apache.org/jira/browse/QPID-8729), updating junit dependencies to the version 6.0.3