### PR TITLE
QPID-8747: [Broker-J] Bump logback-gelf dependency to the version 6.1.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -162,7 +162,7 @@
     <kerby-version>2.1.1</kerby-version>
     <bcprov-version>1.84</bcprov-version>
     <bcpkix-version>1.84</bcpkix-version>
-    <logback-gelf-version>6.1.1</logback-gelf-version>
+    <logback-gelf-version>6.1.2</logback-gelf-version>
     <prometheus-client-version>0.16.0</prometheus-client-version>
     <resilience4j-version>2.4.0</resilience4j-version>
 


### PR DESCRIPTION
This PR addresses JIRA [QPID-8747](https://issues.apache.org/jira/browse/QPID-8747), updating logback-gelf dependency to the version 6.1.2