### PR TITLE
QPID-8754: [Broker-J] Maven plugins and test dependencies updates for version 10.1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -130,9 +130,9 @@
     <dgrid-version>1.3.3</dgrid-version>
 
     <!-- test dependency version numbers -->
-    <junit-version>6.1.2</junit-version>
+    <junit-version>6.1.3</junit-version>
     <mockito-version>5.23.0</mockito-version>
-    <netty-version>4.2.16.Final</netty-version>
+    <netty-version>4.2.17.Final</netty-version>
     <hamcrest-version>3.0</hamcrest-version>
     <maven-resolver-provider-version>3.8.6</maven-resolver-provider-version>
     <maven-resolver-version>1.9.22</maven-resolver-version>
@@ -153,11 +153,11 @@
     <maven-docbx-plugin-version>2.0.17</maven-docbx-plugin-version>
     <maven-docbook-xml-plugin-version>5.0-all</maven-docbook-xml-plugin-version>
     <buildnumber-maven-plugin-version>3.3.0</buildnumber-maven-plugin-version>
-    <maven-compiler-plugin-version>3.15.0</maven-compiler-plugin-version>
-    <maven-jar-plugin-version>3.5.0</maven-jar-plugin-version>
-    <maven-surefire-plugin-version>3.5.6</maven-surefire-plugin-version>
-    <maven-surefire-report-plugin-version>3.5.6</maven-surefire-report-plugin-version>
-    <h2.version>2.4.240</h2.version>
+    <maven-compiler-plugin-version>3.16.0</maven-compiler-plugin-version>
+    <maven-jar-plugin-version>3.5.1</maven-jar-plugin-version>
+    <maven-surefire-plugin-version>3.6.0</maven-surefire-plugin-version>
+    <maven-surefire-report-plugin-version>3.6.0</maven-surefire-report-plugin-version>
+    <h2.version>2.5.250</h2.version>
     <apache-directory-version>2.0.0.AM27</apache-directory-version>
     <kerby-version>2.1.2</kerby-version>
     <bcprov-version>1.84</bcprov-version>


### PR DESCRIPTION
This PR addresses JIRA [QPID-8754](https://issues.apache.org/jira/browse/QPID-8754), updating following dependencies:

**Test dependencies:**

com.h2database:h2 2.4.240 => 2.5.250

io.netty:netty-buffer 4.2.16.Final => 4.2.18.Final
io.netty:netty-common 4.2.16.Final => 4.2.18.Final
io.netty:netty-handler 4.2.16.Final => 4.2.18.Final
io.netty:netty-transport 4.2.16.Final => 4.2.18.Final
io.netty:netty-codec-http 4.2.16.Final => 4.2.18.Final

org.junit.jupiter:junit-jupiter-api 6.1.2 => 6.1.3
org.junit.jupiter:junit-jupiter-engine 6.1.2 => 6.1.3
org.junit.jupiter:junit-jupiter-params 6.1.2 => 6.1.3

**Plugin dependencies:**

org.apache.maven.plugins:maven-compiler-plugin 3.15.0 => 3.16.0
org.apache.maven.plugins:maven-surefire-plugin 3.5.6 => 3.6.0
org.apache.maven.plugins:maven-surefire-report-plugin 3.5.6 => 3.6.0