### PR TITLE
NO-JIRA: [Broker-J] Update GitHub action "setup-java" to version 6

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
       - name: Install JDK ${{ matrix.java }}
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v6
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'


### PR DESCRIPTION
This PR updates GitHub action "setup-java" to the version 6