### PR TITLE
QPID-8746: [Broker-J] Bump hikaricp dependency to the version 7.1.0

### DIFF
--- a/apache-qpid-broker-j/src/main/assembly/dependency-verification/DEPENDENCIES_REFERENCE
+++ b/apache-qpid-broker-j/src/main/assembly/dependency-verification/DEPENDENCIES_REFERENCE
@@ -281,7 +281,7 @@ From: 'Webtide' (https://webtide.com)
 
 From: 'Zaxxer.com' (https://github.com/brettwooldridge)
 
-  - HikariCP (https://github.com/brettwooldridge/HikariCP) com.zaxxer:HikariCP:bundle:7.0.2
+  - HikariCP (https://github.com/brettwooldridge/HikariCP) com.zaxxer:HikariCP:bundle:7.1.0
     License: The Apache Software License, Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
     <jetty-version>12.1.8</jetty-version>
 
     <!-- dependency version numbers -->
-    <hikari-cp-version>7.0.2</hikari-cp-version>
+    <hikari-cp-version>7.1.0</hikari-cp-version>
     <commons-cli-version>1.11.0</commons-cli-version>
 
     <geronimo-jms-1-1-version>1.1.1</geronimo-jms-1-1-version>


### PR DESCRIPTION
This PR addresses JIRA [QPID-8746](https://issues.apache.org/jira/browse/QPID-8746), updating hikaricp dependency to the version 7.1.0