### PR TITLE
QPID-8737: [Broker-J] Bump jetty dependencies to the version 12.1.11

### DIFF
--- a/apache-qpid-broker-j/src/main/assembly/dependency-verification/DEPENDENCIES_REFERENCE
+++ b/apache-qpid-broker-j/src/main/assembly/dependency-verification/DEPENDENCIES_REFERENCE
@@ -218,63 +218,63 @@ From: 'The CometD Project' (https://cometd.org)
 
 From: 'Webtide' (https://webtide.com)
 
-  - Core :: HTTP (https://jetty.org/jetty-core/jetty-http) org.eclipse.jetty:jetty-http:jar:12.1.8
+  - Core :: HTTP (https://jetty.org/jetty-core/jetty-http) org.eclipse.jetty:jetty-http:jar:12.1.11
     License: EPL-2.0  (https://www.eclipse.org/legal/epl-2.0/)
     License: Apache-2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-  - Core :: IO (https://jetty.org/jetty-core/jetty-io) org.eclipse.jetty:jetty-io:jar:12.1.8
+  - Core :: IO (https://jetty.org/jetty-core/jetty-io) org.eclipse.jetty:jetty-io:jar:12.1.11
     License: EPL-2.0  (https://www.eclipse.org/legal/epl-2.0/)
     License: Apache-2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-  - Core :: Rewrite (https://jetty.org/jetty-core/jetty-rewrite) org.eclipse.jetty:jetty-rewrite:jar:12.1.8
+  - Core :: Rewrite (https://jetty.org/jetty-core/jetty-rewrite) org.eclipse.jetty:jetty-rewrite:jar:12.1.11
     License: EPL-2.0  (https://www.eclipse.org/legal/epl-2.0/)
     License: Apache-2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-  - Core :: Security (https://jetty.org/jetty-core/jetty-security) org.eclipse.jetty:jetty-security:jar:12.1.8
+  - Core :: Security (https://jetty.org/jetty-core/jetty-security) org.eclipse.jetty:jetty-security:jar:12.1.11
     License: EPL-2.0  (https://www.eclipse.org/legal/epl-2.0/)
     License: Apache-2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-  - Core :: Server (https://jetty.org/jetty-core/jetty-server) org.eclipse.jetty:jetty-server:jar:12.1.8
+  - Core :: Server (https://jetty.org/jetty-core/jetty-server) org.eclipse.jetty:jetty-server:jar:12.1.11
     License: EPL-2.0  (https://www.eclipse.org/legal/epl-2.0/)
     License: Apache-2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-  - Core :: Sessions (https://jetty.org/jetty-core/jetty-session) org.eclipse.jetty:jetty-session:jar:12.1.8
+  - Core :: Sessions (https://jetty.org/jetty-core/jetty-session) org.eclipse.jetty:jetty-session:jar:12.1.11
     License: EPL-2.0  (https://www.eclipse.org/legal/epl-2.0/)
     License: Apache-2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-  - Core :: Utilities (https://jetty.org/jetty-core/jetty-util) org.eclipse.jetty:jetty-util:jar:12.1.8
+  - Core :: Utilities (https://jetty.org/jetty-core/jetty-util) org.eclipse.jetty:jetty-util:jar:12.1.11
     License: EPL-2.0  (https://www.eclipse.org/legal/epl-2.0/)
     License: Apache-2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-  - EE11 :: Servlet (https://jetty.org/jetty-ee11/jetty-ee11-servlet) org.eclipse.jetty.ee11:jetty-ee11-servlet:jar:12.1.8
+  - EE11 :: Servlet (https://jetty.org/jetty-ee11/jetty-ee11-servlet) org.eclipse.jetty.ee11:jetty-ee11-servlet:jar:12.1.11
     License: EPL-2.0  (https://www.eclipse.org/legal/epl-2.0/)
     License: Apache-2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-  - EE11 :: Websocket :: Jetty Server (https://jetty.org/jetty-ee11/jetty-ee11-websocket/jetty-ee11-websocket-jetty-server) org.eclipse.jetty.ee11.websocket:jetty-ee11-websocket-jetty-server:jar:12.1.8
+  - EE11 :: Websocket :: Jetty Server (https://jetty.org/jetty-ee11/jetty-ee11-websocket/jetty-ee11-websocket-jetty-server) org.eclipse.jetty.ee11.websocket:jetty-ee11-websocket-jetty-server:jar:12.1.11
     License: EPL-2.0  (https://www.eclipse.org/legal/epl-2.0/)
     License: Apache-2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-  - EE11 :: Websocket :: Servlet (https://jetty.org/jetty-ee11/jetty-ee11-websocket/jetty-ee11-websocket-servlet) org.eclipse.jetty.ee11.websocket:jetty-ee11-websocket-servlet:jar:12.1.8
+  - EE11 :: Websocket :: Servlet (https://jetty.org/jetty-ee11/jetty-ee11-websocket/jetty-ee11-websocket-servlet) org.eclipse.jetty.ee11.websocket:jetty-ee11-websocket-servlet:jar:12.1.11
     License: EPL-2.0  (https://www.eclipse.org/legal/epl-2.0/)
     License: Apache-2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-  - Core :: Websocket :: Common (https://jetty.org/jetty-core/jetty-websocket/jetty-websocket-core-common) org.eclipse.jetty.websocket:jetty-websocket-core-common:jar:12.1.8
+  - Core :: Websocket :: Common (https://jetty.org/jetty-core/jetty-websocket/jetty-websocket-core-common) org.eclipse.jetty.websocket:jetty-websocket-core-common:jar:12.1.11
     License: EPL-2.0  (https://www.eclipse.org/legal/epl-2.0/)
     License: Apache-2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-  - Core :: Websocket :: Server (https://jetty.org/jetty-core/jetty-websocket/jetty-websocket-core-server) org.eclipse.jetty.websocket:jetty-websocket-core-server:jar:12.1.8
+  - Core :: Websocket :: Server (https://jetty.org/jetty-core/jetty-websocket/jetty-websocket-core-server) org.eclipse.jetty.websocket:jetty-websocket-core-server:jar:12.1.11
     License: EPL-2.0  (https://www.eclipse.org/legal/epl-2.0/)
     License: Apache-2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-  - Core :: Websocket :: Jetty API (https://jetty.org/jetty-core/jetty-websocket/jetty-websocket-jetty-api) org.eclipse.jetty.websocket:jetty-websocket-jetty-api:jar:12.1.8
+  - Core :: Websocket :: Jetty API (https://jetty.org/jetty-core/jetty-websocket/jetty-websocket-jetty-api) org.eclipse.jetty.websocket:jetty-websocket-jetty-api:jar:12.1.11
     License: EPL-2.0  (https://www.eclipse.org/legal/epl-2.0/)
     License: Apache-2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-  - Core :: Websocket :: Jetty Common (https://jetty.org/jetty-core/jetty-websocket/jetty-websocket-jetty-common) org.eclipse.jetty.websocket:jetty-websocket-jetty-common:jar:12.1.8
+  - Core :: Websocket :: Jetty Common (https://jetty.org/jetty-core/jetty-websocket/jetty-websocket-jetty-common) org.eclipse.jetty.websocket:jetty-websocket-jetty-common:jar:12.1.11
     License: EPL-2.0  (https://www.eclipse.org/legal/epl-2.0/)
     License: Apache-2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-  - Core :: Websocket :: Jetty Server (https://jetty.org/jetty-core/jetty-websocket/jetty-websocket-jetty-server) org.eclipse.jetty.websocket:jetty-websocket-jetty-server:jar:12.1.8
+  - Core :: Websocket :: Jetty Server (https://jetty.org/jetty-core/jetty-websocket/jetty-websocket-jetty-server) org.eclipse.jetty.websocket:jetty-websocket-jetty-server:jar:12.1.11
     License: EPL-2.0  (https://www.eclipse.org/legal/epl-2.0/)
     License: Apache-2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
 

--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
     <fasterxml-jackson-version>3.1.2</fasterxml-jackson-version>
     <fasterxml-jackson-databind-version>3.1.2</fasterxml-jackson-databind-version>
     <slf4j-version>2.0.17</slf4j-version>
-    <jetty-version>12.1.8</jetty-version>
+    <jetty-version>12.1.11</jetty-version>
 
     <!-- dependency version numbers -->
     <hikari-cp-version>7.0.2</hikari-cp-version>


### PR DESCRIPTION
This PR addresses JIRA [QPID-8737](https://issues.apache.org/jira/browse/QPID-8737), updating jetty dependencies to version 12.1.11