### PR TITLE
QPID-8753: [Broker-J] Reduce system tests resources

### DIFF
--- a/systests/qpid-systests-jms_1.1/src/test/java/org/apache/qpid/systests/jms_1_1/extensions/queue/ProducerFlowControlTest.java
+++ b/systests/qpid-systests-jms_1.1/src/test/java/org/apache/qpid/systests/jms_1_1/extensions/queue/ProducerFlowControlTest.java
@@ -92,7 +92,7 @@ public class ProducerFlowControlTest extends OverflowPolicyTestBase
 
                 Message message2 = consumer.receive(getReceiveTimeout());
                 assertNotNull(message2, "Message is not received");
-                assertTrue(messageSender.getSendLatch().await(1000, TimeUnit.MILLISECONDS),
+                assertTrue(messageSender.getSendLatch().await(getReceiveTimeout(), TimeUnit.MILLISECONDS),
                         "Message sending is not finished");
                 assertEquals(5, messageSender.getNumberOfSentMessages(),
                         "Message not sent after two messages received");
@@ -141,7 +141,7 @@ public class ProducerFlowControlTest extends OverflowPolicyTestBase
                 Message message = consumer.receive(getReceiveTimeout());
                 assertNotNull(message, "Message is not received");
 
-                assertTrue(messageSender.getSendLatch().await(1000, TimeUnit.MILLISECONDS),
+                assertTrue(messageSender.getSendLatch().await(getReceiveTimeout(), TimeUnit.MILLISECONDS),
                         "Message sending is not finished");
 
                 assertEquals(5, messageSender.getNumberOfSentMessages(),

--- a/systests/qpid-systests-spawn-admin/src/main/java/org/apache/qpid/systests/admin/SpawnBrokerAdmin.java
+++ b/systests/qpid-systests-spawn-admin/src/main/java/org/apache/qpid/systests/admin/SpawnBrokerAdmin.java
@@ -73,6 +73,7 @@ import org.apache.qpid.server.util.SystemUtils;
 import org.apache.qpid.systests.AmqpManagementFacade;
 import org.apache.qpid.tests.utils.BrokerAdmin;
 import org.apache.qpid.tests.utils.ConfigItem;
+import org.apache.qpid.tests.utils.SystemTestBrokerContext;
 
 @SuppressWarnings("unused")
 @PluggableService
@@ -768,11 +769,8 @@ public class SpawnBrokerAdmin implements BrokerAdmin, Closeable
         context.put("qpid.port.protocol_handshake_timeout", "1000000");
         context.put("qpid.amqp_port", "0");
 
-        System.getProperties()
-              .stringPropertyNames()
-              .stream()
-              .filter(n -> n.startsWith("qpid."))
-              .forEach(n -> context.put(n, System.getProperty(n)));
+        SystemTestBrokerContext.applyResourceDefaults(context);
+        SystemTestBrokerContext.copyBrokerSystemProperties(context);
 
         context.putAll(Arrays.stream(configItems)
                              .filter(i -> !i.jvm())

--- a/systests/qpid-systests-spawn-admin/src/test/java/org/apache/qpid/systests/admin/SpawnBrokerAdminTest.java
+++ b/systests/qpid-systests-spawn-admin/src/test/java/org/apache/qpid/systests/admin/SpawnBrokerAdminTest.java
@@ -37,6 +37,7 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import java.io.File;
 import java.net.InetSocketAddress;
 import java.nio.file.Files;
+import java.util.Map;
 
 import javax.jms.Connection;
 import javax.jms.DeliveryMode;
@@ -51,6 +52,8 @@ import javax.jms.TextMessage;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import org.apache.qpid.server.model.port.AmqpPort;
+import org.apache.qpid.server.virtualhost.QueueManagingVirtualHost;
 import org.apache.qpid.systests.AmqpManagementFacade;
 import org.apache.qpid.test.utils.UnitTestBase;
 import org.apache.qpid.tests.utils.BrokerAdmin;
@@ -118,6 +121,32 @@ public class SpawnBrokerAdminTest extends UnitTestBase
             {
                 connection.close();
             }
+        }
+    }
+
+    @Test
+    public void resourcePropertiesArePropagated() throws Exception
+    {
+        setTestSystemProperty(AmqpPort.PORT_AMQP_THREAD_POOL_SIZE, "5");
+        setTestSystemProperty(AmqpPort.PORT_AMQP_NUMBER_OF_SELECTORS, "2");
+        setTestSystemProperty(QueueManagingVirtualHost.VIRTUALHOST_CONNECTION_THREAD_POOL_SIZE, "6");
+        setTestSystemProperty(QueueManagingVirtualHost.VIRTUALHOST_CONNECTION_THREAD_POOL_NUMBER_OF_SELECTORS, "3");
+
+        try (final SpawnBrokerAdmin admin = new SpawnBrokerAdmin())
+        {
+            admin.beforeTestClass(SpawnBrokerAdminTest.class);
+            admin.beforeTestMethod(SpawnBrokerAdminTest.class, getClass().getMethod("resourcePropertiesArePropagated"));
+
+            final Map<String, Object> portAttributes = admin.getAttributes(true, "AMQP", "org.apache.qpid.AmqpPort");
+            final Map<String, Object> virtualHostAttributes = admin.getAttributes(false, admin.getVirtualHostName(),
+                    "org.apache.qpid.VirtualHost");
+
+            assertThat(((Number) portAttributes.get(AmqpPort.THREAD_POOL_SIZE)).intValue(), is(equalTo(5)));
+            assertThat(((Number) portAttributes.get(AmqpPort.NUMBER_OF_SELECTORS)).intValue(), is(equalTo(2)));
+            assertThat(((Number) virtualHostAttributes.get(QueueManagingVirtualHost.CONNECTION_THREAD_POOL_SIZE)).intValue(),
+                    is(equalTo(6)));
+            assertThat(((Number) virtualHostAttributes.get(QueueManagingVirtualHost.NUMBER_OF_SELECTORS)).intValue(),
+                    is(equalTo(3)));
         }
     }
 

--- a/systests/systests-utils/src/main/java/org/apache/qpid/tests/utils/EmbeddedBrokerPerClassAdminImpl.java
+++ b/systests/systests-utils/src/main/java/org/apache/qpid/tests/utils/EmbeddedBrokerPerClassAdminImpl.java
@@ -109,8 +109,10 @@ public class EmbeddedBrokerPerClassAdminImpl implements BrokerAdmin
                 System.setProperty(i.name(), i.value());
             });
             Map<String, String> context = new HashMap<>();
