### PR TITLE
QPID-8748: [Broker-J] NPE when sorting results in broker query engine

### DIFF
--- a/broker-plugins/query-engine/README.md
+++ b/broker-plugins/query-engine/README.md
@@ -103,10 +103,10 @@ properties, affecting the way query engine works.
 ### Query cache size
 
 After query is parsed from the SQL string, it is stored into a cache. When the same query will be fired against 
-the query engine, parsing will be omitted and the query structure will be retrieved from cache. By default, query cache
-size is 1000. This means, that when 1000 different queries will be fired against the query engine, the next one will 
-override the oldest cache entry. When set to 0 or to negative value, query cache will not be used and each query
-will be parsed.
+the query engine, parsing will be omitted and the query structure will be retrieved from cache. When cache size is 1000,
+it means that 1000 different queries will be fired against the query engine, the next one will override the oldest 
+cache entry. When set to 0 or to negative value, query cache will not be used and each query will be parsed. 
+By default, query cache size is 0 (disabled).
 
 ### Maximal query depth
 

--- a/broker-plugins/query-engine/src/main/java/org/apache/qpid/server/query/engine/evaluator/settings/DefaultQuerySettings.java
+++ b/broker-plugins/query-engine/src/main/java/org/apache/qpid/server/query/engine/evaluator/settings/DefaultQuerySettings.java
@@ -59,7 +59,7 @@ public class DefaultQuerySettings
     /**
      * Maximal amount of queries allowed caching
      */
-    public static int MAX_QUERY_CACHE_SIZE = 1000;
+    public static int MAX_QUERY_CACHE_SIZE = 0;
 
     /**
      * Maximal amount of query tree nodes allowed

--- a/doc/java-broker/src/docbkx/management/channels/Java-Broker-Management-Channel-REST-Query-Engine.xml
+++ b/doc/java-broker/src/docbkx/management/channels/Java-Broker-Management-Channel-REST-Query-Engine.xml
@@ -86,10 +86,10 @@
             <title>Query cache size</title>
             <para>
                 After query is parsed from the SQL string, it is stored into a cache. When the same query will be fired against
-                the query engine, parsing will be omitted and the query structure will be retrieved from cache. By default, query cache
-                size is 1000. This means, that when 1000 different queries will be fired against the query engine, the next one will
-                override the oldest cache entry. When set to 0 or to negative value, query cache will not be used and each query
-                will be parsed.
+                the query engine, parsing will be omitted and the query structure will be retrieved from cache. When cache size is 1000,
+                it means that 1000 different queries will be fired against the query engine, the next one will override the oldest
+                cache entry. When set to 0 or to negative value, query cache will not be used and each query will be parsed.
+                By default, query cache size is 0 (disabled).
             </para>
         </section>
 


### PR DESCRIPTION
This PR addresses [QPID-8748](https://issues.apache.org/jira/browse/QPID-8748), disabling default query engine caching.