### PR TITLE
NO-JIRA: [Broker-J] Update appveyor maven to the version 3.9.14

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,14 +10,14 @@ environment:
 install:
   - ps: |
       Add-Type -AssemblyName System.IO.Compression.FileSystem
-      if (!(Test-Path -Path "C:\maven\apache-maven-3.9.12" )) {
+      if (!(Test-Path -Path "C:\maven\apache-maven-3.9.14" )) {
         (new-object System.Net.WebClient).DownloadFile(
-          'https://dlcdn.apache.org/maven/maven-3/3.9.12/binaries/apache-maven-3.9.12-bin.zip',
+          'https://dlcdn.apache.org/maven/maven-3/3.9.14/binaries/apache-maven-3.9.14-bin.zip',
           'C:\maven-bin.zip'
         )
         [System.IO.Compression.ZipFile]::ExtractToDirectory("C:\maven-bin.zip", "C:\maven")
       }
-  - cmd: SET PATH=C:\maven\apache-maven-3.9.12\bin;%JAVA_HOME%\bin;%PATH%
+  - cmd: SET PATH=C:\maven\apache-maven-3.9.14\bin;%JAVA_HOME%\bin;%PATH%
 
 build_script:
   - mvn clean install -B -DskipTests
@@ -46,4 +46,4 @@ on_finish:
       }
 
 cache:
-  - C:\maven\apache-maven-3.9.12
+  - C:\maven\apache-maven-3.9.14


### PR DESCRIPTION
This PR updates appveyor maven to the version 3.9.14