### PR TITLE
QPID-8741: [Broker-J] Bump logback-db dependency to the version 1.5.32

### DIFF
--- a/apache-qpid-broker-j/src/main/assembly/dependency-verification/DEPENDENCIES_REFERENCE
+++ b/apache-qpid-broker-j/src/main/assembly/dependency-verification/DEPENDENCIES_REFERENCE
@@ -116,13 +116,13 @@ From: 'QOS.ch' (http://www.qos.ch)
     License: Eclipse Public License - v 2.0  (https://www.eclipse.org/legal/epl-v20.html)
     License: GNU Lesser General Public License  (https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html)
 
-  - Logback DBAppender Classic Module (http://logback.qos.ch/logback-classic-db) ch.qos.logback.db:logback-classic-db:jar:1.2.11.1
-    License: Eclipse Public License - v 1.0  (http://www.eclipse.org/legal/epl-v10.html)
-    License: GNU Lesser General Public License  (http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html)
+  - Logback DBAppender Classic Module (http://logback.qos.ch/logback-classic-db) ch.qos.logback.db:logback-classic-db:jar:1.5.32
+    License: EPL-2.0  (https://www.eclipse.org/legal/epl-v20.html)
+    License: LGPL-2.1-only  (https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html)
 
-  - Logback DBAppender Core Module (http://logback.qos.ch/logback-core-db) ch.qos.logback.db:logback-core-db:jar:1.2.11.1
-    License: Eclipse Public License - v 1.0  (http://www.eclipse.org/legal/epl-v10.html)
-    License: GNU Lesser General Public License  (http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html)
+  - Logback DBAppender Core Module (http://logback.qos.ch/logback-core-db) ch.qos.logback.db:logback-core-db:jar:1.5.32
+    License: EPL-2.0  (https://www.eclipse.org/legal/epl-v20.html)
+    License: LGPL-2.1-only  (https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html)
 
   - SLF4J API Module (http://www.slf4j.org) org.slf4j:slf4j-api:jar:2.0.17
     License: MIT  (https://opensource.org/license/mit)

--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@
     <bdb-version>7.4.5</bdb-version>
     <derby-version>10.16.1.1</derby-version>
     <logback-version>1.5.32</logback-version>
-    <logback-db-version>1.2.11.1</logback-db-version>
+    <logback-db-version>1.5.32</logback-db-version>
     <caffeine-version>3.2.3</caffeine-version>
     <fasterxml-jackson-version>3.1.1</fasterxml-jackson-version>
     <fasterxml-jackson-databind-version>3.1.1</fasterxml-jackson-databind-version>


### PR DESCRIPTION
This PR addresses JIRA [QPID-8741](https://issues.apache.org/jira/browse/QPID-8741), updating logback-db version to 1.5.32