### PR TITLE
NO-JIRA: [Broker-J] Bump upload-artifact github action to the version 7

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,7 +62,7 @@ jobs:
 
       - name: Upload Test Logs On Failure
         if: failure()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: surefire-reports-jdk-${{ matrix.java }}
           path: surefire-reports-jdk-${{ matrix.java }}.tar.gz


### PR DESCRIPTION
This PR updates github action "upload-artifact" to the version 7