### PR TITLE
QPID-8729: [Broker-J] Maven plugins and test dependencies updates for version 10.0.2

### DIFF
--- a/perftests/src/main/assembly/dependency-verification/DEPENDENCIES_REFERENCE
+++ b/perftests/src/main/assembly/dependency-verification/DEPENDENCIES_REFERENCE
@@ -26,26 +26,11 @@ Apache Qpid Broker-J Performance Tests
 
 From: 'an unknown organization'
 
-  - resilience4j (https://resilience4j.readme.io) io.github.resilience4j:resilience4j-core:jar:2.3.0
+  - resilience4j (https://resilience4j.readme.io) io.github.resilience4j:resilience4j-core:jar:2.4.0
     License: Apache-2.0  (https://github.com/resilience4j/resilience4j/blob/master/LICENSE.txt)
 
-  - resilience4j (https://resilience4j.readme.io) io.github.resilience4j:resilience4j-ratelimiter:jar:2.3.0
+  - resilience4j (https://resilience4j.readme.io) io.github.resilience4j:resilience4j-ratelimiter:jar:2.4.0
     License: Apache-2.0  (https://github.com/resilience4j/resilience4j/blob/master/LICENSE.txt)
-
-  - IntelliJ IDEA Annotations (http://www.jetbrains.org) org.jetbrains:annotations:jar:13.0
-    License: The Apache Software License, Version 2.0  (http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-  - Kotlin Stdlib (https://kotlinlang.org/) org.jetbrains.kotlin:kotlin-stdlib:jar:1.9.0
-    License: The Apache License, Version 2.0  (http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-  - Kotlin Stdlib Common (https://kotlinlang.org/) org.jetbrains.kotlin:kotlin-stdlib-common:jar:1.9.0
-    License: The Apache License, Version 2.0  (http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-  - Kotlin Stdlib Jdk7 (https://kotlinlang.org/) org.jetbrains.kotlin:kotlin-stdlib-jdk7:jar:1.9.0
-    License: The Apache License, Version 2.0  (http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-  - Kotlin Stdlib Jdk8 (https://kotlinlang.org/) org.jetbrains.kotlin:kotlin-stdlib-jdk8:jar:1.9.0
-    License: The Apache License, Version 2.0  (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 
 From: 'Apache Software Foundation' (http://www.apache.org)
@@ -82,7 +67,7 @@ From: 'QOS.ch' (http://www.qos.ch)
 
 From: 'The Apache Software Foundation' (https://www.apache.org/)
 
-  - Apache HttpClient (https://hc.apache.org/httpcomponents-client-5.5.x/5.6/httpclient5/) org.apache.httpcomponents.client5:httpclient5:jar:5.6
+  - Apache HttpClient (https://hc.apache.org/httpcomponents-client-5.5.x/5.6.1/httpclient5/) org.apache.httpcomponents.client5:httpclient5:jar:5.6.1
     License: Apache License, Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
 
   - Apache HttpComponents Core HTTP/1.1 (https://hc.apache.org/httpcomponents-core-5.4.x/5.4/httpcore5/) org.apache.httpcomponents.core5:httpcore5:jar:5.4

--- a/pom.xml
+++ b/pom.xml
@@ -130,20 +130,20 @@
     <dgrid-version>1.3.3</dgrid-version>
 
     <!-- test dependency version numbers -->
-    <junit-version>6.0.3</junit-version>
+    <junit-version>6.1.0</junit-version>
     <mockito-version>5.23.0</mockito-version>
-    <netty-version>4.2.12.Final</netty-version>
+    <netty-version>4.2.15.Final</netty-version>
     <hamcrest-version>3.0</hamcrest-version>
     <maven-resolver-provider-version>3.8.6</maven-resolver-provider-version>
     <maven-resolver-version>1.9.22</maven-resolver-version>
-    <httpclient-version>5.6</httpclient-version>
+    <httpclient-version>5.6.1</httpclient-version>
     <qpid-jms-client-version>1.16.0</qpid-jms-client-version>
     <qpid-jms-client-amqp-0-x-version>6.4.0</qpid-jms-client-amqp-0-x-version>
     <nashorn-version>15.7</nashorn-version>
 
     <exec-maven-plugin-version>3.6.3</exec-maven-plugin-version>
     <javacc-maven-plugin-version>3.2.0</javacc-maven-plugin-version>
-    <maven-enforcer-plugin-version>3.6.2</maven-enforcer-plugin-version>
+    <maven-enforcer-plugin-version>3.6.3</maven-enforcer-plugin-version>
     <maven-rar-plugin-version>3.0.0</maven-rar-plugin-version>
     <license-maven-plugin-version>2.7.1</license-maven-plugin-version>
     <maven-jxr-plugin-version>3.6.0</maven-jxr-plugin-version>
@@ -155,8 +155,8 @@
     <buildnumber-maven-plugin-version>3.3.0</buildnumber-maven-plugin-version>
     <maven-compiler-plugin-version>3.15.0</maven-compiler-plugin-version>
     <maven-jar-plugin-version>3.5.0</maven-jar-plugin-version>
-    <maven-surefire-plugin-version>3.5.5</maven-surefire-plugin-version>
-    <maven-surefire-report-plugin-version>3.5.5</maven-surefire-report-plugin-version>
+    <maven-surefire-plugin-version>3.5.6</maven-surefire-plugin-version>
+    <maven-surefire-report-plugin-version>3.5.6</maven-surefire-report-plugin-version>
     <h2.version>2.4.240</h2.version>
     <apache-directory-version>2.0.0.AM27</apache-directory-version>
     <kerby-version>2.1.1</kerby-version>
@@ -164,7 +164,7 @@
     <bcpkix-version>1.84</bcpkix-version>
     <logback-gelf-version>6.1.1</logback-gelf-version>
     <prometheus-client-version>0.16.0</prometheus-client-version>
-    <resilience4j-version>2.3.0</resilience4j-version>
+    <resilience4j-version>2.4.0</resilience4j-version>
 
     <bdb-repo-enabled>false</bdb-repo-enabled>
   </properties>


### PR DESCRIPTION
This PR addresses JIRA [QPID-8729](https://issues.apache.org/jira/browse/QPID-8729), updating following test and plugin dependencies:

junit 6.0.3 => 6.1.0
netty 4.2.12.Final => 4.2.15.Final
httpclient 5.6 => 5.6.1
resilience4j 2.3.0 => 2.4.0

maven-enforcer-plugin 3.6.2 => 3.6.3
maven-surefire-plugin 3.5.5 => 3.5.6
maven-surefire-report-plugin 3.5.5 => 3.5.6