### PR TITLE
QPID-8729: [Broker-J] Bump test dependencies and plugin versions

### DIFF
--- a/perftests/src/main/assembly/dependency-verification/DEPENDENCIES_REFERENCE
+++ b/perftests/src/main/assembly/dependency-verification/DEPENDENCIES_REFERENCE
@@ -67,13 +67,13 @@ From: 'QOS.ch' (http://www.qos.ch)
 
 From: 'The Apache Software Foundation' (https://www.apache.org/)
 
-  - Apache HttpClient (https://hc.apache.org/httpcomponents-client-5.5.x/5.6.1/httpclient5/) org.apache.httpcomponents.client5:httpclient5:jar:5.6.1
+  - Apache HttpClient (https://hc.apache.org/httpcomponents-client-5.6.x/5.6.2/httpclient5/) org.apache.httpcomponents.client5:httpclient5:jar:5.6.2
     License: Apache License, Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-  - Apache HttpComponents Core HTTP/1.1 (https://hc.apache.org/httpcomponents-core-5.4.x/5.4/httpcore5/) org.apache.httpcomponents.core5:httpcore5:jar:5.4
+  - Apache HttpComponents Core HTTP/1.1 (https://hc.apache.org/httpcomponents-core-5.4.x/5.4.3/httpcore5/) org.apache.httpcomponents.core5:httpcore5:jar:5.4.3
     License: Apache License, Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-  - Apache HttpComponents Core HTTP/2 (https://hc.apache.org/httpcomponents-core-5.4.x/5.4/httpcore5-h2/) org.apache.httpcomponents.core5:httpcore5-h2:jar:5.4
+  - Apache HttpComponents Core HTTP/2 (https://hc.apache.org/httpcomponents-core-5.4.x/5.4.3/httpcore5-h2/) org.apache.httpcomponents.core5:httpcore5-h2:jar:5.4.3
     License: Apache License, Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -130,13 +130,13 @@
     <dgrid-version>1.3.3</dgrid-version>
 
     <!-- test dependency version numbers -->
-    <junit-version>6.1.0</junit-version>
+    <junit-version>6.1.2</junit-version>
     <mockito-version>5.23.0</mockito-version>
-    <netty-version>4.2.15.Final</netty-version>
+    <netty-version>4.2.16.Final</netty-version>
     <hamcrest-version>3.0</hamcrest-version>
     <maven-resolver-provider-version>3.8.6</maven-resolver-provider-version>
     <maven-resolver-version>1.9.22</maven-resolver-version>
-    <httpclient-version>5.6.1</httpclient-version>
+    <httpclient-version>5.6.2</httpclient-version>
     <qpid-jms-client-version>1.16.0</qpid-jms-client-version>
     <qpid-jms-client-amqp-0-x-version>6.4.0</qpid-jms-client-amqp-0-x-version>
     <nashorn-version>15.7</nashorn-version>
@@ -148,7 +148,7 @@
     <license-maven-plugin-version>2.7.1</license-maven-plugin-version>
     <maven-jxr-plugin-version>3.6.0</maven-jxr-plugin-version>
     <findbugs-maven-plugin-version>3.0.5</findbugs-maven-plugin-version>
-    <jacoco-plugin-version>0.8.14</jacoco-plugin-version>
+    <jacoco-plugin-version>0.8.15</jacoco-plugin-version>
     <apache-rat-plugin-version>0.18</apache-rat-plugin-version>
     <maven-docbx-plugin-version>2.0.17</maven-docbx-plugin-version>
     <maven-docbook-xml-plugin-version>5.0-all</maven-docbook-xml-plugin-version>
@@ -159,7 +159,7 @@
     <maven-surefire-report-plugin-version>3.5.6</maven-surefire-report-plugin-version>
     <h2.version>2.4.240</h2.version>
     <apache-directory-version>2.0.0.AM27</apache-directory-version>
-    <kerby-version>2.1.1</kerby-version>
+    <kerby-version>2.1.2</kerby-version>
     <bcprov-version>1.84</bcprov-version>
     <bcpkix-version>1.84</bcpkix-version>
     <logback-gelf-version>6.1.1</logback-gelf-version>


### PR DESCRIPTION
This PR addresses JIRA [QPID-8729](https://issues.apache.org/jira/browse/QPID-8729), updating dependencies:

io.netty:netty-buffer 4.2.15.Final => 4.2.16.Final
io.netty:netty-common 4.2.15.Final => 4.2.16.Final
io.netty:netty-handler 4.2.15.Final => 4.2.16.Final
io.netty:netty-transport 4.2.15.Final => 4.2.16.Final
io.netty:netty-codec-http 4.2.15.Final => 4.2.16.Final
org.apache.httpcomponents.client5:httpclient5 5.6.1 => 5.6.2
org.apache.httpcomponents.client5:httpclient5-fluent  5.6.1 => 5.6.2
org.junit.jupiter:junit-jupiter-api 6.1.0 => 6.1.2
org.apache.kerby:kerb-simplekdc 2.1.1 => 2.1.2

org.jacoco:jacoco-maven-plugin 0.8.14 => 0.8.15