+            SystemTestBrokerContext.applyResourceDefaults(context);
+            SystemTestBrokerContext.copyBrokerSystemProperties(context);
             context.put("qpid.work_dir", _currentWorkDirectory);
-            context.put("qpid.port.protocol_handshake_timeout", "1000000");
+            context.putIfAbsent(AmqpPort.PROTOCOL_HANDSHAKE_TIMEOUT, "1000000");
             context.putAll(Arrays.stream(configItems)
                     .filter(i -> !i.jvm())
                     .collect(Collectors.toMap(ConfigItem::name, ConfigItem::value, (name, value) -> value)));

--- a/systests/systests-utils/src/main/java/org/apache/qpid/tests/utils/SystemTestBrokerContext.java
+++ b/systests/systests-utils/src/main/java/org/apache/qpid/tests/utils/SystemTestBrokerContext.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package org.apache.qpid.tests.utils;
+
+import java.util.List;
+import java.util.Map;
+
+import org.apache.qpid.server.model.port.AmqpPort;
+import org.apache.qpid.server.model.port.HttpPort;
+import org.apache.qpid.server.virtualhost.QueueManagingVirtualHost;
+
+public final class SystemTestBrokerContext
+{
+    public static final String DEFAULT_PORT_AMQP_THREAD_POOL_SIZE = "4";
+    public static final String DEFAULT_PORT_AMQP_NUMBER_OF_SELECTORS = "1";
+    public static final String DEFAULT_PORT_HTTP_THREAD_POOL_MINIMUM = "4";
+    public static final String DEFAULT_PORT_HTTP_THREAD_POOL_MAXIMUM = "8";
+    public static final String DEFAULT_PORT_HTTP_NUMBER_OF_SELECTORS = "2";
+    public static final String DEFAULT_PORT_HTTP_NUMBER_OF_ACCEPTORS = "1";
+    public static final String DEFAULT_VIRTUALHOST_CONNECTION_THREAD_POOL_SIZE = "4";
+    public static final String DEFAULT_VIRTUALHOST_CONNECTION_THREAD_POOL_NUMBER_OF_SELECTORS = "1";
+
+    private static final Map<String, String> RESOURCE_DEFAULTS = Map.of(
+            AmqpPort.PORT_AMQP_THREAD_POOL_SIZE, DEFAULT_PORT_AMQP_THREAD_POOL_SIZE,
+            AmqpPort.PORT_AMQP_NUMBER_OF_SELECTORS, DEFAULT_PORT_AMQP_NUMBER_OF_SELECTORS,
+            HttpPort.PORT_HTTP_THREAD_POOL_MINIMUM, DEFAULT_PORT_HTTP_THREAD_POOL_MINIMUM,
+            HttpPort.PORT_HTTP_THREAD_POOL_MAXIMUM, DEFAULT_PORT_HTTP_THREAD_POOL_MAXIMUM,
+            HttpPort.PORT_HTTP_NUMBER_OF_SELECTORS, DEFAULT_PORT_HTTP_NUMBER_OF_SELECTORS,
+            HttpPort.PORT_HTTP_NUMBER_OF_ACCEPTORS, DEFAULT_PORT_HTTP_NUMBER_OF_ACCEPTORS,
+            QueueManagingVirtualHost.VIRTUALHOST_CONNECTION_THREAD_POOL_SIZE,
+            DEFAULT_VIRTUALHOST_CONNECTION_THREAD_POOL_SIZE,
+            QueueManagingVirtualHost.VIRTUALHOST_CONNECTION_THREAD_POOL_NUMBER_OF_SELECTORS,
+            DEFAULT_VIRTUALHOST_CONNECTION_THREAD_POOL_NUMBER_OF_SELECTORS);
+
+    private static final List<String> BROKER_SYSTEM_PROPERTY_PREFIXES = List.of("qpid.", "virtualhost.", "port.http.");
+
+    private SystemTestBrokerContext()
+    {
+        // utility class has private constructor
+    }
+
+    public static void applyResourceDefaults(final Map<String, String> context)
+    {
+        RESOURCE_DEFAULTS.forEach(context::putIfAbsent);
+    }
+
+    public static void copyBrokerSystemProperties(final Map<String, String> context)
+    {
+        System.getProperties().stringPropertyNames().stream()
+              .filter(SystemTestBrokerContext::isBrokerSystemProperty)
+              .forEach(name -> context.put(name, System.getProperty(name)));
+    }
+
+    private static boolean isBrokerSystemProperty(final String name)
+    {
+        return BROKER_SYSTEM_PROPERTY_PREFIXES.stream().anyMatch(name::startsWith);
+    }
+}

