### PR TITLE
QPID-8733: [Broker-J] Bump fasterxml jackson dependencies to the version 3.1.2

### DIFF
--- a/apache-qpid-broker-j/src/main/assembly/dependency-verification/DEPENDENCIES_REFERENCE
+++ b/apache-qpid-broker-j/src/main/assembly/dependency-verification/DEPENDENCIES_REFERENCE
@@ -84,10 +84,10 @@ From: 'FasterXML' (http://fasterxml.com/)
   - Jackson-annotations (https://github.com/FasterXML/jackson) com.fasterxml.jackson.core:jackson-annotations:jar:2.21
     License: The Apache Software License, Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-  - Jackson-core (https://github.com/FasterXML/jackson-core) tools.jackson.core:jackson-core:jar:3.1.1
+  - Jackson-core (https://github.com/FasterXML/jackson-core) tools.jackson.core:jackson-core:jar:3.1.2
     License: The Apache Software License, Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-  - jackson-databind (https://github.com/FasterXML/jackson) tools.jackson.core:jackson-databind:jar:3.1.1
+  - jackson-databind (https://github.com/FasterXML/jackson) tools.jackson.core:jackson-databind:jar:3.1.2
     License: The Apache Software License, Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
 
 

--- a/perftests/src/main/assembly/dependency-verification/DEPENDENCIES_REFERENCE
+++ b/perftests/src/main/assembly/dependency-verification/DEPENDENCIES_REFERENCE
@@ -59,10 +59,10 @@ From: 'FasterXML' (http://fasterxml.com/)
   - Jackson-annotations (https://github.com/FasterXML/jackson) com.fasterxml.jackson.core:jackson-annotations:jar:2.21
     License: The Apache Software License, Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-  - Jackson-core (https://github.com/FasterXML/jackson-core) tools.jackson.core:jackson-core:jar:3.1.1
+  - Jackson-core (https://github.com/FasterXML/jackson-core) tools.jackson.core:jackson-core:jar:3.1.2
     License: The Apache Software License, Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-  - jackson-databind (https://github.com/FasterXML/jackson) tools.jackson.core:jackson-databind:jar:3.1.1
+  - jackson-databind (https://github.com/FasterXML/jackson) tools.jackson.core:jackson-databind:jar:3.1.2
     License: The Apache Software License, Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -108,8 +108,8 @@
     <logback-version>1.5.32</logback-version>
     <logback-db-version>1.2.11.1</logback-db-version>
     <caffeine-version>3.2.3</caffeine-version>
-    <fasterxml-jackson-version>3.1.1</fasterxml-jackson-version>
-    <fasterxml-jackson-databind-version>3.1.1</fasterxml-jackson-databind-version>
+    <fasterxml-jackson-version>3.1.2</fasterxml-jackson-version>
+    <fasterxml-jackson-databind-version>3.1.2</fasterxml-jackson-databind-version>
     <slf4j-version>2.0.17</slf4j-version>
     <jetty-version>12.1.7</jetty-version>
 


### PR DESCRIPTION
This PR addresses JIRA [QPID-8733](https://issues.apache.org/jira/browse/QPID-8733), updating fasterxml jackson dependencies to version 3.1.2