### PR TITLE
Update HttpClient dependency reference

### DIFF
--- a/perftests/src/main/assembly/dependency-verification/DEPENDENCIES_REFERENCE
+++ b/perftests/src/main/assembly/dependency-verification/DEPENDENCIES_REFERENCE
@@ -67,7 +67,7 @@ From: 'QOS.ch' (http://www.qos.ch)
 
 From: 'The Apache Software Foundation' (https://www.apache.org/)
 
-  - Apache HttpClient (https://hc.apache.org/httpcomponents-client-5.6.x/5.6.2/httpclient5/) org.apache.httpcomponents.client5:httpclient5:jar:5.6.2
+  - Apache HttpClient (https://hc.apache.org/httpcomponents-client-5.6.x/5.6.3/httpclient5/) org.apache.httpcomponents.client5:httpclient5:jar:5.6.3
     License: Apache License, Version 2.0  (https://www.apache.org/licenses/LICENSE-2.0.txt)
 
   - Apache HttpComponents Core HTTP/1.1 (https://hc.apache.org/httpcomponents-core-5.4.x/5.4.3/httpcore5/) org.apache.httpcomponents.core5:httpcore5:jar:5.4.3


### PR DESCRIPTION
This is a companion fix for Dependabot PR #426.

The HttpClient 5.6.3 upgrade itself compiles and tests successfully, but Qpid's release/license gate intentionally rejects dependency changes until the checked-in assembly reference matches the generated dependency metadata. The reference still described HttpClient 5.6.2.

This updates the single generated reference entry (artifact version and upstream documentation URL) to 5.6.3. The artifact and Apache 2.0 license are otherwise unchanged, so no LICENSE or NOTICE update is needed.

Verification on Amazon Corretto 17:

- Reproduced the exact bot-head failure with the repository's GitHub `Licence Check` command: 42 modules passed before `qpid-perftests` rejected the stale dependency reference.
- Confirmed the generated/reference diff contains only the HttpClient 5.6.2 to 5.6.3 entry.
- Re-ran the exact clean release/license command successfully across all 52 reactor modules, including RAT, licensing, compilation, test compilation, packaging, and dependency verification.
- Ran the affected `qpid-perftests` unit suite plus its test utility dependency: 184 tests passed with zero failures.

The change is limited to the dependency-verification reference required by the existing release gate.
