### PR TITLE
QPID-8730: [Broker-J] Bump logback dependencies to the version 1.5.34

### DIFF
--- a/apache-qpid-broker-j/src/main/assembly/dependency-verification/DEPENDENCIES_REFERENCE
+++ b/apache-qpid-broker-j/src/main/assembly/dependency-verification/DEPENDENCIES_REFERENCE
@@ -108,13 +108,13 @@ From: 'OW2' (http://www.ow2.org/)
 
 From: 'QOS.ch' (http://www.qos.ch)
 
-  - Logback Classic Module (http://logback.qos.ch/logback-classic) ch.qos.logback:logback-classic:jar:1.5.32
-    License: Eclipse Public License - v 2.0  (https://www.eclipse.org/legal/epl-v20.html)
-    License: GNU Lesser General Public License  (https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html)
+  - Logback Classic Module (http://logback.qos.ch/logback-classic) ch.qos.logback:logback-classic:jar:1.5.34
+    License: EPL-2.0  (https://www.eclipse.org/legal/epl-v20.html)
+    License: LGPL-2.1-only  (https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html)
 
-  - Logback Core Module (http://logback.qos.ch/logback-core) ch.qos.logback:logback-core:jar:1.5.32
-    License: Eclipse Public License - v 2.0  (https://www.eclipse.org/legal/epl-v20.html)
-    License: GNU Lesser General Public License  (https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html)
+  - Logback Core Module (http://logback.qos.ch/logback-core) ch.qos.logback:logback-core:jar:1.5.34
+    License: EPL-2.0  (https://www.eclipse.org/legal/epl-v20.html)
+    License: LGPL-2.1-only  (https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html)
 
   - Logback DBAppender Classic Module (http://logback.qos.ch/logback-classic-db) ch.qos.logback.db:logback-classic-db:jar:1.5.32
     License: EPL-2.0  (https://www.eclipse.org/legal/epl-v20.html)

--- a/perftests/src/main/assembly/dependency-verification/DEPENDENCIES_REFERENCE
+++ b/perftests/src/main/assembly/dependency-verification/DEPENDENCIES_REFERENCE
@@ -68,13 +68,13 @@ From: 'FasterXML' (http://fasterxml.com/)
 
 From: 'QOS.ch' (http://www.qos.ch)
 
-  - Logback Classic Module (http://logback.qos.ch/logback-classic) ch.qos.logback:logback-classic:jar:1.5.32
-    License: Eclipse Public License - v 2.0  (https://www.eclipse.org/legal/epl-v20.html)
-    License: GNU Lesser General Public License  (https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html)
+  - Logback Classic Module (http://logback.qos.ch/logback-classic) ch.qos.logback:logback-classic:jar:1.5.34
+    License: EPL-2.0  (https://www.eclipse.org/legal/epl-v20.html)
+    License: LGPL-2.1-only  (https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html)
 
-  - Logback Core Module (http://logback.qos.ch/logback-core) ch.qos.logback:logback-core:jar:1.5.32
-    License: Eclipse Public License - v 2.0  (https://www.eclipse.org/legal/epl-v20.html)
-    License: GNU Lesser General Public License  (https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html)
+  - Logback Core Module (http://logback.qos.ch/logback-core) ch.qos.logback:logback-core:jar:1.5.34
+    License: EPL-2.0  (https://www.eclipse.org/legal/epl-v20.html)
+    License: LGPL-2.1-only  (https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html)
 
   - SLF4J API Module (http://www.slf4j.org) org.slf4j:slf4j-api:jar:2.0.17
     License: MIT  (https://opensource.org/license/mit)

--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
 
     <bdb-version>7.4.5</bdb-version>
     <derby-version>10.16.1.1</derby-version>
-    <logback-version>1.5.32</logback-version>
+    <logback-version>1.5.34</logback-version>
     <logback-db-version>1.5.32</logback-db-version>
     <caffeine-version>3.2.3</caffeine-version>
     <fasterxml-jackson-version>3.1.2</fasterxml-jackson-version>


### PR DESCRIPTION
This PR addresses JIRA [QPID-8730](https://issues.apache.org/jira/browse/QPID-8730), updating logback dependencies to version 1.5.34