### PR TITLE
NO-JIRA: [Broker-J] Bump github actions versions (checkout v7, cache v6)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,8 +27,8 @@ jobs:
         java: [ 17, 21, 25 ]
 
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/cache@v5
+      - uses: actions/checkout@v7
+      - uses: actions/cache@v6
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}


### PR DESCRIPTION
This PR updates github action "checkout" to the version 7 and  github action "cache" to the version 6