### PR TITLE
QPID-8730: [Broker-J] Bump logback dependencies to the version 1.6.0 and slf4j to the version 2.0.18

### DIFF
--- a/apache-qpid-broker-j/src/main/assembly/dependency-verification/DEPENDENCIES_REFERENCE
+++ b/apache-qpid-broker-j/src/main/assembly/dependency-verification/DEPENDENCIES_REFERENCE
@@ -108,11 +108,11 @@ From: 'OW2' (http://www.ow2.org/)
 
 From: 'QOS.ch' (http://www.qos.ch)
 
-  - Logback Classic Module (http://logback.qos.ch/logback-classic) ch.qos.logback:logback-classic:jar:1.5.34
+  - Logback Classic Module (http://logback.qos.ch/logback-classic) ch.qos.logback:logback-classic:jar:1.6.0
     License: EPL-2.0  (https://www.eclipse.org/legal/epl-v20.html)
     License: LGPL-2.1-only  (https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html)
 
-  - Logback Core Module (http://logback.qos.ch/logback-core) ch.qos.logback:logback-core:jar:1.5.34
+  - Logback Core Module (http://logback.qos.ch/logback-core) ch.qos.logback:logback-core:jar:1.6.0
     License: EPL-2.0  (https://www.eclipse.org/legal/epl-v20.html)
     License: LGPL-2.1-only  (https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html)
 
@@ -124,7 +124,7 @@ From: 'QOS.ch' (http://www.qos.ch)
     License: EPL-2.0  (https://www.eclipse.org/legal/epl-v20.html)
     License: LGPL-2.1-only  (https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html)
 
-  - SLF4J API Module (http://www.slf4j.org) org.slf4j:slf4j-api:jar:2.0.17
+  - SLF4J API Module (http://www.slf4j.org) org.slf4j:slf4j-api:jar:2.0.18
     License: MIT  (https://opensource.org/license/mit)
 
 

--- a/perftests/src/main/assembly/dependency-verification/DEPENDENCIES_REFERENCE
+++ b/perftests/src/main/assembly/dependency-verification/DEPENDENCIES_REFERENCE
@@ -53,15 +53,15 @@ From: 'FasterXML' (http://fasterxml.com/)
 
 From: 'QOS.ch' (http://www.qos.ch)
 
-  - Logback Classic Module (http://logback.qos.ch/logback-classic) ch.qos.logback:logback-classic:jar:1.5.34
+  - Logback Classic Module (http://logback.qos.ch/logback-classic) ch.qos.logback:logback-classic:jar:1.6.0
     License: EPL-2.0  (https://www.eclipse.org/legal/epl-v20.html)
     License: LGPL-2.1-only  (https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html)
 
-  - Logback Core Module (http://logback.qos.ch/logback-core) ch.qos.logback:logback-core:jar:1.5.34
+  - Logback Core Module (http://logback.qos.ch/logback-core) ch.qos.logback:logback-core:jar:1.6.0
     License: EPL-2.0  (https://www.eclipse.org/legal/epl-v20.html)
     License: LGPL-2.1-only  (https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html)
 
-  - SLF4J API Module (http://www.slf4j.org) org.slf4j:slf4j-api:jar:2.0.17
+  - SLF4J API Module (http://www.slf4j.org) org.slf4j:slf4j-api:jar:2.0.18
     License: MIT  (https://opensource.org/license/mit)
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -105,12 +105,12 @@
 
     <bdb-version>7.4.5</bdb-version>
     <derby-version>10.16.1.1</derby-version>
-    <logback-version>1.5.34</logback-version>
+    <logback-version>1.6.0</logback-version>
     <logback-db-version>1.5.32</logback-db-version>
     <caffeine-version>3.2.3</caffeine-version>
     <fasterxml-jackson-version>3.1.2</fasterxml-jackson-version>
     <fasterxml-jackson-databind-version>3.1.2</fasterxml-jackson-databind-version>
-    <slf4j-version>2.0.17</slf4j-version>
+    <slf4j-version>2.0.18</slf4j-version>
     <jetty-version>12.1.8</jetty-version>
 
     <!-- dependency version numbers -->


### PR DESCRIPTION
This PR addresses JIRA [QPID-8730](https://issues.apache.org/jira/browse/QPID-8730), updating logback dependencies to version 1.6.0 and slf4j to the version 2.0.18