--- a/systests/systests-utils/src/test/java/org/apache/qpid/tests/utils/SystemTestBrokerContextTest.java
+++ b/systests/systests-utils/src/test/java/org/apache/qpid/tests/utils/SystemTestBrokerContextTest.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package org.apache.qpid.tests.utils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import org.apache.qpid.server.model.port.AmqpPort;
+import org.apache.qpid.server.model.port.HttpPort;
+import org.apache.qpid.server.virtualhost.QueueManagingVirtualHost;
+import org.apache.qpid.test.utils.UnitTestBase;
+
+public class SystemTestBrokerContextTest extends UnitTestBase
+{
+    @Test
+    public void resourceDefaultsAreAppliedWhenAbsent()
+    {
+        final Map<String, String> context = new HashMap<>();
+
+        SystemTestBrokerContext.applyResourceDefaults(context);
+
+        assertEquals(Map.of(
+                AmqpPort.PORT_AMQP_THREAD_POOL_SIZE, SystemTestBrokerContext.DEFAULT_PORT_AMQP_THREAD_POOL_SIZE,
+                AmqpPort.PORT_AMQP_NUMBER_OF_SELECTORS, SystemTestBrokerContext.DEFAULT_PORT_AMQP_NUMBER_OF_SELECTORS,
+                HttpPort.PORT_HTTP_THREAD_POOL_MINIMUM, SystemTestBrokerContext.DEFAULT_PORT_HTTP_THREAD_POOL_MINIMUM,
+                HttpPort.PORT_HTTP_THREAD_POOL_MAXIMUM, SystemTestBrokerContext.DEFAULT_PORT_HTTP_THREAD_POOL_MAXIMUM,
+                HttpPort.PORT_HTTP_NUMBER_OF_SELECTORS, SystemTestBrokerContext.DEFAULT_PORT_HTTP_NUMBER_OF_SELECTORS,
+                HttpPort.PORT_HTTP_NUMBER_OF_ACCEPTORS, SystemTestBrokerContext.DEFAULT_PORT_HTTP_NUMBER_OF_ACCEPTORS,
+                QueueManagingVirtualHost.VIRTUALHOST_CONNECTION_THREAD_POOL_SIZE,
+                SystemTestBrokerContext.DEFAULT_VIRTUALHOST_CONNECTION_THREAD_POOL_SIZE,
+                QueueManagingVirtualHost.VIRTUALHOST_CONNECTION_THREAD_POOL_NUMBER_OF_SELECTORS,
+                SystemTestBrokerContext.DEFAULT_VIRTUALHOST_CONNECTION_THREAD_POOL_NUMBER_OF_SELECTORS), context);
+    }
+
+    @Test
+    public void systemPropertiesOverrideResourceDefaults()
+    {
+        setTestSystemProperty(AmqpPort.PORT_AMQP_THREAD_POOL_SIZE, "17");
+        setTestSystemProperty(QueueManagingVirtualHost.VIRTUALHOST_CONNECTION_THREAD_POOL_SIZE, "19");
+        setTestSystemProperty(HttpPort.PORT_HTTP_THREAD_POOL_MAXIMUM, "23");
+        final Map<String, String> context = new HashMap<>();
+
+        SystemTestBrokerContext.applyResourceDefaults(context);
+        SystemTestBrokerContext.copyBrokerSystemProperties(context);
+
+        assertEquals("17", context.get(AmqpPort.PORT_AMQP_THREAD_POOL_SIZE));
+        assertEquals("19", context.get(QueueManagingVirtualHost.VIRTUALHOST_CONNECTION_THREAD_POOL_SIZE));
+        assertEquals("23", context.get(HttpPort.PORT_HTTP_THREAD_POOL_MAXIMUM));
+    }
+
+    @Test
+    public void brokerSystemPropertyNamespacesAreCopied()
+    {
+        setTestSystemProperty("qpid.test.context", "qpid-value");
+        setTestSystemProperty("virtualhost.test.context", "virtualhost-value");
+        setTestSystemProperty("port.http.test.context", "http-value");
+        final Map<String, String> context = new HashMap<>();
+
+        SystemTestBrokerContext.copyBrokerSystemProperties(context);
+
+        assertEquals("qpid-value", context.get("qpid.test.context"));
+        assertEquals("virtualhost-value", context.get("virtualhost.test.context"));
+        assertEquals("http-value", context.get("port.http.test.context"));
+    }
+
+    @Test
+    public void unrelatedSystemPropertiesAreNotCopied()
+    {
+        setTestSystemProperty("broker.version", "excluded");
+        setTestSystemProperty("virtualhostnode.test.context", "excluded");
+        final Map<String, String> context = new HashMap<>();
+
+        SystemTestBrokerContext.copyBrokerSystemProperties(context);
+
+        assertFalse(context.containsKey("java.version"));
+        assertFalse(context.containsKey("broker.version"));
+        assertFalse(context.containsKey("virtualhostnode.test.context"));
+    }
+}


### PR DESCRIPTION
This PR addresses JIRA [QPID-8753](https://issues.apache.org/jira/browse/QPID-8753) by reducing the default broker resource usage in system tests, including AMQP, HTTP, and virtual-host connection thread-pool sizes and selector / acceptor counts. The change primarily benefits the BDB HA system tests:  TwoNodeTest  starts two broker JVMs concurrently, while  MultiNodeTest  starts three. It also reduces resource consumption across system-test runs in general, particularly on CI machines.